### PR TITLE
Ensure Transaction Uniqueness in check_next_block

### DIFF
--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -36,6 +36,13 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
         }
 
+        // Ensure the transactions do not already exist.
+        for transaction_id in block.transactions().transaction_ids() {
+            if self.contains_transaction_id(transaction_id)? {
+                bail!("Transaction ID {transaction_id} already exists in the ledger");
+            }
+        }
+
         // TODO (howardwu): Remove this after moving the total supply into credits.aleo.
         {
             // // Retrieve the latest total supply.


### PR DESCRIPTION
## Motivation

The `check_next_block` function, which is executed by syncing nodes, currently lacks a validation step to ensure that new transactions in a block do not already exist in the ledger. Without this check, there is a risk that duplicate transactions could be introduced into the ledger. This PR adds the necessary validation to prevent such scenarios, ensuring that each transaction is only included once.

This only affects syncing nodes.

## Test Plan

Ran it locally.

TODOs: 
- [ ] add unit test to showcase in which scenario the missing uniqueness check could have been exploited.