### PR TITLE
[Perf] Reduce allocs when parsing Program

### DIFF
--- a/console/network/environment/src/lib.rs
+++ b/console/network/environment/src/lib.rs
@@ -126,8 +126,10 @@ pub mod prelude {
         bytes::{complete::tag, streaming::take},
         character::complete::{alpha1, alphanumeric1, char, one_of},
         combinator::{complete, fail, map, map_res, opt, recognize},
+        error::{make_error, ErrorKind},
         multi::{count, many0, many0_count, many1, separated_list0, separated_list1},
         sequence::{pair, terminated},
+        Err,
     };
     pub use num_traits::{AsPrimitive, One, Pow, Zero};
     pub use rand::{

--- a/console/program/src/data_types/record_type/parse.rs
+++ b/console/program/src/data_types/record_type/parse.rs
@@ -45,8 +45,6 @@ impl<N: Network> Parser for RecordType<N> {
             Ok((string, (identifier, value_type)))
         }
 
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the type name from the string.
         let (string, _) = tag(Self::type_name())(string)?;
         // Parse the whitespace from the string.

--- a/console/program/src/data_types/struct_type/parse.rs
+++ b/console/program/src/data_types/struct_type/parse.rs
@@ -45,8 +45,6 @@ impl<N: Network> Parser for StructType<N> {
             Ok((string, (identifier, plaintext_type)))
         }
 
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the type name from the string.
         let (string, _) = tag(Self::type_name())(string)?;
         // Parse the whitespace from the string.

--- a/synthesizer/program/src/closure/parse.rs
+++ b/synthesizer/program/src/closure/parse.rs
@@ -18,8 +18,6 @@ impl<N: Network, Instruction: InstructionTrait<N>> Parser for ClosureCore<N, Ins
     /// Parses a string into a closure.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the 'closure' keyword from the string.
         let (string, _) = tag(Self::type_name())(string)?;
         // Parse the whitespace from the string.

--- a/synthesizer/program/src/function/parse.rs
+++ b/synthesizer/program/src/function/parse.rs
@@ -20,8 +20,6 @@ impl<N: Network, Instruction: InstructionTrait<N>, Command: CommandTrait<N>> Par
     /// Parses a string into a function.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the 'function' keyword from the string.
         let (string, _) = tag(Self::type_name())(string)?;
         // Parse the whitespace from the string.

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -48,13 +48,13 @@ mod serialize;
 
 use console::{
     network::prelude::{
-        alt,
         anyhow,
         bail,
         de,
         ensure,
         error,
         fmt,
+        make_error,
         many0,
         many1,
         map,
@@ -65,7 +65,9 @@ use console::{
         Deserialize,
         Deserializer,
         Display,
+        Err,
         Error,
+        ErrorKind,
         Formatter,
         FromBytes,
         FromBytesDeserializer,

--- a/synthesizer/program/src/mapping/parse.rs
+++ b/synthesizer/program/src/mapping/parse.rs
@@ -18,8 +18,6 @@ impl<N: Network> Parser for Mapping<N> {
     /// Parses a string into a mapping.
     #[inline]
     fn parse(string: &str) -> ParserResult<Self> {
-        // Parse the whitespace and comments from the string.
-        let (string, _) = Sanitizer::parse(string)?;
         // Parse the 'mapping' keyword from the string.
         let (string, _) = tag(Self::type_name())(string)?;
         // Parse the whitespace from the string.


### PR DESCRIPTION
(transferred from https://github.com/ProvableHQ/snarkVM/pull/5, and asking @d0cd for a review as suggested there)

`Program` parsing is something that has always been prominent in node heap profiles, and this PR targets its highest-level bits.

While parsing its components, we currently use a combination of the functions `many1` and `alt`, which cause us to clone the parsed input at least once (more if it's not the expected component) for every component; this can be avoided by removing the use of `alt` in favor of a new intermediate function which is able to determine the type of the parsed component in advance and select the right parsing function without "making guesses". This is what the 1st commit does.

The 2nd commit avoids all the clones of program components that we currently perform presumably as a workaround introduced in order to be able to manage the notoriously tricky `nom` errors. With some refactoring (i.e. applying `map_res` only to potential errors), we are able to remove many allocations.

These changes reduce the number of allocations caused by the parsing of a `Program` in a 15-minute run of a `--dev` node by ~**8%** (an absolute decrease of over 54k allocs), making the process faster. The impact on the performance of the node as a whole depends on the number and size of the `Program`s it has to process.