### PR TITLE
Catch usize conversion and Err more consistently

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,9 @@ snarkVM is a big project, so (non-)adherence to best practices related to perfor
 - try to keep the sizes of `enum` variants uniform; use `Box<T>` on ones that are large
 
 ### Cross-platform consistency
-- types which contain consensus- or cryptographic logic should have a consistent size across platforms. Their serialized output should not contain `usize`, and at times it may be worth it to avoid using `usize` in the types themselves for clarity.
+- First and foremost, types which contain consensus- or cryptographic logic should have a consistent size across platforms. Their serialized output should not contain `usize`. For defense in depth, we serialize `usize` as `u64`.
+- For clarity, use `u32` and `u64` as much or long as possible, especially in type definitions. 
+- Given that we only target 32- and 64-bit systems, casting `usize` as `u64` and casting `u32` as `usize` will always be safe and doesn't need a `try_from::`. In serialization code, for defense in depth it is still encouraged to use `try_from::`.
 
 ### Misc. performance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,9 @@ snarkVM is a big project, so (non-)adherence to best practices related to perfor
 - if possible, reuse collections; an example would be a loop that needs a clean vector on each iteration: instead of creating and allocating it over and over, create it _before_ the loop and use `.clear()` on every iteration instead
 - try to keep the sizes of `enum` variants uniform; use `Box<T>` on ones that are large
 
+### Cross-platform consistency
+- types which contain consensus- or cryptographic logic should have a consistent size across platforms. Their serialized output should not contain `usize`, and at times it may be worth it to avoid using `usize` in the types themselves for clarity.
+
 ### Misc. performance
 
 - avoid the `format!()` macro; if it is used only to convert a single value to a `String`, use `.to_string()` instead, which is also available to all the implementors of `Display`

--- a/algorithms/examples/msm.rs
+++ b/algorithms/examples/msm.rs
@@ -90,8 +90,8 @@ pub fn main() -> Result<()> {
 
         // Parse the variant.
         match args[1].as_str() {
-            "batched" => batched::msm(bases.as_slice(), scalars.as_slice()),
-            "standard" => standard::msm(bases.as_slice(), scalars.as_slice()),
+            "batched" => batched::msm(bases.as_slice(), scalars.as_slice())?,
+            "standard" => standard::msm(bases.as_slice(), scalars.as_slice())?,
             _ => panic!("Invalid variant: use 'batched' or 'standard'"),
         };
 

--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -385,6 +385,7 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
         optimization_type: OptimizationType,
     ) -> SmallVec<[F; 10]> {
         let params = get_params(TargetField::size_in_bits(), F::size_in_bits(), optimization_type);
+        assert!(params.bits_per_limb <= u32::MAX as usize);
 
         // Push the lower limbs first
         let mut limbs: SmallVec<[F; 10]> = SmallVec::new();

--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -377,6 +377,8 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
         Self::get_limbs_representations_from_big_integer::<TargetField>(&elem.to_bigint(), optimization_type)
     }
 
