### PR TITLE
Increase max number of mainnet validators to 15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
   snarkvm:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - checkout
       - run:
@@ -147,7 +147,7 @@ jobs:
   algorithms:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: algorithms
@@ -156,7 +156,7 @@ jobs:
   algorithms-profiler:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial: # This runs a single test with profiler enabled
           workspace_member: algorithms
@@ -166,7 +166,7 @@ jobs:
   circuit:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit
@@ -175,7 +175,7 @@ jobs:
   circuit-account:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/account
@@ -185,7 +185,7 @@ jobs:
   circuit-account-noconsole:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/account
@@ -195,7 +195,7 @@ jobs:
   circuit-algorithms:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/algorithms
@@ -204,7 +204,7 @@ jobs:
   circuit-collections:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/collections
@@ -214,7 +214,7 @@ jobs:
   circuit-collections-noconsole:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/collections
@@ -224,7 +224,7 @@ jobs:
   circuit-environment:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/environment
@@ -233,7 +233,7 @@ jobs:
   circuit-network:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/network
@@ -242,7 +242,7 @@ jobs:
   circuit-program:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/program
@@ -251,7 +251,7 @@ jobs:
   circuit-types:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/types
@@ -260,7 +260,7 @@ jobs:
   circuit-types-address:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/types/address
@@ -269,7 +269,7 @@ jobs:
   circuit-types-boolean:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/types/boolean
@@ -278,7 +278,7 @@ jobs:
   circuit-types-field:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/types/field
@@ -287,7 +287,7 @@ jobs:
   circuit-types-group:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/types/group
@@ -296,7 +296,7 @@ jobs:
   circuit-types-integers:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: circuit/types/integers
@@ -306,7 +306,7 @@ jobs:
   circuit-types-scalar:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/types/scalar
@@ -315,7 +315,7 @@ jobs:
   circuit-types-string:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: circuit/types/string
@@ -323,7 +323,7 @@ jobs:
   console:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console
@@ -332,7 +332,7 @@ jobs:
   console-account:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/account
@@ -341,7 +341,7 @@ jobs:
   console-algorithms:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/algorithms
@@ -350,7 +350,7 @@ jobs:
   console-collections:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/collections
@@ -359,7 +359,7 @@ jobs:
   console-network:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/network
@@ -368,7 +368,7 @@ jobs:
   console-network-environment:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/network/environment
@@ -377,7 +377,7 @@ jobs:
   console-program:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/program
@@ -386,7 +386,7 @@ jobs:
   console-types:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/types
@@ -395,7 +395,7 @@ jobs:
   console-types-address:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/types/address
@@ -404,7 +404,7 @@ jobs:
   console-types-boolean:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/types/boolean
@@ -413,7 +413,7 @@ jobs:
   console-types-field:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/types/field
@@ -422,7 +422,7 @@ jobs:
   console-types-group:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/types/group
@@ -431,7 +431,7 @@ jobs:
   console-types-integers:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/types/integers
@@ -440,7 +440,7 @@ jobs:
   console-types-scalar:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/types/scalar
@@ -449,7 +449,7 @@ jobs:
   console-types-string:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: console/types/string
@@ -458,7 +458,7 @@ jobs:
   curves:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: curves
@@ -467,7 +467,7 @@ jobs:
   fields:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: fields
@@ -476,7 +476,7 @@ jobs:
   ledger:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger
@@ -485,7 +485,7 @@ jobs:
   ledger-with-rocksdb:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           flags: --features=rocks
@@ -495,7 +495,7 @@ jobs:
   ledger-with-valid-solutions:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           flags: valid_solutions --features=test
@@ -505,7 +505,7 @@ jobs:
   ledger-authority:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/authority
@@ -514,7 +514,7 @@ jobs:
   ledger-block:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/block
@@ -523,7 +523,7 @@ jobs:
   ledger-committee:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: ledger/committee
@@ -532,7 +532,7 @@ jobs:
   ledger-narwhal:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/narwhal
