### PR TITLE
Downgrade a write guard on Process to read

### DIFF
--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -262,10 +262,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
             /* Perform the atomic finalize over the transactions. */
 
-            // Acquire the write lock on the process.
+            // Acquire the read lock on the process.
             // Note: Due to the highly-sensitive nature of processing all `finalize` calls,
-            // we choose to acquire the write lock for the entire duration of this atomic batch.
-            let process = self.process.write();
+            // we choose to acquire the read lock for the entire duration of this atomic batch.
+            let process = self.process.read();
 
             // Initialize a list of the confirmed transactions.
             let mut confirmed = Vec::with_capacity(num_transactions);


### PR DESCRIPTION
The `Process` is a resource with many potential readers; we currently create write guards for it in 2 locations, and one of them could just be a read guard, which would significantly reduce contention on that lock. This has no impact on atomic speculation, other than allowing other callers to read the `Process` while it's running.

Cc https://github.com/AleoNet/snarkOS/issues/3063