+    // params.bits_per_limb is safe to cast as u32 because it will be less than `max_limb_size`
+    #[allow(clippy::cast_possible_truncation)]
     /// Obtain the limbs directly from a big int
     pub fn get_limbs_representations_from_big_integer<TargetField: PrimeField>(
         elem: &<TargetField as PrimeField>::BigInteger,

--- a/algorithms/src/errors.rs
+++ b/algorithms/src/errors.rs
@@ -20,29 +20,35 @@ pub enum SNARKError {
     #[error("{}", _0)]
     AnyhowError(#[from] anyhow::Error),
 
+    #[error("Batch size was different between public input and proof")]
+    BatchSizeMismatch,
+
+    #[error("Circuit not found")]
+    CircuitNotFound,
+
     #[error("{}", _0)]
     ConstraintFieldError(#[from] ConstraintFieldError),
 
     #[error("{}: {}", _0, _1)]
     Crate(&'static str, String),
 
+    #[error("Batch size was zero; must be at least 1")]
+    EmptyBatch,
+
     #[error("Expected a circuit-specific SRS in SNARK")]
     ExpectedCircuitSpecificSRS,
+
+    #[error(transparent)]
+    IntError(#[from] std::num::TryFromIntError),
 
     #[error("{}", _0)]
     Message(String),
 
+    #[error(transparent)]
+    ParseIntError(#[from] std::num::ParseIntError),
+
     #[error("{}", _0)]
     SynthesisError(SynthesisError),
-
-    #[error("Batch size was zero; must be at least 1")]
-    EmptyBatch,
-
-    #[error("Batch size was different between public input and proof")]
-    BatchSizeMismatch,
-
-    #[error("Circuit not found")]
-    CircuitNotFound,
 
     #[error("terminated")]
     Terminated,

--- a/algorithms/src/fft/polynomial/sparse.rs
+++ b/algorithms/src/fft/polynomial/sparse.rs
@@ -16,12 +16,11 @@
 
 use crate::fft::{EvaluationDomain, Evaluations, Polynomial};
 use snarkvm_fields::{Field, PrimeField};
-use snarkvm_utilities::serialize::*;
 
 use std::{collections::BTreeMap, fmt};
 
 /// Stores a sparse polynomial in coefficient form.
-#[derive(Clone, PartialEq, Eq, Hash, Default, CanonicalSerialize, CanonicalDeserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Default)]
 #[must_use]
 pub struct SparsePolynomial<F: Field> {
     /// The coefficient a_i of `x^i` is stored as (i, a_i) in `self.coeffs`.

--- a/algorithms/src/lib.rs
+++ b/algorithms/src/lib.rs
@@ -15,6 +15,7 @@
 #![allow(clippy::module_inception)]
 #![allow(clippy::type_complexity)]
 #![cfg_attr(test, allow(clippy::assertions_on_result_states))]
+#![warn(clippy::cast_possible_truncation)]
 
 #[cfg(feature = "wasm")]
 #[macro_use]

--- a/algorithms/src/msm/fixed_base.rs
+++ b/algorithms/src/msm/fixed_base.rs
@@ -22,7 +22,7 @@ use rayon::prelude::*;
 pub struct FixedBase;
 
 impl FixedBase {
-    pub fn get_mul_window_size(num_scalars: usize) -> usize {
+    pub fn get_mul_window_size(num_scalars: usize) -> u32 {
         match num_scalars < 32 {
             true => 3,
             false => super::ln_without_floats(num_scalars),

--- a/algorithms/src/msm/mod.rs
+++ b/algorithms/src/msm/mod.rs
@@ -25,7 +25,7 @@ pub use variable_base::*;
 /// [`Explanation of usage`]
 ///
 /// [`Explanation of usage`]: https://github.com/scipr-lab/zexe/issues/79#issue-556220473
-fn ln_without_floats(a: usize) -> usize {
+fn ln_without_floats(a: usize) -> u32 {
     // log2(a) * ln(2)
-    (crate::fft::domain::log2(a) * 69 / 100) as usize
+    crate::fft::domain::log2(a) * 69 / 100
 }

--- a/algorithms/src/msm/tests.rs
+++ b/algorithms/src/msm/tests.rs
@@ -45,7 +45,7 @@ fn variable_base_test_with_bls12() {
     let g = (0..SAMPLES).map(|_| G1Projective::rand(&mut rng).to_affine()).collect::<Vec<_>>();
 
     let naive = naive_variable_base_msm(g.as_slice(), v.as_slice());
-    let fast = VariableBase::msm(g.as_slice(), v.as_slice());
+    let fast = VariableBase::msm(g.as_slice(), v.as_slice()).unwrap();
 
     assert_eq!(naive.to_affine(), fast.to_affine());
 }
@@ -60,7 +60,7 @@ fn variable_base_test_with_bls12_unequal_numbers() {
     let g = (0..SAMPLES).map(|_| G1Projective::rand(&mut rng).to_affine()).collect::<Vec<_>>();
 
     let naive = naive_variable_base_msm(g.as_slice(), v.as_slice());
-    let fast = VariableBase::msm(g.as_slice(), v.as_slice());
+    let fast = VariableBase::msm(g.as_slice(), v.as_slice()).unwrap();
 
     assert_eq!(naive.to_affine(), fast.to_affine());
 }

--- a/algorithms/src/msm/variable_base/batched.rs
+++ b/algorithms/src/msm/variable_base/batched.rs
@@ -170,16 +170,13 @@ fn batch_add_write<G: AffineCurve>(
 }
 
 #[inline]
-// It is safe to cast num_buckets to u32 because it was small enough earlier in the callchain
-#[allow(clippy::cast_possible_truncation)]
 pub(super) fn batch_add<G: AffineCurve>(
-    num_buckets: usize,
+    num_buckets: u32,
     bases: &[G],
     bucket_positions: &mut [BucketPosition],
-) -> Vec<G> {
+) -> Result<Vec<G>, anyhow::Error> {
     // assert_eq!(bases.len(), bucket_positions.len());
     assert!(!bases.is_empty());
-    assert!(num_buckets <= u32::MAX as usize);
 
     // Fetch the ideal batch size for the number of bases.
     let batch_size = batch_size(bases.len());
@@ -205,7 +202,7 @@ pub(super) fn batch_add<G: AffineCurve>(
             global_counter += 1;
             local_counter += 1;
         }
-        if current_bucket >= num_buckets as u32 {
+        if current_bucket >= num_buckets {
             local_counter = 1;
         } else if local_counter > 1 {
             // all ones is false if next len is not 1
@@ -219,13 +216,17 @@ pub(super) fn batch_add<G: AffineCurve>(
                     bucket_positions[global_counter - (local_counter - 1) + 2 * i].scalar_index,
                     bucket_positions[global_counter - (local_counter - 1) + 2 * i + 1].scalar_index,
                 ));
-                bucket_positions[new_scalar_length + i] =
-                    BucketPosition { bucket_index: current_bucket, scalar_index: (new_scalar_length + i) as u32 };
+                bucket_positions[new_scalar_length + i] = BucketPosition {
+                    bucket_index: current_bucket,
+                    scalar_index: u32::try_from(new_scalar_length + i)?,
+                };
             }
             if is_odd {
                 instr.push((bucket_positions[global_counter].scalar_index, !0u32));
-                bucket_positions[new_scalar_length + half] =
-                    BucketPosition { bucket_index: current_bucket, scalar_index: (new_scalar_length + half) as u32 };
+                bucket_positions[new_scalar_length + half] = BucketPosition {
+                    bucket_index: current_bucket,
+                    scalar_index: u32::try_from(new_scalar_length + half)?,
+                };
             }
             // Reset the local_counter and update state
             new_scalar_length += half + (local_counter % 2);
@@ -244,7 +245,7 @@ pub(super) fn batch_add<G: AffineCurve>(
         } else {
             instr.push((bucket_positions[global_counter].scalar_index, !0u32));
             bucket_positions[new_scalar_length] =
-                BucketPosition { bucket_index: current_bucket, scalar_index: new_scalar_length as u32 };
+                BucketPosition { bucket_index: current_bucket, scalar_index: u32::try_from(new_scalar_length)? };
             new_scalar_length += 1;
         }
         global_counter += 1;
@@ -270,7 +271,7 @@ pub(super) fn batch_add<G: AffineCurve>(
                 global_counter += 1;
                 local_counter += 1;
             }
-            if current_bucket >= num_buckets as u32 {
+            if current_bucket >= num_buckets {
                 local_counter = 1;
             } else if local_counter > 1 {
                 // all ones is false if next len is not 1
@@ -318,24 +319,20 @@ pub(super) fn batch_add<G: AffineCurve>(
         new_scalar_length = 0;
     }
 
-    let mut res = vec![Zero::zero(); num_buckets];
+    let mut res = vec![Zero::zero(); num_buckets as usize];
     for bucket_position in bucket_positions.iter().take(num_scalars) {
         res[bucket_position.bucket_index as usize] = new_bases[bucket_position.scalar_index as usize];
     }
-    res
+    Ok(res)
 }
 
 #[inline]
-// It is safe to cast w_start and c to u32 because they were small enough earlier in the callchain
-#[allow(clippy::cast_possible_truncation)]
 fn batched_window<G: AffineCurve>(
     bases: &[G],
     scalars: &[<G::ScalarField as PrimeField>::BigInteger],
-    w_start: usize,
-    c: usize,
-) -> (G::Projective, usize) {
-    assert!(w_start <= u32::MAX as usize);
-    assert!(c <= u32::MAX as usize);
+    w_start: u32,
+    c: u32,
+) -> Result<(G::Projective, u32), anyhow::Error> {
     // We don't need the "zero" bucket, so we only have 2^c - 1 buckets
     let window_size = if (w_start % c) != 0 { w_start % c } else { c };
     let num_buckets = (1 << window_size) - 1;
@@ -347,16 +344,19 @@ fn batched_window<G: AffineCurve>(
             let mut scalar = scalar;
 
             // We right-shift by w_start, thus getting rid of the lower bits.
-            scalar.divn(w_start as u32);
+            scalar.divn(w_start);
 
             // We mod the remaining bits by the window size.
-            let scalar = (scalar.as_ref()[0] % (1 << c)) as i32;
+            let scalar = i32::try_from(scalar.as_ref()[0] % (1 << c))?;
 
-            BucketPosition { bucket_index: (scalar - 1) as u32, scalar_index: scalar_index as u32 }
+            Ok::<_, anyhow::Error>(BucketPosition {
+                bucket_index: (scalar - 1) as u32,
+                scalar_index: u32::try_from(scalar_index)?,
+            })
         })
-        .collect();
+        .collect::<Result<_, _>>()?;
 
-    let buckets = batch_add(num_buckets, bases, &mut bucket_positions);
+    let buckets = batch_add(num_buckets, bases, &mut bucket_positions)?;
 
     let mut res = G::Projective::zero();
     let mut running_sum = G::Projective::zero();
@@ -365,10 +365,13 @@ fn batched_window<G: AffineCurve>(
         res += &running_sum;
     }
 
-    (res, window_size)
+    Ok((res, window_size))
 }
 
-pub fn msm<G: AffineCurve>(bases: &[G], scalars: &[<G::ScalarField as PrimeField>::BigInteger]) -> G::Projective {
+pub fn msm<G: AffineCurve>(
+    bases: &[G],
+    scalars: &[<G::ScalarField as PrimeField>::BigInteger],
+) -> Result<G::Projective, anyhow::Error> {
     if bases.len() < 15 {
         let num_bits = G::ScalarField::size_in_bits();
         let bigint_size = <G::ScalarField as PrimeField>::BigInteger::NUM_LIMBS * 64;
@@ -389,7 +392,7 @@ pub fn msm<G: AffineCurve>(bases: &[G], scalars: &[<G::ScalarField as PrimeField
             }
         }
         debug_assert!(bits.iter_mut().all(|b| b.next().is_none()));
-        sum
+        Ok(sum)
     } else {
         // Determine the bucket size `c` (chosen empirically).
         let c = match scalars.len() < 32 {
@@ -397,24 +400,26 @@ pub fn msm<G: AffineCurve>(bases: &[G], scalars: &[<G::ScalarField as PrimeField
             false => crate::msm::ln_without_floats(scalars.len()) + 2,
         };
 
-        let num_bits = <G::ScalarField as PrimeField>::size_in_bits();
+        let num_bits = <G::ScalarField as PrimeField>::size_in_bits_u32();
 
         // Each window is of size `c`.
         // We divide up the bits 0..num_bits into windows of size `c`, and
         // in parallel process each such window.
-        let window_sums: Vec<_> =
-            cfg_into_iter!(0..num_bits).step_by(c).map(|w_start| batched_window(bases, scalars, w_start, c)).collect();
+        let window_sums: Vec<_> = cfg_into_iter!(0..num_bits)
+            .step_by(c as usize)
+            .map(|w_start| batched_window(bases, scalars, w_start, c))
+            .collect::<Result<_, _>>()?;
 
         // We store the sum for the lowest window.
         let (lowest, window_sums) = window_sums.split_first().unwrap();
 
         // We're traversing windows from high to low.
-        window_sums.iter().rev().fold(G::Projective::zero(), |mut total, (sum_i, window_size)| {
+        Ok(window_sums.iter().rev().fold(G::Projective::zero(), |mut total, (sum_i, window_size)| {
             total += sum_i;
             for _ in 0..*window_size {
                 total.double_in_place();
             }
             total
-        }) + lowest.0
+        }) + lowest.0)
     }
 }

--- a/algorithms/src/msm/variable_base/batched.rs
+++ b/algorithms/src/msm/variable_base/batched.rs
@@ -179,6 +179,7 @@ pub(super) fn batch_add<G: AffineCurve>(
 ) -> Vec<G> {
     // assert_eq!(bases.len(), bucket_positions.len());
     assert!(!bases.is_empty());
+    assert!(num_buckets <= u32::MAX as usize);
 
     // Fetch the ideal batch size for the number of bases.
     let batch_size = batch_size(bases.len());
@@ -333,6 +334,8 @@ fn batched_window<G: AffineCurve>(
     w_start: usize,
     c: usize,
 ) -> (G::Projective, usize) {
+    assert!(w_start <= u32::MAX as usize);
+    assert!(c <= u32::MAX as usize);
     // We don't need the "zero" bucket, so we only have 2^c - 1 buckets
     let window_size = if (w_start % c) != 0 { w_start % c } else { c };
     let num_buckets = (1 << window_size) - 1;

--- a/algorithms/src/msm/variable_base/batched.rs
+++ b/algorithms/src/msm/variable_base/batched.rs
@@ -170,6 +170,8 @@ fn batch_add_write<G: AffineCurve>(
 }
 
 #[inline]
+// It is safe to cast num_buckets to u32 because it was small enough earlier in the callchain
+#[allow(clippy::cast_possible_truncation)]
 pub(super) fn batch_add<G: AffineCurve>(
     num_buckets: usize,
     bases: &[G],
@@ -323,6 +325,8 @@ pub(super) fn batch_add<G: AffineCurve>(
 }
 
 #[inline]
+// It is safe to cast w_start and c to u32 because they were small enough earlier in the callchain
+#[allow(clippy::cast_possible_truncation)]
 fn batched_window<G: AffineCurve>(
     bases: &[G],
     scalars: &[<G::ScalarField as PrimeField>::BigInteger],

--- a/algorithms/src/msm/variable_base/mod.rs
+++ b/algorithms/src/msm/variable_base/mod.rs
@@ -38,7 +38,7 @@ impl VariableBase {
                 let result = snarkvm_algorithms_cuda::msm::<G, G::Projective, <G::ScalarField as PrimeField>::BigInteger>(
                     bases, scalars,
                 );
-                if let Ok(result) = result {
+                if result.is_ok() {
                     return result;
                 }
             }
@@ -114,8 +114,8 @@ mod tests {
         let mut rng = TestRng::default();
         for i in 2..17 {
             let (bases, scalars) = create_scalar_bases::<G1Affine, Fr>(&mut rng, 1 << i);
-            let rust = standard::msm(bases.as_slice(), scalars.as_slice());
-            let cuda = VariableBase::msm::<G1Affine>(bases.as_slice(), scalars.as_slice());
+            let rust = standard::msm(bases.as_slice(), scalars.as_slice()).unwrap();
+            let cuda = VariableBase::msm::<G1Affine>(bases.as_slice(), scalars.as_slice()).unwrap();
             assert_eq!(rust.to_affine(), cuda.to_affine());
         }
     }

--- a/algorithms/src/msm/variable_base/mod.rs
+++ b/algorithms/src/msm/variable_base/mod.rs
@@ -38,8 +38,9 @@ impl VariableBase {
                 let result = snarkvm_algorithms_cuda::msm::<G, G::Projective, <G::ScalarField as PrimeField>::BigInteger>(
                     bases, scalars,
                 );
-                if result.is_ok() {
-                    return result;
+                // Remove any cuda::Error
+                if let Ok(result) = result {
+                    return Ok(result);
                 }
             }
             batched::msm(bases, scalars)

--- a/algorithms/src/msm/variable_base/mod.rs
+++ b/algorithms/src/msm/variable_base/mod.rs
@@ -26,7 +26,10 @@ use core::any::TypeId;
 pub struct VariableBase;
 
 impl VariableBase {
-    pub fn msm<G: AffineCurve>(bases: &[G], scalars: &[<G::ScalarField as PrimeField>::BigInteger]) -> G::Projective {
+    pub fn msm<G: AffineCurve>(
+        bases: &[G],
+        scalars: &[<G::ScalarField as PrimeField>::BigInteger],
+    ) -> Result<G::Projective, anyhow::Error> {
         // For BLS12-377, we perform variable base MSM using a batched addition technique.
         if TypeId::of::<G>() == TypeId::of::<G1Affine>() {
             #[cfg(all(feature = "cuda", target_arch = "x86_64"))]
@@ -97,10 +100,10 @@ mod tests {
             let naive_b = VariableBase::msm_naive_parallel(bases.as_slice(), scalars.as_slice()).to_affine();
             assert_eq!(naive_a, naive_b, "MSM size: {msm_size}");
 
-            let candidate = standard::msm(bases.as_slice(), scalars.as_slice()).to_affine();
+            let candidate = standard::msm(bases.as_slice(), scalars.as_slice()).unwrap().to_affine();
             assert_eq!(naive_a, candidate, "MSM size: {msm_size}");
 
-            let candidate = batched::msm(bases.as_slice(), scalars.as_slice()).to_affine();
+            let candidate = batched::msm(bases.as_slice(), scalars.as_slice()).unwrap().to_affine();
             assert_eq!(naive_a, candidate, "MSM size: {msm_size}");
         }
     }

--- a/algorithms/src/msm/variable_base/standard.rs
+++ b/algorithms/src/msm/variable_base/standard.rs
@@ -29,6 +29,7 @@ fn update_buckets<G: AffineCurve>(
     c: usize,
     buckets: &mut [G::Projective],
 ) {
+    assert!(w_start <= u32::MAX as usize);
     // We right-shift by w_start, thus getting rid of the lower bits.
     scalar.divn(w_start as u32);
 

--- a/algorithms/src/msm/variable_base/standard.rs
+++ b/algorithms/src/msm/variable_base/standard.rs
@@ -19,6 +19,9 @@ use snarkvm_utilities::{cfg_into_iter, BigInteger};
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
 
+// It is safe to cast w_start to u32 because it was small enough earlier in the callchain
+// It is safe to cast scalar to usize because it is mod c, which is usize
+#[allow(clippy::cast_possible_truncation)]
 fn update_buckets<G: AffineCurve>(
     base: &G,
     mut scalar: <G::ScalarField as PrimeField>::BigInteger,

--- a/algorithms/src/polycommit/error.rs
+++ b/algorithms/src/polycommit/error.rs
@@ -92,6 +92,9 @@ pub enum PCError {
         label: String,
     },
 
+    /// Could not convert from int.
+    IntError(std::num::TryFromIntError),
+
     Terminated,
 }
 
@@ -100,6 +103,12 @@ impl snarkvm_utilities::error::Error for PCError {}
 impl From<anyhow::Error> for PCError {
     fn from(other: anyhow::Error) -> Self {
         Self::AnyhowError(other)
+    }
+}
+
+impl From<std::num::TryFromIntError> for PCError {
+    fn from(other: std::num::TryFromIntError) -> Self {
+        Self::IntError(other)
     }
 }
 
@@ -148,6 +157,7 @@ impl core::fmt::Display for PCError {
                  (having degree {poly_degree:?}) is greater than the maximum \
                  supported degree ({supported_degree:?})"
             ),
+            Self::IntError(error) => write!(f, "{error}"),
             Self::Terminated => write!(f, "terminated"),
         }
     }

--- a/algorithms/src/polycommit/kzg10/data_structures.rs
+++ b/algorithms/src/polycommit/kzg10/data_structures.rs
@@ -129,6 +129,8 @@ impl<E: PairingEngine> FromBytes for UniversalParams<E> {
     }
 }
 
+// It is safe to cast `supported_degree_bounds.len()` and individual bounds to a `u32` because they are read and used as u32
+#[allow(clippy::cast_possible_truncation)]
 impl<E: PairingEngine> ToBytes for UniversalParams<E> {
     fn write_le<W: Write>(&self, mut writer: W) -> io::Result<()> {
         // Serialize powers.
@@ -350,7 +352,7 @@ impl<E: PairingEngine> ToBytes for KZGCommitment<E> {
 }
 
 impl<E: PairingEngine> ToMinimalBits for KZGCommitment<E> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
         self.0.to_minimal_bits()
     }
 }

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -118,7 +118,7 @@ impl<E: PairingEngine> KZG10<E> {
                 let (num_leading_zeros, plain_coeffs) = skip_leading_zeros_and_convert_to_bigints(polynomial);
 
                 let msm_time = start_timer!(|| "MSM to compute commitment to plaintext poly");
-                let commitment = VariableBase::msm(&powers.powers_of_beta_g[num_leading_zeros..], &plain_coeffs);
+                let commitment = VariableBase::msm(&powers.powers_of_beta_g[num_leading_zeros..], &plain_coeffs)?;
                 end_timer!(msm_time);
 
                 if terminator.load(Ordering::Relaxed) {
@@ -151,7 +151,7 @@ impl<E: PairingEngine> KZG10<E> {
         let random_ints = convert_to_bigints(&randomness.blinding_polynomial.coeffs);
         let msm_time = start_timer!(|| "MSM to compute commitment to random poly");
         let random_commitment =
-            VariableBase::msm(&powers.powers_of_beta_times_gamma_g, random_ints.as_slice()).to_affine();
+            VariableBase::msm(&powers.powers_of_beta_times_gamma_g, random_ints.as_slice())?.to_affine();
         end_timer!(msm_time);
 
         if terminator.load(Ordering::Relaxed) {
@@ -186,7 +186,7 @@ impl<E: PairingEngine> KZG10<E> {
 
         let evaluations = evaluations.iter().map(|e| e.to_bigint()).collect::<Vec<_>>();
         let msm_time = start_timer!(|| "MSM to compute commitment to plaintext poly");
-        let mut commitment = VariableBase::msm(&lagrange_basis.lagrange_basis_at_beta_g, &evaluations);
+        let mut commitment = VariableBase::msm(&lagrange_basis.lagrange_basis_at_beta_g, &evaluations)?;
         end_timer!(msm_time);
 
         if terminator.load(Ordering::Relaxed) {
@@ -210,7 +210,7 @@ impl<E: PairingEngine> KZG10<E> {
         let random_ints = convert_to_bigints(&randomness.blinding_polynomial.coeffs);
         let msm_time = start_timer!(|| "MSM to compute commitment to random poly");
         let random_commitment =
-            VariableBase::msm(&lagrange_basis.powers_of_beta_times_gamma_g, random_ints.as_slice()).to_affine();
+            VariableBase::msm(&lagrange_basis.powers_of_beta_times_gamma_g, random_ints.as_slice())?.to_affine();
         end_timer!(msm_time);
 
         if terminator.load(Ordering::Relaxed) {
@@ -265,7 +265,7 @@ impl<E: PairingEngine> KZG10<E> {
         let (num_leading_zeros, witness_coeffs) = skip_leading_zeros_and_convert_to_bigints(witness_polynomial);
 
         let witness_comm_time = start_timer!(|| "Computing commitment to witness polynomial");
-        let mut w = VariableBase::msm(&powers.powers_of_beta_g[num_leading_zeros..], &witness_coeffs);
+        let mut w = VariableBase::msm(&powers.powers_of_beta_g[num_leading_zeros..], &witness_coeffs)?;
         end_timer!(witness_comm_time);
 
         let random_v = if let Some(hiding_witness_polynomial) = hiding_witness_polynomial {
@@ -276,7 +276,7 @@ impl<E: PairingEngine> KZG10<E> {
 
             let random_witness_coeffs = convert_to_bigints(&hiding_witness_polynomial.coeffs);
             let witness_comm_time = start_timer!(|| "Computing commitment to random witness polynomial");
-            w += &VariableBase::msm(&powers.powers_of_beta_times_gamma_g, &random_witness_coeffs);
+            w += &VariableBase::msm(&powers.powers_of_beta_times_gamma_g, &random_witness_coeffs)?;
             end_timer!(witness_comm_time);
             Some(blinding_evaluation)
         } else {

--- a/algorithms/src/polycommit/sonic_pc/data_structures.rs
+++ b/algorithms/src/polycommit/sonic_pc/data_structures.rs
@@ -223,7 +223,6 @@ impl<E: PairingEngine> FromBytes for CommitterKey<E> {
 impl<E: PairingEngine> ToBytes for CommitterKey<E> {
     fn write_le<W: Write>(&self, mut writer: W) -> io::Result<()> {
         // Serialize `powers`.
-        // u32::try_from(*degree_bound).map_err(|e| error(e.to_string()))?.write_le(&mut writer)?;
         try_write_as::<u32, W>(self.powers_of_beta_g.len(), &mut writer)?;
         for power in &self.powers_of_beta_g {
             power.write_le(&mut writer)?;

--- a/algorithms/src/polycommit/sonic_pc/mod.rs
+++ b/algorithms/src/polycommit/sonic_pc/mod.rs
@@ -156,7 +156,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
             shifted_powers_of_beta_g,
             shifted_powers_of_beta_times_gamma_g,
             enforced_degree_bounds,
-            max_degree,
+            max_degree: u32::try_from(max_degree)?,
         };
 
         let g = pp.power_of_beta_g(0)?;
@@ -244,7 +244,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
 
             kzg10::KZG10::<E>::check_degrees_and_bounds(
                 ck.supported_degree(),
-                ck.max_degree,
+                usize::try_from(ck.max_degree)?,
                 ck.enforced_degree_bounds.as_deref(),
                 p.clone(),
             )?;
@@ -327,16 +327,12 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         Randomness<E>: 'a,
         Commitment<E>: 'a,
     {
+        let max_degree = usize::try_from(ck.max_degree)?;
         Ok(Self::combine_polynomials(labeled_polynomials.into_iter().zip_eq(rands).map(|(p, r)| {
             let enforced_degree_bounds: Option<&[usize]> = ck.enforced_degree_bounds.as_deref();
 
-            kzg10::KZG10::<E>::check_degrees_and_bounds(
-                ck.supported_degree(),
-                ck.max_degree,
-                enforced_degree_bounds,
-                p,
-            )
-            .unwrap();
+            kzg10::KZG10::<E>::check_degrees_and_bounds(ck.supported_degree(), max_degree, enforced_degree_bounds, p)
+                .unwrap();
             let challenge = fs_rng.squeeze_short_nonnative_field_element::<E::Fr>();
             (challenge, p.polynomial().to_dense(), r)
         })))

--- a/algorithms/src/snark/marlin/ahp/ahp.rs
+++ b/algorithms/src/snark/marlin/ahp/ahp.rs
@@ -29,7 +29,7 @@ use snarkvm_fields::{Field, PrimeField};
 use snarkvm_r1cs::SynthesisError;
 
 use core::{borrow::Borrow, marker::PhantomData};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, num::TryFromIntError};
 
 /// The algebraic holographic proof defined in [CHMMVW19](https://eprint.iacr.org/2019/1047).
 /// Currently, this AHP only supports inputs of size one
@@ -89,7 +89,7 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
     /// of this protocol.
     /// The number of the variables must include the "one" variable. That is, it
     /// must be with respect to the number of formatted public inputs.
-    pub fn max_degree(num_constraints: usize, num_variables: usize, num_non_zero: usize) -> Result<usize, AHPError> {
+    pub fn max_degree(num_constraints: usize, num_variables: usize, num_non_zero: usize) -> Result<u32, AHPError> {
         let padded_matrix_dim = matrices::padded_matrix_dim(num_variables, num_constraints);
         let zk_bound = Self::zk_bound().unwrap_or(0);
         let constraint_domain_size = EvaluationDomain::<F>::compute_size_of_domain(padded_matrix_dim)
@@ -97,16 +97,18 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
         let non_zero_domain_size =
             EvaluationDomain::<F>::compute_size_of_domain(num_non_zero).ok_or(AHPError::PolynomialDegreeTooLarge)?;
 
-        Ok(*[
-            2 * constraint_domain_size + zk_bound - 2,
-            if MM::ZK { constraint_domain_size + 3 } else { 0 }, //  mask_poly
-            constraint_domain_size,
-            constraint_domain_size,
-            non_zero_domain_size - 1, // non-zero polynomials
-        ]
-        .iter()
-        .max()
-        .unwrap())
+        Ok(u32::try_from(
+            *[
+                2 * constraint_domain_size + zk_bound - 2,
+                if MM::ZK { constraint_domain_size + 3 } else { 0 }, //  mask_poly
+                constraint_domain_size,
+                constraint_domain_size,
+                non_zero_domain_size - 1, // non-zero polynomials
+            ]
+            .iter()
+            .max()
+            .unwrap(),
+        )?)
     }
 
     /// Get all the strict degree bounds enforced in the AHP.
@@ -241,13 +243,13 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
             .map(|(&circuit_id, circuit_state)| {
                 let z_b_i = (0..circuit_state.batch_size)
                     .map(|i| {
-                        let z_b = witness_label(circuit_id, "z_b", i);
-                        LinearCombination::new(z_b.clone(), [(F::one(), z_b)])
+                        let z_b = witness_label(circuit_id, "z_b", usize::try_from(i)?);
+                        Ok::<_, TryFromIntError>(LinearCombination::new(z_b.clone(), [(F::one(), z_b)]))
                     })
-                    .collect::<Vec<_>>();
-                (circuit_id, z_b_i)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok((circuit_id, z_b_i))
             })
-            .collect::<BTreeMap<_, _>>();
+            .collect::<Result<BTreeMap<CircuitId, _>, TryFromIntError>>()?;
 
         let g_1 = LinearCombination::new("g_1", [(F::one(), "g_1")]);
 
@@ -277,18 +279,18 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
         end_timer!(v_X_at_beta_time);
 
         let z_b_s_at_beta = z_b_s
-            .values()
-            .map(|z_b_i| {
-                let z_b_i_s = z_b_i.iter().map(|z_b| evals.get_lc_eval(z_b, beta)).collect::<Result<Vec<F>, _>>();
-                z_b_i_s
+            .iter()
+            .map(|(circuit_id, z_b_i)| {
+                let z_b_i_s = z_b_i.iter().map(|z_b| evals.get_lc_eval(z_b, beta)).try_collect()?;
+                Ok((*circuit_id, z_b_i_s))
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<BTreeMap<CircuitId, Vec<F>>, AHPError>>()?;
 
         let batch_z_b_s_at_beta = z_b_s_at_beta
             .iter()
-            .zip_eq(batch_combiners.iter())
+            .zip_eq(batch_combiners.values())
             .zip_eq(r_alpha_at_beta_s.values())
-            .map(|((z_b_i_at_beta, (circuit_id, combiners)), &r_alpha_at_beta)| {
+            .map(|(((circuit_id, z_b_i_at_beta), combiners), &r_alpha_at_beta)| {
                 let z_b_at_beta = z_b_i_at_beta
                     .iter()
                     .zip_eq(&combiners.instance_combiners)
@@ -323,13 +325,13 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
             if MM::ZK {
                 lincheck_sumcheck.add(F::one(), "mask_poly");
             }
-            for (i, (id, c)) in batch_combiners.iter().enumerate() {
+            for (id, c) in batch_combiners.iter() {
                 let mut circuit_term = LinearCombination::empty(format!("lincheck_sumcheck term {id}"));
                 for (j, instance_combiner) in c.instance_combiners.iter().enumerate() {
                     let z_a_j = witness_label(*id, "z_a", j);
                     let w_j = witness_label(*id, "w", j);
                     circuit_term
-                        .add(r_alpha_at_beta_s[id] * instance_combiner * (eta_a + eta_c * z_b_s_at_beta[i][j]), z_a_j)
+                        .add(r_alpha_at_beta_s[id] * instance_combiner * (eta_a + eta_c * z_b_s_at_beta[id][j]), z_a_j)
                         .add(-t_at_beta_s[id] * v_X_at_beta[id] * instance_combiner, w_j);
                 }
                circuit_term

--- a/algorithms/src/snark/marlin/ahp/ahp.rs
+++ b/algorithms/src/snark/marlin/ahp/ahp.rs
@@ -46,7 +46,7 @@ struct VerifierChallenges<F: Field> {
     gamma: F,
 }
 
-pub(crate) fn witness_label(circuit_id: CircuitId, poly: &str, i: usize) -> String {
+pub(crate) fn witness_label(circuit_id: CircuitId, poly: &str, i: u32) -> String {
     format!("circuit_{circuit_id}_{poly}_{i:0>8}")
 }
 
@@ -243,7 +243,7 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
             .map(|(&circuit_id, circuit_state)| {
                 let z_b_i = (0..circuit_state.batch_size)
                     .map(|i| {
-                        let z_b = witness_label(circuit_id, "z_b", usize::try_from(i)?);
+                        let z_b = witness_label(circuit_id, "z_b", i);
                         Ok::<_, TryFromIntError>(LinearCombination::new(z_b.clone(), [(F::one(), z_b)]))
                     })
                     .collect::<Result<Vec<_>, _>>()?;
@@ -328,8 +328,8 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
             for (id, c) in batch_combiners.iter() {
                 let mut circuit_term = LinearCombination::empty(format!("lincheck_sumcheck term {id}"));
                 for (j, instance_combiner) in c.instance_combiners.iter().enumerate() {
-                    let z_a_j = witness_label(*id, "z_a", j);
-                    let w_j = witness_label(*id, "w", j);
+                    let z_a_j = witness_label(*id, "z_a", u32::try_from(j)?);
+                    let w_j = witness_label(*id, "w", u32::try_from(j)?);
                     circuit_term
                         .add(r_alpha_at_beta_s[id] * instance_combiner * (eta_a + eta_c * z_b_s_at_beta[id][j]), z_a_j)
                         .add(-t_at_beta_s[id] * v_X_at_beta[id] * instance_combiner, w_j);

--- a/algorithms/src/snark/marlin/ahp/ahp.rs
+++ b/algorithms/src/snark/marlin/ahp/ahp.rs
@@ -467,7 +467,7 @@ fn selector_evals<F: PrimeField>(
     challenge: F,
 ) -> F {
     *cached_selector_evaluations
-        .entry((target_domain.size, largest_domain.size, challenge))
+        .entry((target_domain.size as u64, largest_domain.size as u64, challenge))
         .or_insert_with(|| largest_domain.evaluate_selector_polynomial(*target_domain, challenge))
 }
 

--- a/algorithms/src/snark/marlin/ahp/errors.rs
+++ b/algorithms/src/snark/marlin/ahp/errors.rs
@@ -21,6 +21,8 @@ pub enum AHPError {
     ConstraintSystemError(snarkvm_r1cs::errors::SynthesisError),
     /// The instance generated during proving does not match that in the index.
     InstanceDoesNotMatchIndex,
+    /// Could not convert from int.
+    IntError(std::num::TryFromIntError),
     /// The number of public inputs is incorrect.
     InvalidPublicInputLength,
     /// During verification, a required evaluation is missing
@@ -34,5 +36,11 @@ pub enum AHPError {
 impl From<snarkvm_r1cs::errors::SynthesisError> for AHPError {
     fn from(other: snarkvm_r1cs::errors::SynthesisError) -> Self {
         AHPError::ConstraintSystemError(other)
+    }
+}
+
+impl From<std::num::TryFromIntError> for AHPError {
+    fn from(other: std::num::TryFromIntError) -> Self {
+        Self::IntError(other)
     }
 }

--- a/algorithms/src/snark/marlin/ahp/indexer/circuit.rs
+++ b/algorithms/src/snark/marlin/ahp/indexer/circuit.rs
@@ -113,7 +113,7 @@ impl<F: PrimeField, MM: MarlinMode> Circuit<F, MM> {
     }
 
     /// The maximum degree required to represent polynomials of this index.
-    pub fn max_degree(&self) -> usize {
+    pub fn max_degree(&self) -> u32 {
         self.index_info.max_degree::<MM>()
     }
 

--- a/algorithms/src/snark/marlin/ahp/indexer/circuit_info.rs
+++ b/algorithms/src/snark/marlin/ahp/indexer/circuit_info.rs
@@ -43,7 +43,7 @@ pub struct CircuitInfo<F: Sync + Send> {
 
 impl<F: PrimeField> CircuitInfo<F> {
     /// The maximum degree of polynomial required to represent this index in the AHP.
-    pub fn max_degree<MM: MarlinMode>(&self) -> usize {
+    pub fn max_degree<MM: MarlinMode>(&self) -> u32 {
         let max_non_zero = self.num_non_zero_a.max(self.num_non_zero_b).max(self.num_non_zero_c);
         AHPForR1CS::<F, MM>::max_degree(self.num_constraints, self.num_variables, max_non_zero).unwrap()
     }

--- a/algorithms/src/snark/marlin/ahp/prover/round_functions/first.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/round_functions/first.rs
@@ -49,9 +49,9 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
 
     /// Output the degree bounds of oracles in the first round.
     pub fn first_round_polynomial_info<'a>(
-        circuits: impl Iterator<Item = (&'a CircuitId, &'a usize)>,
+        batch_sizes: impl Iterator<Item = (&'a CircuitId, &'a usize)>,
     ) -> BTreeMap<PolynomialLabel, PolynomialInfo> {
-        let mut polynomials = circuits
+        let mut polynomials = batch_sizes
             .flat_map(|(&circuit_id, &batch_size)| {
                 (0..batch_size).flat_map(move |i| {
                     [
@@ -72,13 +72,14 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
     #[allow(clippy::type_complexity)]
     pub fn prover_first_round<'a, R: RngCore>(
         mut state: prover::State<'a, F, MM>,
+        batch_sizes: impl Iterator<Item = (&'a CircuitId, &'a usize)>,
         rng: &mut R,
     ) -> Result<prover::State<'a, F, MM>, AHPError> {
         let round_time = start_timer!(|| "AHP::Prover::FirstRound");
         let mut r_b_s = Vec::with_capacity(state.circuit_specific_states.len());
-        let mut job_pool = snarkvm_utilities::ExecutionPool::with_capacity(3 * state.total_instances);
+        let mut job_pool = snarkvm_utilities::ExecutionPool::with_capacity((3 * state.total_instances).try_into()?);
         for (circuit, circuit_state) in state.circuit_specific_states.iter_mut() {
-            let batch_size = circuit_state.batch_size;
+            let batch_size = usize::try_from(circuit_state.batch_size)?;
 
             let z_a = circuit_state.z_a.take().unwrap();
             let z_b = circuit_state.z_b.take().unwrap();
@@ -121,20 +122,18 @@ impl<F: PrimeField, MM: MarlinMode> AHPForR1CS<F, MM> {
                 prover::SingleEntry { z_a, z_b, w_poly, z_a_poly, z_b_poly }
             })
             .collect::<Vec<_>>();
-        assert_eq!(batches.len(), state.total_instances);
+        assert_eq!(batches.len(), usize::try_from(state.total_instances)?);
 
         let mut circuit_specific_batches = BTreeMap::new();
         for ((circuit, state), r_b_s) in state.circuit_specific_states.iter_mut().zip(r_b_s) {
-            let batches = batches.drain(0..state.batch_size).collect_vec();
+            let batches = batches.drain(0..state.batch_size.try_into()?).collect_vec();
             circuit_specific_batches.insert(circuit.id, batches);
             state.mz_poly_randomizer = MM::ZK.then_some(r_b_s);
             end_timer!(round_time);
         }
         let mask_poly = Self::calculate_mask_poly(state.max_constraint_domain, rng);
         let oracles = prover::FirstOracles { batches: circuit_specific_batches, mask_poly };
-        assert!(oracles.matches_info(&Self::first_round_polynomial_info(
-            state.circuit_specific_states.iter().map(|(c, s)| (&c.id, &s.batch_size))
-        )));
+        assert!(oracles.matches_info(&Self::first_round_polynomial_info(batch_sizes)));
         state.first_round_oracles = Some(Arc::new(oracles));
         Ok(state)
     }

--- a/algorithms/src/snark/marlin/ahp/prover/state.rs
+++ b/algorithms/src/snark/marlin/ahp/prover/state.rs
@@ -30,7 +30,7 @@ pub struct CircuitSpecificState<F: PrimeField> {
     pub(super) non_zero_c_domain: EvaluationDomain<F>,
 
     /// The number of instances being proved in this batch.
-    pub(in crate::snark) batch_size: usize,
+    pub(in crate::snark) batch_size: u32,
 
     /// The list of public inputs for each instance in the batch.
     /// The length of this list must be equal to the batch size.
@@ -74,7 +74,7 @@ pub struct State<'a, F: PrimeField, MM: MarlinMode> {
     /// The largest constraint domain of all circuits in the batch.
     pub(in crate::snark) max_constraint_domain: EvaluationDomain<F>,
     /// The total number of instances we're proving in the batch.
-    pub(in crate::snark) total_instances: usize,
+    pub(in crate::snark) total_instances: u32,
 }
 
 /// The public inputs for a single instance.
@@ -112,13 +112,14 @@ impl<'a, F: PrimeField, MM: MarlinMode> State<'a, F, MM> {
 
                 let first_padded_public_inputs = &variable_assignments[0].0;
                 let input_domain = EvaluationDomain::new(first_padded_public_inputs.len()).unwrap();
-                let batch_size = variable_assignments.len();
+                let batch_size = variable_assignments.len().try_into()?;
                 total_instances += batch_size;
-                let mut z_as = Vec::with_capacity(batch_size);
-                let mut z_bs = Vec::with_capacity(batch_size);
-                let mut x_polys = Vec::with_capacity(batch_size);
-                let mut padded_public_variables = Vec::with_capacity(batch_size);
-                let mut private_variables = Vec::with_capacity(batch_size);
+                let batch_size_usize = batch_size as usize;
+                let mut z_as = Vec::with_capacity(batch_size_usize);
+                let mut z_bs = Vec::with_capacity(batch_size_usize);
+                let mut x_polys = Vec::with_capacity(batch_size_usize);
+                let mut padded_public_variables = Vec::with_capacity(batch_size_usize);
+                let mut private_variables = Vec::with_capacity(batch_size_usize);
 
                 for Assignments(padded_public_input, private_input, z_a, z_b) in variable_assignments {
                     z_as.push(z_a);
@@ -163,7 +164,7 @@ impl<'a, F: PrimeField, MM: MarlinMode> State<'a, F, MM> {
     }
 
     /// Get the batch size for a given circuit.
-    pub fn batch_size(&self, circuit: &Circuit<F, MM>) -> Option<usize> {
+    pub fn batch_size(&self, circuit: &Circuit<F, MM>) -> Option<u32> {
         self.circuit_specific_states.get(circuit).map(|s| s.batch_size)
     }
 

--- a/algorithms/src/snark/marlin/ahp/verifier/messages.rs
+++ b/algorithms/src/snark/marlin/ahp/verifier/messages.rs
@@ -110,11 +110,11 @@ impl<F: PrimeField> QuerySet<F> {
 
     /// Returns a `BTreeSet` containing elements of the form
     /// `(polynomial_label, (query_label, query))`.
-    pub fn to_set(&self) -> crate::polycommit::sonic_pc::QuerySet<F> {
+    pub fn to_set(&self) -> Result<crate::polycommit::sonic_pc::QuerySet<F>, TryFromIntError> {
         let mut query_set = crate::polycommit::sonic_pc::QuerySet::new();
         for (&circuit_id, &batch_size) in self.batch_sizes.iter() {
             for j in 0..batch_size {
-                query_set.insert((witness_label(circuit_id, "z_b", j), self.z_b_query.clone()));
+                query_set.insert((witness_label(circuit_id, "z_b", u32::try_from(j)?), self.z_b_query.clone()));
             }
             query_set.insert((witness_label(circuit_id, "g_a", 0), self.g_a_query.clone()));
             query_set.insert((witness_label(circuit_id, "g_b", 0), self.g_b_query.clone()));
@@ -123,6 +123,6 @@ impl<F: PrimeField> QuerySet<F> {
         query_set.insert(("g_1".into(), self.g_1_query.clone()));
         query_set.insert(("lincheck_sumcheck".into(), self.lincheck_sumcheck_query.clone()));
         query_set.insert(("matrix_sumcheck".into(), self.matrix_sumcheck_query.clone()));
-        query_set
+        Ok(query_set)
     }
 }

--- a/algorithms/src/snark/marlin/ahp/verifier/state.rs
+++ b/algorithms/src/snark/marlin/ahp/verifier/state.rs
@@ -35,7 +35,7 @@ pub struct CircuitSpecificState<F: PrimeField> {
     pub(crate) non_zero_c_domain: EvaluationDomain<F>,
 
     /// The number of instances being proved in this batch.
-    pub(in crate::snark::marlin) batch_size: usize,
+    pub(in crate::snark::marlin) batch_size: u32,
 }
 /// State of the AHP verifier.
 #[derive(Debug)]

--- a/algorithms/src/snark/marlin/ahp/verifier/verifier.rs
+++ b/algorithms/src/snark/marlin/ahp/verifier/verifier.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 use smallvec::SmallVec;
 use snarkvm_fields::PrimeField;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, num::TryFromIntError};
 
 impl<TargetField: PrimeField, MM: MarlinMode> AHPForR1CS<TargetField, MM> {
     /// Output the first message and next round state.
@@ -102,7 +102,7 @@ impl<TargetField: PrimeField, MM: MarlinMode> AHPForR1CS<TargetField, MM> {
                 non_zero_a_domain,
                 non_zero_b_domain,
                 non_zero_c_domain,
-                batch_size: *batch_size,
+                batch_size: (*batch_size).try_into()?,
             };
             circuit_specific_states.insert(*circuit_id, circuit_specific_state);
         }
@@ -182,7 +182,9 @@ impl<TargetField: PrimeField, MM: MarlinMode> AHPForR1CS<TargetField, MM> {
     }
 
     /// Output the query state and next round state.
-    pub fn verifier_query_set(state: State<TargetField, MM>) -> (QuerySet<TargetField>, State<TargetField, MM>) {
-        (QuerySet::new(&state), state)
+    pub fn verifier_query_set(
+        state: State<TargetField, MM>,
+    ) -> Result<(QuerySet<TargetField>, State<TargetField, MM>), TryFromIntError> {
+        Ok((QuerySet::new(&state)?, state))
     }
 }

--- a/algorithms/src/snark/marlin/data_structures/circuit_verifying_key.rs
+++ b/algorithms/src/snark/marlin/data_structures/circuit_verifying_key.rs
@@ -95,7 +95,7 @@ impl<E: PairingEngine, MM: MarlinMode> From<PreparedCircuitVerifyingKey<E, MM>> 
 }
 
 impl<E: PairingEngine, MM: MarlinMode> ToMinimalBits for CircuitVerifyingKey<E, MM> {
-    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
+    fn to_minimal_bits(&self) -> Vec<bool> {
         let constraint_domain = EvaluationDomain::<E::Fr>::new(self.circuit_info.num_constraints)
             .ok_or(SynthesisError::PolynomialDegreeTooLarge)
             .unwrap();
@@ -109,10 +109,10 @@ impl<E: PairingEngine, MM: MarlinMode> ToMinimalBits for CircuitVerifyingKey<E, 
             .ok_or(SynthesisError::PolynomialDegreeTooLarge)
             .unwrap();
 
-        let constraint_domain_size = u64::try_from(constraint_domain.size())?;
-        let non_zero_domain_a_size = u64::try_from(non_zero_domain_a.size())?;
-        let non_zero_domain_b_size = u64::try_from(non_zero_domain_b.size())?;
-        let non_zero_domain_c_size = u64::try_from(non_zero_domain_c.size())?;
+        let constraint_domain_size = constraint_domain.size() as u64;
+        let non_zero_domain_a_size = non_zero_domain_a.size() as u64;
+        let non_zero_domain_b_size = non_zero_domain_b.size() as u64;
+        let non_zero_domain_c_size = non_zero_domain_c.size() as u64;
 
         let constraint_domain_size_bits = constraint_domain_size
             .to_le_bytes()
@@ -135,16 +135,16 @@ impl<E: PairingEngine, MM: MarlinMode> ToMinimalBits for CircuitVerifyingKey<E, 
             .flat_map(|&byte| (0..8).map(move |i| (byte >> i) & 1u8 == 1u8))
             .collect::<Vec<bool>>();
 
-        let circuit_commitments_bits = self.circuit_commitments.to_minimal_bits()?;
+        let circuit_commitments_bits = self.circuit_commitments.to_minimal_bits();
 
-        Ok([
+        [
             constraint_domain_size_bits,
             non_zero_domain_size_a_bits,
             non_zero_domain_size_b_bits,
             non_zero_domain_size_c_bits,
             circuit_commitments_bits,
         ]
-        .concat())
+        .concat()
     }
 }
 

--- a/algorithms/src/snark/marlin/data_structures/proof.rs
+++ b/algorithms/src/snark/marlin/data_structures/proof.rs
@@ -372,6 +372,7 @@ impl<E: PairingEngine> FromBytes for Proof<E> {
 }
 
 #[cfg(test)]
+#[allow(clippy::cast_possible_truncation)]
 mod test {
     #![allow(non_camel_case_types)]
 

--- a/algorithms/src/snark/marlin/data_structures/proof.rs
+++ b/algorithms/src/snark/marlin/data_structures/proof.rs
@@ -28,7 +28,10 @@ use snarkvm_utilities::{
     ToBytes,
 };
 
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    num::{ParseIntError, TryFromIntError},
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Commitments<E: PairingEngine> {
@@ -80,14 +83,14 @@ impl<E: PairingEngine> Commitments<E> {
     }
 
     fn deserialize_with_mode<R: snarkvm_utilities::Read>(
-        batch_sizes: &[usize],
+        batch_sizes: &[u32],
         mut reader: R,
         compress: Compress,
         validate: Validate,
     ) -> Result<Self, snarkvm_utilities::SerializationError> {
-        let mut w = Vec::with_capacity(batch_sizes.iter().sum());
-        for batch_size in batch_sizes {
-            w.extend(deserialize_vec_without_len(&mut reader, compress, validate, *batch_size)?);
+        let mut w = Vec::with_capacity(batch_sizes.iter().sum::<u32>().try_into()?);
+        for &batch_size in batch_sizes {
+            w.extend(deserialize_vec_without_len(&mut reader, compress, validate, batch_size.try_into()?)?);
         }
         Ok(Commitments {
             witness_commitments: w,
@@ -155,16 +158,17 @@ impl<F: PrimeField> Evaluations<F> {
     }
 
     fn deserialize_with_mode<R: snarkvm_utilities::Read>(
-        batch_sizes: &[usize],
+        batch_sizes: &[u32],
         mut reader: R,
         compress: Compress,
         validate: Validate,
     ) -> Result<Self, snarkvm_utilities::SerializationError> {
+        let mut z_b_evals = Vec::with_capacity(batch_sizes.len());
+        for &batch_size in batch_sizes {
+            z_b_evals.push(deserialize_vec_without_len(&mut reader, compress, validate, batch_size.try_into()?)?);
+        }
         Ok(Evaluations {
-            z_b_evals: batch_sizes
-                .iter()
-                .map(|batch_size| deserialize_vec_without_len(&mut reader, compress, validate, *batch_size))
-                .collect::<Result<_, _>>()?,
+            z_b_evals,
             g_1_eval: CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?,
             g_a_evals: deserialize_vec_without_len(&mut reader, compress, validate, batch_sizes.len())?,
             g_b_evals: deserialize_vec_without_len(&mut reader, compress, validate, batch_sizes.len())?,
@@ -177,7 +181,7 @@ impl<F: PrimeField> Evaluations<F> {
     pub(crate) fn from_map(
         map: &std::collections::BTreeMap<String, F>,
         batch_sizes: BTreeMap<CircuitId, usize>,
-    ) -> Self {
+    ) -> Result<Self, TryFromIntError> {
         let mut z_b_evals_collect: BTreeMap<CircuitId, Vec<F>> = BTreeMap::new();
         let mut g_a_evals = Vec::with_capacity(batch_sizes.len());
         let mut g_b_evals = Vec::with_capacity(batch_sizes.len());
@@ -206,26 +210,26 @@ impl<F: PrimeField> Evaluations<F> {
             }
         }
         let z_b_evals = z_b_evals_collect.into_values().collect();
-        Self { z_b_evals, g_1_eval: map["g_1"], g_a_evals, g_b_evals, g_c_evals }
+        Ok(Self { z_b_evals, g_1_eval: map["g_1"], g_a_evals, g_b_evals, g_c_evals })
     }
 
-    pub(crate) fn get(&self, circuit_index: usize, label: &str) -> Option<F> {
+    pub(crate) fn get(&self, circuit_index: usize, label: &str) -> Result<Option<F>, ParseIntError> {
         if label == "g_1" {
-            return Some(self.g_1_eval);
+            return Ok(Some(self.g_1_eval));
         }
 
         if let Some(index) = label.find("z_b_") {
             let z_b_eval_circuit = &self.z_b_evals[circuit_index];
-            let instance_index = label[index + 4..].parse::<usize>().unwrap();
-            z_b_eval_circuit.get(instance_index).copied()
+            let instance_index = label[index + 4..].parse::<usize>()?;
+            Ok(z_b_eval_circuit.get(instance_index).copied())
         } else if label.contains("g_a") {
-            self.g_a_evals.get(circuit_index).copied()
+            Ok(self.g_a_evals.get(circuit_index).copied())
         } else if label.contains("g_b") {
-            self.g_b_evals.get(circuit_index).copied()
+            Ok(self.g_b_evals.get(circuit_index).copied())
         } else if label.contains("g_c") {
-            self.g_c_evals.get(circuit_index).copied()
+            Ok(self.g_c_evals.get(circuit_index).copied())
         } else {
-            None
+            Ok(None)
         }
     }
 
@@ -253,7 +257,7 @@ impl<F: PrimeField> Valid for Evaluations<F> {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Proof<E: PairingEngine> {
     /// The number of instances being proven in this proof.
-    batch_sizes: Vec<usize>,
+    batch_sizes: Vec<u32>,
 
     /// Commitments to prover polynomials.
     pub commitments: Commitments<E>,
@@ -271,16 +275,17 @@ pub struct Proof<E: PairingEngine> {
 impl<E: PairingEngine> Proof<E> {
     /// Construct a new proof.
     pub fn new(
-        batch_sizes: BTreeMap<CircuitId, usize>,
+        batch_sizes_in: BTreeMap<CircuitId, usize>,
         commitments: Commitments<E>,
         evaluations: Evaluations<E::Fr>,
         msg: ahp::prover::ThirdMessage<E::Fr>,
         pc_proof: sonic_pc::BatchLCProof<E>,
     ) -> Result<Self, SNARKError> {
         let mut total_instances = 0;
-        let batch_sizes: Vec<usize> = batch_sizes.into_values().collect();
-        for (z_b_evals, batch_size) in evaluations.z_b_evals.iter().zip(&batch_sizes) {
+        let mut batch_sizes = Vec::with_capacity(batch_sizes_in.len());
+        for (z_b_evals, batch_size) in evaluations.z_b_evals.iter().zip(batch_sizes_in.values()) {
             total_instances += batch_size;
+            batch_sizes.push(u32::try_from(*batch_size)?);
             if z_b_evals.len() != *batch_size {
                 return Err(SNARKError::BatchSizeMismatch);
             }
@@ -291,15 +296,15 @@ impl<E: PairingEngine> Proof<E> {
         Ok(Self { batch_sizes, commitments, evaluations, msg, pc_proof })
     }
 
-    pub fn batch_sizes(&self) -> Result<&[usize], SNARKError> {
+    pub fn batch_sizes(&self) -> Result<&[u32], SNARKError> {
         let mut total_instances = 0;
         for (z_b_evals_i, &batch_size) in self.evaluations.z_b_evals.iter().zip(self.batch_sizes.iter()) {
             total_instances += batch_size;
-            if z_b_evals_i.len() != batch_size {
+            if u32::try_from(z_b_evals_i.len())? != batch_size {
                 return Err(SNARKError::BatchSizeMismatch);
             }
         }
-        if self.commitments.witness_commitments.len() != total_instances {
+        if u32::try_from(self.commitments.witness_commitments.len())? != total_instances {
             return Err(SNARKError::BatchSizeMismatch);
         }
         Ok(&self.batch_sizes)
@@ -308,8 +313,7 @@ impl<E: PairingEngine> Proof<E> {
 
 impl<E: PairingEngine> CanonicalSerialize for Proof<E> {
     fn serialize_with_mode<W: Write>(&self, mut writer: W, compress: Compress) -> Result<(), SerializationError> {
-        let batch_sizes: Vec<u64> = self.batch_sizes.iter().map(|x| u64::try_from(*x)).collect::<Result<_, _>>()?;
-        CanonicalSerialize::serialize_with_mode(&batch_sizes, &mut writer, compress)?;
+        CanonicalSerialize::serialize_with_mode(&self.batch_sizes, &mut writer, compress)?;
         Commitments::serialize_with_mode(&self.commitments, &mut writer, compress)?;
         Evaluations::serialize_with_mode(&self.evaluations, &mut writer, compress)?;
         CanonicalSerialize::serialize_with_mode(&self.msg, &mut writer, compress)?;
@@ -344,8 +348,7 @@ impl<E: PairingEngine> CanonicalDeserialize for Proof<E> {
         compress: Compress,
         validate: Validate,
     ) -> Result<Self, SerializationError> {
-        let batch_sizes: Vec<u64> = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
-        let batch_sizes: Vec<usize> = batch_sizes.into_iter().map(|x| x as usize).collect();
+        let batch_sizes: Vec<u32> = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
         Ok(Proof {
             commitments: Commitments::deserialize_with_mode(&batch_sizes, &mut reader, compress, validate)?,
             evaluations: Evaluations::deserialize_with_mode(&batch_sizes, &mut reader, compress, validate)?,
@@ -446,7 +449,7 @@ mod test {
             for j in 1..11 {
                 let test_with_none = i * j % 2 == 0;
                 let commitments = rand_commitments(i, j, test_with_none);
-                let batch_sizes = vec![i; j];
+                let batch_sizes = vec![i as u32; j];
                 let combinations = modes();
                 for (compress, validate) in combinations {
                     let size = Commitments::serialized_size(&commitments, compress);
@@ -467,7 +470,7 @@ mod test {
         for i in 1..11 {
             for j in 1..11 {
                 let evaluations: Evaluations<Fr> = rand_evaluations(rng, i, j);
-                let batch_sizes = vec![i; j];
+                let batch_sizes = vec![i as u32; j];
                 let combinations = modes();
                 for (compress, validate) in combinations {
                     let size = Evaluations::serialized_size(&evaluations, compress);
@@ -488,7 +491,7 @@ mod test {
         for i in 1..11 {
             for j in 1..11 {
                 let test_with_none = i * j % 2 == 0;
-                let batch_sizes = vec![i; j];
+                let batch_sizes = vec![i as u32; j];
                 let commitments = rand_commitments(i, j, test_with_none);
                 let evaluations: Evaluations<Fr> = rand_evaluations(rng, i, j);
                 let msg = ahp::prover::ThirdMessage::<Fr> { sums: vec![rand_sums(rng); j] };

--- a/algorithms/src/snark/marlin/marlin.rs
+++ b/algorithms/src/snark/marlin/marlin.rs
@@ -102,10 +102,11 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, MM: MarlinMode> MarlinSNAR
             let indexed_circuit = AHPForR1CS::<_, MM>::index(*circuit)?;
             // TODO: Add check that c is in the correct mode.
             // Increase the universal SRS size to support the circuit size.
-            if universal_srs.max_degree() < indexed_circuit.max_degree() {
-                universal_srs.download_powers_for(0..indexed_circuit.max_degree()).map_err(|_| {
-                    MarlinError::IndexTooLarge(universal_srs.max_degree(), indexed_circuit.max_degree())
-                })?;
+            let max_degree = usize::try_from(indexed_circuit.max_degree())?;
+            if universal_srs.max_degree() < max_degree {
+                universal_srs
+                    .download_powers_for(0..max_degree)
+                    .map_err(|_| MarlinError::IndexTooLarge(universal_srs.max_degree(), max_degree))?;
             }
             let coefficient_support = AHPForR1CS::<_, MM>::get_degree_bounds(&indexed_circuit.index_info);
 
@@ -113,7 +114,7 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, MM: MarlinMode> MarlinSNAR
             let supported_hiding_bound = 1;
             let (committer_key, verifier_key) = SonicKZG10::<E, FS>::trim(
                 universal_srs,
-                indexed_circuit.max_degree(),
+                max_degree,
                 [indexed_circuit.constraint_domain_size()],
                 supported_hiding_bound,
                 Some(coefficient_support.as_slice()),
@@ -166,7 +167,7 @@ impl<E: PairingEngine, FS: AlgebraicSponge<E::Fq, 2>, MM: MarlinMode> MarlinSNAR
 
     fn init_sponge<'a>(
         fs_parameters: &FS::Parameters,
-        inputs_and_batch_sizes: &BTreeMap<CircuitId, (usize, &[Vec<E::Fr>])>,
+        inputs_and_batch_sizes: &BTreeMap<CircuitId, (u32, &[Vec<E::Fr>])>,
         circuit_commitments: impl Iterator<Item = &'a [crate::polycommit::sonic_pc::Commitment<E>]>,
     ) -> FS {
         let mut sponge = FS::new_with_parameters(fs_parameters);
@@ -237,7 +238,7 @@ where
     type Proof = Proof<E>;
     type ProvingKey = CircuitProvingKey<E, MM>;
     type ScalarField = E::Fr;
-    type UniversalSetupConfig = usize;
+    type UniversalSetupConfig = u32;
     type UniversalSetupParameters = UniversalSRS<E>;
     type VerifierInput = [E::Fr];
     type VerifyingKey = CircuitVerifyingKey<E, MM>;
@@ -245,7 +246,7 @@ where
     fn universal_setup(max_degree: &Self::UniversalSetupConfig) -> Result<Self::UniversalSetupParameters, SNARKError> {
         let setup_time = start_timer!(|| { format!("Marlin::UniversalSetup with max_degree {max_degree}",) });
 
-        let srs = SonicKZG10::<E, FS>::load_srs(*max_degree).map_err(Into::into);
+        let srs = SonicKZG10::<E, FS>::load_srs((*max_degree).try_into()?).map_err(Into::into);
         end_timer!(setup_time);
         srs
     }
@@ -397,12 +398,14 @@ where
             let padded_public_input =
                 prover_state.padded_public_inputs(&pk.circuit).ok_or(SNARKError::CircuitNotFound)?;
             let circuit_id = pk.circuit.id;
-            batch_sizes.insert(circuit_id, batch_size);
+            circuit_ids.push(circuit_id);
             circuit_infos.insert(circuit_id, &pk.circuit_verifying_key.circuit_info);
             inputs_and_batch_sizes.insert(circuit_id, (batch_size, padded_public_input));
-            total_instances += batch_size;
             public_inputs.insert(circuit_id, public_input);
-            circuit_ids.push(circuit_id);
+            total_instances += batch_size;
+
+            let batch_size = usize::try_from(batch_size)?;
+            batch_sizes.insert(circuit_id, batch_size);
         }
         assert_eq!(prover_state.total_instances, total_instances);
 
@@ -417,7 +420,7 @@ where
         // First round
 
         Self::terminate(terminator)?;
-        let mut prover_state = AHPForR1CS::<_, MM>::prover_first_round(prover_state, zk_rng)?;
+        let mut prover_state = AHPForR1CS::<_, MM>::prover_first_round(prover_state, batch_sizes.iter(), zk_rng)?;
         Self::terminate(terminator)?;
 
         let first_round_comm_time = start_timer!(|| "Committing to first round polys");
@@ -524,7 +527,7 @@ where
         assert!(
             polynomials.len()
                 == keys_to_constraints.len() * 12 + // polys for row, col, rowcol, val
-            AHPForR1CS::<E::Fr, MM>::num_first_round_oracles(total_instances) +
+            AHPForR1CS::<E::Fr, MM>::num_first_round_oracles(total_instances.try_into()?) +
             AHPForR1CS::<E::Fr, MM>::num_second_round_oracles() +
             AHPForR1CS::<E::Fr, MM>::num_third_round_oracles(keys_to_constraints.len()) +
             AHPForR1CS::<E::Fr, MM>::num_fourth_round_oracles()
@@ -586,7 +589,7 @@ where
         }
 
         // Compute the AHP verifier's query set.
-        let (query_set, verifier_state) = AHPForR1CS::<_, MM>::verifier_query_set(verifier_state);
+        let (query_set, verifier_state) = AHPForR1CS::<_, MM>::verifier_query_set(verifier_state)?;
         let lc_s = AHPForR1CS::<_, MM>::construct_linear_combinations(
             &public_inputs,
             &polynomials,
@@ -606,7 +609,7 @@ where
             }
         }
 
-        let evaluations = proof::Evaluations::from_map(&evaluations, batch_sizes.clone());
+        let evaluations = proof::Evaluations::from_map(&evaluations, batch_sizes.clone())?;
         end_timer!(eval_time);
 
         Self::terminate(terminator)?;
@@ -658,13 +661,13 @@ where
         let batch_sizes_vec = proof.batch_sizes()?;
         let mut batch_sizes = BTreeMap::new();
         for (i, (vk, public_inputs_i)) in keys_to_inputs.iter().enumerate() {
-            batch_sizes.insert(vk.orig_vk.id, batch_sizes_vec[i]);
+            batch_sizes.insert(vk.orig_vk.id, batch_sizes_vec[i].try_into()?);
 
             if public_inputs_i.is_empty() {
                 return Err(SNARKError::EmptyBatch);
             }
 
-            if public_inputs_i.len() != batch_sizes_vec[i] {
+            if u32::try_from(public_inputs_i.len())? != batch_sizes_vec[i] {
                 return Err(SNARKError::BatchSizeMismatch);
             }
         }
@@ -714,7 +717,7 @@ where
             circuit_infos.insert(circuit_id, &vk.orig_vk.circuit_info);
             circuit_ids.push(circuit_id);
         }
-        for (i, (vk, &batch_size)) in keys_to_inputs.keys().zip(batch_sizes.values()).enumerate() {
+        for (i, (vk, &batch_size)) in keys_to_inputs.keys().zip(batch_sizes_vec).enumerate() {
             inputs_and_batch_sizes.insert(vk.orig_vk.id, (batch_size, padded_public_vec[i].as_slice()));
         }
 
@@ -860,7 +863,7 @@ where
             .collect();
 
         let query_set_time = start_timer!(|| "Constructing query set");
-        let (query_set, verifier_state) = AHPForR1CS::<_, MM>::verifier_query_set(verifier_state);
+        let (query_set, verifier_state) = AHPForR1CS::<_, MM>::verifier_query_set(verifier_state)?;
         end_timer!(query_set_time);
 
         sponge.absorb_nonnative_field_elements(proof.evaluations.to_field_elements());
@@ -882,7 +885,7 @@ where
                 }
                 let eval = proof
                     .evaluations
-                    .get(circuit_index as usize, &label)
+                    .get(circuit_index as usize, &label)?
                     .ok_or_else(|| AHPError::MissingEval(label.clone()))?;
                 evaluations.insert((label, q), eval);
             }

--- a/algorithms/src/snark/marlin/marlin.rs
+++ b/algorithms/src/snark/marlin/marlin.rs
@@ -885,7 +885,7 @@ where
                 }
                 let eval = proof
                     .evaluations
-                    .get(circuit_index as usize, &label)?
+                    .get(usize::try_from(circuit_index)?, &label)?
                     .ok_or_else(|| AHPError::MissingEval(label.clone()))?;
                 evaluations.insert((label, q), eval);
             }

--- a/algorithms/src/traits/algebraic_sponge.rs
+++ b/algorithms/src/traits/algebraic_sponge.rs
@@ -66,7 +66,7 @@ pub trait AlgebraicSponge<F: PrimeField, const RATE: usize>: Clone + Debug {
         self.absorb_native_field_elements(&elements);
     }
 
-    /// Takes in field elements.
+    /// Takes out field elements.
     fn squeeze_native_field_elements(&mut self, num: usize) -> SmallVec<[F; 10]>;
 
     /// Takes out field elements.

--- a/algorithms/src/traits/algebraic_sponge.rs
+++ b/algorithms/src/traits/algebraic_sponge.rs
@@ -128,17 +128,17 @@ pub(crate) mod nonnative_params {
     #[derive(Clone, Debug)]
     pub struct NonNativeFieldParams {
         /// The number of limbs (`BaseField` elements) used to represent a `TargetField` element. Highest limb first.
-        pub num_limbs: usize,
+        pub num_limbs: u32,
 
         /// The number of bits of the limb
-        pub bits_per_limb: usize,
+        pub bits_per_limb: u32,
     }
 
     /// Obtain the parameters from a `ConstraintSystem`'s cache or generate a new one
     #[must_use]
     pub const fn get_params(
-        target_field_size: usize,
-        base_field_size: usize,
+        target_field_size: u32,
+        base_field_size: u32,
         optimization_type: OptimizationType,
     ) -> NonNativeFieldParams {
         let (num_of_limbs, limb_size) = find_parameters(base_field_size, target_field_size, optimization_type);
@@ -156,21 +156,21 @@ pub(crate) mod nonnative_params {
 
     /// A function to search for parameters for nonnative field gadgets
     pub const fn find_parameters(
-        base_field_prime_length: usize,
-        target_field_prime_bit_length: usize,
+        base_field_prime_length: u32,
+        target_field_prime_bit_length: u32,
         optimization_type: OptimizationType,
-    ) -> (usize, usize) {
+    ) -> (u32, u32) {
         let mut found = false;
-        let mut min_cost = 0usize;
-        let mut min_cost_limb_size = 0usize;
-        let mut min_cost_num_of_limbs = 0usize;
+        let mut min_cost = 0u32;
+        let mut min_cost_limb_size = 0u32;
+        let mut min_cost_num_of_limbs = 0u32;
 
         let surfeit = 10;
         let mut max_limb_size = (base_field_prime_length - 1 - surfeit - 1) / 2 - 1;
         if max_limb_size > target_field_prime_bit_length {
             max_limb_size = target_field_prime_bit_length;
         }
-        let mut limb_size = 1;
+        let mut limb_size = 1u32;
 
         while limb_size <= max_limb_size {
             let num_of_limbs = (target_field_prime_bit_length + limb_size - 1) / limb_size;

--- a/curves/src/templates/short_weierstrass_jacobian/affine.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/affine.rs
@@ -263,11 +263,11 @@ impl<P: Parameters> AffineCurve for Affine<P> {
 }
 
 impl<P: Parameters> ToMinimalBits for Affine<P> {
-    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
+    fn to_minimal_bits(&self) -> Vec<bool> {
         let mut res_bits = self.x.to_bits_le();
         res_bits.push(*self.y.to_bits_le().first().unwrap());
         res_bits.push(self.infinity);
-        Ok(res_bits)
+        res_bits
     }
 }
 

--- a/curves/src/templates/short_weierstrass_jacobian/affine.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/affine.rs
@@ -263,11 +263,11 @@ impl<P: Parameters> AffineCurve for Affine<P> {
 }
 
 impl<P: Parameters> ToMinimalBits for Affine<P> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
         let mut res_bits = self.x.to_bits_le();
         res_bits.push(*self.y.to_bits_le().first().unwrap());
         res_bits.push(self.infinity);
-        res_bits
+        Ok(res_bits)
     }
 }
 

--- a/curves/src/templates/twisted_edwards_extended/affine.rs
+++ b/curves/src/templates/twisted_edwards_extended/affine.rs
@@ -256,8 +256,8 @@ impl<P: Parameters> AffineCurve for Affine<P> {
 }
 
 impl<P: Parameters> ToMinimalBits for Affine<P> {
-    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
-        Ok(self.x.to_bits_le())
+    fn to_minimal_bits(&self) -> Vec<bool> {
+        self.x.to_bits_le()
     }
 }
 

--- a/curves/src/templates/twisted_edwards_extended/affine.rs
+++ b/curves/src/templates/twisted_edwards_extended/affine.rs
@@ -256,8 +256,8 @@ impl<P: Parameters> AffineCurve for Affine<P> {
 }
 
 impl<P: Parameters> ToMinimalBits for Affine<P> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
-        self.x.to_bits_le()
+    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
+        Ok(self.x.to_bits_le())
     }
 }
 

--- a/fields/src/traits/prime_field.rs
+++ b/fields/src/traits/prime_field.rs
@@ -49,6 +49,11 @@ pub trait PrimeField:
         Self::Parameters::MODULUS_BITS as usize
     }
 
+    /// Returns the field size in bits as u32
+    fn size_in_bits_u32() -> u32 {
+        Self::Parameters::MODULUS_BITS
+    }
+
     /// Returns the capacity size for data bits.
     fn size_in_data_bits() -> usize {
         Self::Parameters::CAPACITY as usize

--- a/r1cs/src/errors.rs
+++ b/r1cs/src/errors.rs
@@ -29,24 +29,27 @@ pub enum SynthesisError {
     /// During synthesis, we divided by zero.
     #[error("Division by zero during synthesis")]
     DivisionByZero,
-    /// During synthesis, we constructed an unsatisfiable constraint system.
-    #[error("Unsatisfiable constraint system")]
-    Unsatisfiable,
-    /// During synthesis, our polynomials ended up being too high of degree
-    #[error("Polynomial degree is too large")]
-    PolynomialDegreeTooLarge,
-    /// During proof generation, we encountered an identity in the CRS
-    #[error("Encountered an identity element in the CRS")]
-    UnexpectedIdentity,
+    /// During synthesis, we could not recover our desired int.
+    #[error(transparent)]
+    IntError(#[from] std::num::TryFromIntError),
     /// During proof generation, we encountered an I/O error with the CRS
     #[error("Encountered an I/O error")]
     IoError(std::io::Error),
     /// During verification, our verifying key was malformed.
     #[error("Malformed verifying key, public input count was {} but expected {}", _0, _1)]
     MalformedVerifyingKey(usize, usize),
+    /// During synthesis, our polynomials ended up being too high of degree
+    #[error("Polynomial degree is too large")]
+    PolynomialDegreeTooLarge,
     /// During CRS generation, we observed an unconstrained auxiliary variable
     #[error("Auxiliary variable was unconstrained")]
     UnconstrainedVariable,
+    /// During proof generation, we encountered an identity in the CRS
+    #[error("Encountered an identity element in the CRS")]
+    UnexpectedIdentity,
+    /// During synthesis, we constructed an unsatisfiable constraint system.
+    #[error("Unsatisfiable constraint system")]
+    Unsatisfiable,
 }
 
 impl From<std::io::Error> for SynthesisError {

--- a/synthesizer/coinbase/src/helpers/coinbase_solution/bytes.rs
+++ b/synthesizer/coinbase/src/helpers/coinbase_solution/bytes.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::*;
+use snarkvm_utilities::try_write_as;
 
 impl<N: Network> FromBytes for CoinbaseSolution<N> {
     /// Reads the coinbase solution from the buffer.
@@ -34,7 +35,7 @@ impl<N: Network> FromBytes for CoinbaseSolution<N> {
 impl<N: Network> ToBytes for CoinbaseSolution<N> {
     /// Writes the coinbase solution to the buffer.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
-        (u32::try_from(self.partial_solutions.len()).map_err(|e| error(e.to_string()))?).write_le(&mut writer)?;
+        try_write_as::<u32, W>(self.partial_solutions.len(), &mut writer)?;
 
         for individual_puzzle_solution in &self.partial_solutions {
             individual_puzzle_solution.write_le(&mut writer)?;

--- a/synthesizer/coinbase/src/lib.rs
+++ b/synthesizer/coinbase/src/lib.rs
@@ -335,7 +335,7 @@ impl<N: Network> CoinbasePuzzle<N> {
             cfg_iter!(coinbase_solution.partial_solutions()).map(|solution| solution.commitment().0).collect();
         let fs_challenges = challenge_points.into_iter().map(|f| f.to_bigint()).collect::<Vec<_>>();
         let accumulator_commitment =
-            KZGCommitment::<N::PairingCurve>(VariableBase::msm(&commitments, &fs_challenges).into());
+            KZGCommitment::<N::PairingCurve>(VariableBase::msm(&commitments, &fs_challenges)?.into());
 
         // Retrieve the coinbase verifying key.
         let coinbase_verifying_key = match self {

--- a/synthesizer/src/block/transaction/deployment/bytes.rs
+++ b/synthesizer/src/block/transaction/deployment/bytes.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::*;
+use snarkvm_utilities::try_write_as;
 
 impl<N: Network> FromBytes for Deployment<N> {
     /// Reads the deployment from a buffer.
@@ -59,7 +60,7 @@ impl<N: Network> ToBytes for Deployment<N> {
         // Write the program.
         self.program.write_le(&mut writer)?;
         // Write the number of entries in the bundle.
-        (u16::try_from(self.verifying_keys.len()).map_err(|e| error(e.to_string()))?).write_le(&mut writer)?;
+        try_write_as::<u16, W>(self.verifying_keys.len(), &mut writer)?;
         // Write each entry.
         for (function_name, (verifying_key, certificate)) in &self.verifying_keys {
             // Write the function name.

--- a/synthesizer/src/block/transaction/execution/bytes.rs
+++ b/synthesizer/src/block/transaction/execution/bytes.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use snarkvm_utilities::try_write_as;
+
 use super::*;
 
 impl<N: Network> FromBytes for Execution<N> {
@@ -54,7 +56,7 @@ impl<N: Network> ToBytes for Execution<N> {
         // Write the version.
         0u8.write_le(&mut writer)?;
         // Write the number of transitions.
-        (u8::try_from(self.transitions.len()).map_err(|e| error(e.to_string()))?).write_le(&mut writer)?;
+        try_write_as::<u8, W>(self.transitions.len(), &mut writer)?;
         // Write the transitions.
         for transition in self.transitions.values() {
             transition.write_le(&mut writer)?;

--- a/synthesizer/src/block/transactions/confirmed/bytes.rs
+++ b/synthesizer/src/block/transactions/confirmed/bytes.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::*;
+use snarkvm_utilities::try_write_as;
 
 impl<N: Network> FromBytes for ConfirmedTransaction<N> {
     /// Reads the confirmed transaction from a buffer.
@@ -82,7 +83,7 @@ impl<N: Network> ToBytes for ConfirmedTransaction<N> {
                 // Write the transaction.
                 transaction.write_le(&mut writer)?;
                 // Write the number of finalize operations.
-                NumFinalizeSize::try_from(finalize.len()).map_err(|e| error(e.to_string()))?.write_le(&mut writer)?;
+                try_write_as::<NumFinalizeSize, W>(finalize.len(), &mut writer)?;
                 // Write the finalize operations.
                 finalize.iter().try_for_each(|finalize| finalize.write_le(&mut writer))
             }
@@ -94,7 +95,7 @@ impl<N: Network> ToBytes for ConfirmedTransaction<N> {
                 // Write the transaction.
                 transaction.write_le(&mut writer)?;
                 // Write the number of finalize operations.
-                NumFinalizeSize::try_from(finalize.len()).map_err(|e| error(e.to_string()))?.write_le(&mut writer)?;
+                try_write_as::<NumFinalizeSize, W>(finalize.len(), &mut writer)?;
                 // Write the finalize operations.
                 finalize.iter().try_for_each(|finalize| finalize.write_le(&mut writer))
             }

--- a/synthesizer/src/block/transition/bytes.rs
+++ b/synthesizer/src/block/transition/bytes.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use snarkvm_utilities::try_write_as;
+
 use super::*;
 
 impl<N: Network> FromBytes for Transition<N> {
@@ -98,12 +100,12 @@ impl<N: Network> ToBytes for Transition<N> {
         self.function_name.write_le(&mut writer)?;
 
         // Write the number of inputs.
-        (u8::try_from(self.inputs.len()).map_err(|e| error(e.to_string()))?).write_le(&mut writer)?;
+        try_write_as::<u8, W>(self.inputs.len(), &mut writer)?;
         // Write the inputs.
         self.inputs.write_le(&mut writer)?;
 
         // Write the number of outputs.
-        (u8::try_from(self.outputs.len()).map_err(|e| error(e.to_string()))?).write_le(&mut writer)?;
+        try_write_as::<u8, W>(self.outputs.len(), &mut writer)?;
         // Write the outputs.
         self.outputs.write_le(&mut writer)?;
 
@@ -117,7 +119,7 @@ impl<N: Network> ToBytes for Transition<N> {
                 // Write the finalize variant.
                 1u8.write_le(&mut writer)?;
                 // Write the number of inputs to finalize.
-                (u8::try_from(finalize.len()).map_err(|e| error(e.to_string()))?).write_le(&mut writer)?;
+                try_write_as::<u8, W>(finalize.len(), &mut writer)?;
                 // Write the inputs to finalize.
                 finalize.write_le(&mut writer)?;
             }

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -185,13 +185,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(1387, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(1385, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(1352, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(1350, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -185,13 +185,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(1385, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(1383, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(1350, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(1348, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -224,13 +224,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(2222, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(2214, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(2187, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(2179, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 
@@ -258,13 +258,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(2099, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(2091, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(2064, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(2056, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 
@@ -291,13 +291,13 @@ mod tests {
 
         // Assert the size of the transaction.
         let transaction_size_in_bytes = transaction.to_bytes_le().unwrap().len();
-        assert_eq!(2111, transaction_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(2103, transaction_size_in_bytes, "Update me if serialization has changed");
 
         // Assert the size of the execution.
         assert!(matches!(transaction, Transaction::Execute(_, _, _)));
         if let Transaction::Execute(_, execution, _) = &transaction {
             let execution_size_in_bytes = execution.to_bytes_le().unwrap().len();
-            assert_eq!(2076, execution_size_in_bytes, "Update me if serialization has changed");
+            assert_eq!(2068, execution_size_in_bytes, "Update me if serialization has changed");
         }
     }
 }

--- a/synthesizer/src/vm/execute_fee.rs
+++ b/synthesizer/src/vm/execute_fee.rs
@@ -130,6 +130,6 @@ mod tests {
         };
         // Assert the size of the transition.
         let fee_size_in_bytes = fee.to_bytes_le().unwrap().len();
-        assert_eq!(1935, fee_size_in_bytes, "Update me if serialization has changed");
+        assert_eq!(1927, fee_size_in_bytes, "Update me if serialization has changed");
     }
 }

--- a/utilities/src/bits.rs
+++ b/utilities/src/bits.rs
@@ -34,16 +34,16 @@ pub trait FromBits: Sized {
 
 pub trait ToMinimalBits: Sized {
     /// Returns `self` as a minimal boolean array.
-    fn to_minimal_bits(&self) -> Vec<bool>;
+    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError>;
 }
 
 impl<T: ToMinimalBits> ToMinimalBits for Vec<T> {
-    fn to_minimal_bits(&self) -> Vec<bool> {
+    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
         let mut res_bits = vec![];
         for elem in self.iter() {
-            res_bits.extend(elem.to_minimal_bits());
+            res_bits.extend(elem.to_minimal_bits()?);
         }
-        res_bits
+        Ok(res_bits)
     }
 }
 

--- a/utilities/src/bits.rs
+++ b/utilities/src/bits.rs
@@ -34,16 +34,16 @@ pub trait FromBits: Sized {
 
 pub trait ToMinimalBits: Sized {
     /// Returns `self` as a minimal boolean array.
-    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError>;
+    fn to_minimal_bits(&self) -> Vec<bool>;
 }
 
 impl<T: ToMinimalBits> ToMinimalBits for Vec<T> {
-    fn to_minimal_bits(&self) -> Result<Vec<bool>, std::num::TryFromIntError> {
+    fn to_minimal_bits(&self) -> Vec<bool> {
         let mut res_bits = vec![];
         for elem in self.iter() {
-            res_bits.extend(elem.to_minimal_bits()?);
+            res_bits.extend(elem.to_minimal_bits());
         }
-        Ok(res_bits)
+        res_bits
     }
 }
 


### PR DESCRIPTION
## Motivation

See for a motivation [this comment](https://github.com/AleoHQ/snarkVM/pull/1382/files#r1181041614).

However, my initial intuition was wrong, we can't reduce developer confusion with a "use `usize` as little as possible" because Rust's library uses `usize` all over the place. We instead increase clarity and safety by being more rigorous about our usage of usize. See the CONTRIBUTING doc for more details.

## Test Plan

Given that the main concern for this is consensus issues, I suggest to take extra care to stress test snark{VM,OS} on both 32-bit and 64-bit machines, generating test input from the different machine or constructing it manually. Let me know if you want me to help setting that up already, otherwise I'll make a TODO for once we start testing AleoBFT more extensively.