@@ -541,7 +541,7 @@ jobs:
   ledger-narwhal-batch-certificate:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/batch-certificate
@@ -550,7 +550,7 @@ jobs:
   ledger-narwhal-batch-header:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/batch-header
@@ -559,7 +559,7 @@ jobs:
   ledger-narwhal-data:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/data
@@ -568,7 +568,7 @@ jobs:
   ledger-narwhal-subdag:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/subdag
@@ -577,7 +577,7 @@ jobs:
   ledger-narwhal-transmission:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/transmission
@@ -586,7 +586,7 @@ jobs:
   ledger-narwhal-transmission-id:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/narwhal/transmission-id
@@ -595,7 +595,7 @@ jobs:
   ledger-puzzle:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/puzzle
@@ -604,7 +604,7 @@ jobs:
   ledger-puzzle-epoch:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/puzzle/epoch
@@ -613,7 +613,7 @@ jobs:
   ledger-query:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/query
@@ -622,7 +622,7 @@ jobs:
   ledger-store:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           flags: --features=rocks
@@ -632,7 +632,7 @@ jobs:
   ledger-test-helpers:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: ledger/test-helpers
@@ -641,7 +641,7 @@ jobs:
   parameters:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: parameters
@@ -650,7 +650,7 @@ jobs:
   synthesizer:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           flags: --lib --bins
@@ -660,7 +660,7 @@ jobs:
   synthesizer-integration:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           flags: --test '*'
@@ -670,7 +670,7 @@ jobs:
   synthesizer-process:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: synthesizer/process
@@ -679,7 +679,7 @@ jobs:
   synthesizer-process-with-rocksdb:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           flags: --features=rocks
@@ -689,7 +689,7 @@ jobs:
   synthesizer-program:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           flags: --lib --bins
@@ -699,7 +699,7 @@ jobs:
   synthesizer-program-integration:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           flags: --test '*' -- --skip keccak --skip psd --skip sha
@@ -709,7 +709,7 @@ jobs:
   synthesizer-program-integration-keccak:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           flags: keccak --test '*'
@@ -719,7 +719,7 @@ jobs:
   synthesizer-program-integration-psd:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           flags: psd --test '*'
@@ -729,7 +729,7 @@ jobs:
   synthesizer-program-integration-sha:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           flags: sha --test '*'
@@ -739,7 +739,7 @@ jobs:
   synthesizer-snark:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - run_serial:
           workspace_member: synthesizer/snark
@@ -748,7 +748,7 @@ jobs:
   utilities:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: utilities
@@ -757,7 +757,7 @@ jobs:
   utilities-derives:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - run_serial:
           workspace_member: utilities/derives
@@ -766,7 +766,7 @@ jobs:
   wasm:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - checkout
       - setup_environment:
@@ -784,7 +784,7 @@ jobs:
   check-fmt:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - checkout
       - install_rust_nightly
@@ -800,7 +800,7 @@ jobs:
   check-clippy:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/2xlarge
+    resource_class: 2xlarge
     steps:
       - checkout
       - setup_environment:
@@ -817,7 +817,7 @@ jobs:
   check-all-targets:
     docker:
       - image: cimg/rust:1.76.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
-    resource_class: anf/xlarge
+    resource_class: xlarge
     steps:
       - checkout
       - setup_environment:

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -140,7 +140,7 @@ impl Network for MainnetV0 {
     /// The function name for the inclusion circuit.
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// The maximum number of certificates in a batch.
-    const MAX_CERTIFICATES: u16 = 10;
+    const MAX_CERTIFICATES: u16 = 15;
     /// The network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";
 


### PR DESCRIPTION
## Motivation

Increases the maximum number of mainnet validators to 15.

## Test Plan

In order to really test this, we'll actually have to go through the elaborate effort of generating a temporary mainnet genesis block and bonding in new validators. However, assuming equal behaviour across network traits, this should be a sufficient change.

