### PR TITLE
Enforce block spend and synthesis limits for beacon blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3904,6 +3904,7 @@ dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-puzzle",
  "snarkvm-ledger-test-helpers",
+ "snarkvm-metrics",
  "snarkvm-slipstream-plugin-manager",
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ save_r1cs_hashes = [ "snarkvm-circuit/save_r1cs_hashes" ]
 test_exports = [ "snarkvm-algorithms/test_exports" ]
 test_targets = [ "snarkvm-console/test_targets" ]
 test_consensus_heights = [ "snarkvm-console/test_consensus_heights", "snarkvm-synthesizer/test_consensus_heights" ]
+test_limits = [ "snarkvm-ledger/test_limits" ]
 
 [workspace.dependencies.snarkvm-algorithms]
 path = "algorithms"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -115,6 +115,9 @@ test-helpers = [
 test_targets = [
   "snarkvm-console/test_targets",
 ]
+test_limits = [
+  "snarkvm-ledger-authority/test_limits",
+]
 dev-committee = []
 dev-print = [ "snarkvm-utilities/dev-print" ]
 timer = [ "aleo-std/timer" ]

--- a/ledger/authority/Cargo.toml
+++ b/ledger/authority/Cargo.toml
@@ -28,6 +28,7 @@ default = [ ]
 serial = [ "snarkvm-console/serial" ]
 wasm = [ "snarkvm-console/wasm" ]
 test-helpers = [ "snarkvm-ledger-narwhal-subdag/test-helpers" ]
+test_limits = []
 
 [dependencies.snarkvm-console]
 workspace = true

--- a/ledger/authority/src/lib.rs
+++ b/ledger/authority/src/lib.rs
@@ -123,7 +123,7 @@ impl<N: Network> Authority<N> {
     pub fn spend_limit(&self, block_height: u32) -> Option<u64> {
         match self {
             Self::Quorum(subdag) => subdag.spend_limit(block_height),
-            Self::Beacon(_) => Subdag::<N>::max_spend_limit(block_height),
+            Self::Beacon(_) => Subdag::<N>::min_spend_limit(block_height),
         }
     }
 
@@ -134,7 +134,7 @@ impl<N: Network> Authority<N> {
     pub fn synthesis_limit(&self, block_height: u32) -> Option<u64> {
         match self {
             Self::Quorum(subdag) => subdag.synthesis_limit(block_height),
-            Self::Beacon(_) => Subdag::<N>::max_synthesis_limit(block_height),
+            Self::Beacon(_) => Subdag::<N>::min_synthesis_limit(block_height),
         }
     }
 }

--- a/ledger/authority/src/lib.rs
+++ b/ledger/authority/src/lib.rs
@@ -118,8 +118,8 @@ impl<N: Network> Authority<N> {
 
     /// Returns the block spend limit for this authority at `block_height`.
     ///
-    /// Quorum authorities use the subdag certificate count. Beacon authorities use the limit of a
-    /// maximally dense subdag, so block-wide spend limits are enforced on trusted/dev chains too.
+    /// Quorum authorities use the subdag certificate count. Beacon authorities use the limit for
+    /// `min_certificates`, so block-wide spend limits are enforced on trusted/dev chains too.
     pub fn spend_limit(&self, block_height: u32) -> Option<u64> {
         match self {
             Self::Quorum(subdag) => subdag.spend_limit(block_height),
@@ -129,8 +129,8 @@ impl<N: Network> Authority<N> {
 
     /// Returns the block synthesis limit for this authority at `block_height`.
     ///
-    /// Quorum authorities use the subdag certificate count. Beacon authorities use the limit of a
-    /// maximally dense subdag, so block-wide synthesis limits are enforced on trusted/dev chains too.
+    /// Quorum authorities use the subdag certificate count. Beacon authorities use the limit for
+    /// `min_certificates`, so block-wide synthesis limits are enforced on trusted/dev chains too.
     pub fn synthesis_limit(&self, block_height: u32) -> Option<u64> {
         match self {
             Self::Quorum(subdag) => subdag.synthesis_limit(block_height),

--- a/ledger/authority/src/lib.rs
+++ b/ledger/authority/src/lib.rs
@@ -116,26 +116,32 @@ impl<N: Network> Authority<N> {
         }
     }
 
-    /// Returns the block spend limit for this authority at `block_height`.
+    /// Returns the block spend and synthesis limits for this authority at `block_height`.
     ///
-    /// Quorum authorities use the subdag certificate count. Beacon authorities use the limit for
-    /// `min_certificates`, so block-wide spend limits are enforced on trusted/dev chains too.
-    pub fn spend_limit(&self, block_height: u32) -> Option<u64> {
+    /// Quorum authorities use the subdag certificate count. Beacon authorities use the limits for
+    /// `min_certificates`, so block-wide limits are enforced on trusted/dev chains too.
+    pub fn limits(&self, block_height: u32) -> (Option<u64>, Option<u64>) {
         match self {
-            Self::Quorum(subdag) => subdag.spend_limit(block_height),
-            Self::Beacon(_) => Subdag::<N>::min_spend_limit(block_height),
+            #[cfg(not(feature = "test_limits"))]
+            Self::Quorum(subdag) => (subdag.spend_limit(block_height), subdag.synthesis_limit(block_height)),
+            #[cfg(feature = "test_limits")]
+            Self::Quorum(_subdag) => {
+                (Subdag::<N>::min_spend_limit(block_height), Subdag::<N>::min_synthesis_limit(block_height))
+            }
+            Self::Beacon(_) => {
+                (Subdag::<N>::min_spend_limit(block_height), Subdag::<N>::min_synthesis_limit(block_height))
+            }
         }
     }
 
+    /// Returns the block spend limit for this authority at `block_height`.
+    pub fn spend_limit(&self, block_height: u32) -> Option<u64> {
+        self.limits(block_height).0
+    }
+
     /// Returns the block synthesis limit for this authority at `block_height`.
-    ///
-    /// Quorum authorities use the subdag certificate count. Beacon authorities use the limit for
-    /// `min_certificates`, so block-wide synthesis limits are enforced on trusted/dev chains too.
     pub fn synthesis_limit(&self, block_height: u32) -> Option<u64> {
-        match self {
-            Self::Quorum(subdag) => subdag.synthesis_limit(block_height),
-            Self::Beacon(_) => Subdag::<N>::min_synthesis_limit(block_height),
-        }
+        self.limits(block_height).1
     }
 }
 
@@ -160,5 +166,49 @@ pub mod test_helpers {
     /// Returns a list of sample authorities.
     pub fn sample_authorities(rng: &mut TestRng) -> Vec<Authority<CurrentNetwork>> {
         vec![sample_beacon_authority(rng), sample_quorum_authority(rng)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use console::{network::MainnetV0, prelude::TestRng};
+    use snarkvm_ledger_narwhal_subdag::Subdag;
+
+    type CurrentNetwork = MainnetV0;
+
+    /// Beacon and (under `test_limits`) quorum authorities both return the paired min_* limits.
+    #[test]
+    fn test_authority_limits_pair_min_limits() {
+        let mut rng = TestRng::default();
+        let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(console::network::ConsensusVersion::V16).unwrap();
+        let v18_height = CurrentNetwork::CONSENSUS_HEIGHT(console::network::ConsensusVersion::V18).unwrap();
+
+        let expected = |height| {
+            (Subdag::<CurrentNetwork>::min_spend_limit(height), Subdag::<CurrentNetwork>::min_synthesis_limit(height))
+        };
+
+        let beacon = test_helpers::sample_beacon_authority(&mut rng);
+        for height in [v16_height, v18_height, u32::MAX] {
+            assert_eq!(beacon.limits(height), expected(height));
+            assert_eq!(beacon.spend_limit(height), expected(height).0);
+            assert_eq!(beacon.synthesis_limit(height), expected(height).1);
+        }
+
+        let quorum = test_helpers::sample_quorum_authority(&mut rng);
+        #[cfg(feature = "test_limits")]
+        for height in [v16_height, v18_height, u32::MAX] {
+            assert_eq!(quorum.limits(height), expected(height));
+        }
+
+        #[cfg(not(feature = "test_limits"))]
+        {
+            let Authority::Quorum(subdag) = &quorum else {
+                panic!("expected quorum authority");
+            };
+            for height in [v16_height, v18_height, u32::MAX] {
+                assert_eq!(quorum.limits(height), (subdag.spend_limit(height), subdag.synthesis_limit(height)));
+            }
+        }
     }
 }

--- a/ledger/authority/src/lib.rs
+++ b/ledger/authority/src/lib.rs
@@ -115,6 +115,28 @@ impl<N: Network> Authority<N> {
             Self::Quorum(subdag) => subdag.leader_address(),
         }
     }
+
+    /// Returns the block spend limit for this authority at `block_height`.
+    ///
+    /// Quorum authorities use the subdag certificate count. Beacon authorities use the limit of a
+    /// maximally dense subdag, so block-wide spend limits are enforced on trusted/dev chains too.
+    pub fn spend_limit(&self, block_height: u32) -> Option<u64> {
+        match self {
+            Self::Quorum(subdag) => subdag.spend_limit(block_height),
+            Self::Beacon(_) => Subdag::<N>::max_spend_limit(block_height),
+        }
+    }
+
+    /// Returns the block synthesis limit for this authority at `block_height`.
+    ///
+    /// Quorum authorities use the subdag certificate count. Beacon authorities use the limit of a
+    /// maximally dense subdag, so block-wide synthesis limits are enforced on trusted/dev chains too.
+    pub fn synthesis_limit(&self, block_height: u32) -> Option<u64> {
+        match self {
+            Self::Quorum(subdag) => subdag.synthesis_limit(block_height),
+            Self::Beacon(_) => Subdag::<N>::max_synthesis_limit(block_height),
+        }
+    }
 }
 
 #[cfg(any(test, feature = "test-helpers"))]

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -224,12 +224,14 @@ impl<N: Network> Subdag<N> {
 
     /// Returns a lower-bound certificate count for a subdag at `block_height`.
     ///
-    /// This is 66% of two rounds of certificates:
-    /// `(2 * MAX_CERTIFICATES(block_height) * 66) / 100`.
+    /// For `N = MAX_CERTIFICATES(block_height)` written as `N = 3f + 1`, this is the integer
+    /// `2 * (f + 1)`. In general (including `N = 3f + 1 + k` with `0 <= k < 3`), this is two
+    /// rounds of the availability threshold: `2 * ((N + 2) / 3)`.
     #[inline]
     pub fn min_certificates(block_height: u32) -> u64 {
-        let max_certificates_per_round = consensus_config_value!(N, MAX_CERTIFICATES, block_height).unwrap() as u64;
-        max_certificates_per_round.saturating_mul(2).saturating_mul(66).saturating_div(100)
+        let n = consensus_config_value!(N, MAX_CERTIFICATES, block_height).unwrap() as u64;
+        // `(N + 2) / 3 = f + 1` when `N = 3f + 1 + k` with `0 <= k < 3`.
+        n.saturating_add(2).saturating_div(3).saturating_mul(2)
     }
 
     /// Returns the block spend limit for `certificate_count` certificates at `block_height`.
@@ -652,13 +654,14 @@ mod tests {
 
         for height in [v16_height, v18_height, v18_height.saturating_add(1), u32::MAX] {
             let min_certs = Subdag::<CurrentNetwork>::min_certificates(height);
-            let max_certificates_per_round =
-                consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, height).unwrap() as u64;
-            assert_eq!(
-                min_certs,
-                max_certificates_per_round.saturating_mul(2).saturating_mul(66).saturating_div(100),
-                "min_certificates must be 66% of two rounds at height {height}"
-            );
+            let n = consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, height).unwrap() as u64;
+            // When `N = 3f + 1`, `(N + 2) / 3 = f + 1`, so the result is exactly `2 * (f + 1)`.
+            let expected = n.saturating_add(2).saturating_div(3).saturating_mul(2);
+            assert_eq!(min_certs, expected, "min_certificates must be 2*((N+2)/3) at height {height}");
+            if n % 3 == 1 {
+                let f = n.saturating_sub(1) / 3;
+                assert_eq!(min_certs, 2 * (f + 1), "min_certificates must equal 2*(f+1) when N=3f+1");
+            }
 
             // Equivalence: min_* is defined as the limit for a subdag with exactly min_certificates.
             assert_eq!(

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -222,14 +222,14 @@ impl<N: Network> Subdag<N> {
         self.values().map(|certificates| certificates.len() as u64).sum()
     }
 
-    /// Returns the maximum number of certificates in a maximally dense subdag at `block_height`.
+    /// Returns a lower-bound certificate count for a subdag at `block_height`.
     ///
-    /// This is `MAX_ROUNDS * MAX_CERTIFICATES(block_height)`, matching the bound checked in
-    /// `test_max_certificates`.
+    /// This is 66% of two rounds of certificates:
+    /// `(2 * MAX_CERTIFICATES(block_height) * 66) / 100`.
     #[inline]
-    pub fn max_certificates(block_height: u32) -> u64 {
+    pub fn min_certificates(block_height: u32) -> u64 {
         let max_certificates_per_round = consensus_config_value!(N, MAX_CERTIFICATES, block_height).unwrap() as u64;
-        Self::MAX_ROUNDS.saturating_mul(max_certificates_per_round)
+        max_certificates_per_round.saturating_mul(2).saturating_mul(66).saturating_div(100)
     }
 
     /// Returns the block spend limit for `certificate_count` certificates at `block_height`.
@@ -275,20 +275,20 @@ impl<N: Network> Subdag<N> {
         Self::synthesis_limit_from_certificate_count(block_height, self.certificate_count())
     }
 
-    /// Returns the block spend limit for a maximally dense subdag at `block_height`.
+    /// Returns the block spend limit for a subdag with `min_certificates` at `block_height`.
     ///
     /// Used for beacon blocks, which have no subdag but must still enforce block-wide limits.
     #[inline]
     pub fn max_spend_limit(block_height: u32) -> Option<u64> {
-        Self::spend_limit_from_certificate_count(block_height, Self::max_certificates(block_height))
+        Self::spend_limit_from_certificate_count(block_height, Self::min_certificates(block_height))
     }
 
-    /// Returns the synthesis limit for a maximally dense subdag at `block_height`.
+    /// Returns the synthesis limit for a subdag with `min_certificates` at `block_height`.
     ///
     /// Used for beacon blocks, which have no subdag but must still enforce block-wide limits.
     #[inline]
     pub fn max_synthesis_limit(block_height: u32) -> Option<u64> {
-        Self::synthesis_limit_from_certificate_count(block_height, Self::max_certificates(block_height))
+        Self::synthesis_limit_from_certificate_count(block_height, Self::min_certificates(block_height))
     }
 
     /// Returns the leader certificate.
@@ -643,26 +643,33 @@ mod tests {
         }
     }
 
-    /// Beacon max limits must equal the limits of a subdag with `max_certificates` certificates.
+    /// Beacon max limits must equal the limits of a subdag with `min_certificates` certificates.
     #[test]
-    fn test_max_limits_equivalent_to_maximally_dense_subdag() {
+    fn test_max_limits_equivalent_to_min_certificates_subdag() {
         let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap();
         let v18_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V18).unwrap();
         let mut rng = TestRng::default();
 
         for height in [v16_height, v18_height, v18_height.saturating_add(1), u32::MAX] {
-            let max_certs = Subdag::<CurrentNetwork>::max_certificates(height);
+            let min_certs = Subdag::<CurrentNetwork>::min_certificates(height);
+            let max_certificates_per_round =
+                consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, height).unwrap() as u64;
+            assert_eq!(
+                min_certs,
+                max_certificates_per_round.saturating_mul(2).saturating_mul(66).saturating_div(100),
+                "min_certificates must be 66% of two rounds at height {height}"
+            );
 
-            // Equivalence: max_* is defined as the limit for a subdag with exactly max_certificates.
+            // Equivalence: max_* is defined as the limit for a subdag with exactly min_certificates.
             assert_eq!(
                 Subdag::<CurrentNetwork>::max_spend_limit(height),
-                Subdag::<CurrentNetwork>::spend_limit_from_certificate_count(height, max_certs),
-                "max_spend_limit must match a maximally dense subdag at height {height}"
+                Subdag::<CurrentNetwork>::spend_limit_from_certificate_count(height, min_certs),
+                "max_spend_limit must match a min_certificates subdag at height {height}"
             );
             assert_eq!(
                 Subdag::<CurrentNetwork>::max_synthesis_limit(height),
-                Subdag::<CurrentNetwork>::synthesis_limit_from_certificate_count(height, max_certs),
-                "max_synthesis_limit must match a maximally dense subdag at height {height}"
+                Subdag::<CurrentNetwork>::synthesis_limit_from_certificate_count(height, min_certs),
+                "max_synthesis_limit must match a min_certificates subdag at height {height}"
             );
 
             // Concrete subdags must use the same certificate-count formulas.
@@ -685,7 +692,7 @@ mod tests {
                 let unit_limit = Subdag::<CurrentNetwork>::spend_limit_from_certificate_count(height, 1).unwrap();
                 assert_eq!(
                     Subdag::<CurrentNetwork>::max_spend_limit(height),
-                    Some(unit_limit.saturating_mul(max_certs)),
+                    Some(unit_limit.saturating_mul(min_certs)),
                 );
                 assert_eq!(
                     Subdag::<CurrentNetwork>::spend_limit_from_certificate_count(height, n),

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -279,7 +279,7 @@ impl<N: Network> Subdag<N> {
     ///
     /// Used for beacon blocks, which have no subdag but must still enforce block-wide limits.
     #[inline]
-    pub fn max_spend_limit(block_height: u32) -> Option<u64> {
+    pub fn min_spend_limit(block_height: u32) -> Option<u64> {
         Self::spend_limit_from_certificate_count(block_height, Self::min_certificates(block_height))
     }
 
@@ -287,7 +287,7 @@ impl<N: Network> Subdag<N> {
     ///
     /// Used for beacon blocks, which have no subdag but must still enforce block-wide limits.
     #[inline]
-    pub fn max_synthesis_limit(block_height: u32) -> Option<u64> {
+    pub fn min_synthesis_limit(block_height: u32) -> Option<u64> {
         Self::synthesis_limit_from_certificate_count(block_height, Self::min_certificates(block_height))
     }
 
@@ -643,9 +643,9 @@ mod tests {
         }
     }
 
-    /// Beacon max limits must equal the limits of a subdag with `min_certificates` certificates.
+    /// Beacon min limits must equal the limits of a subdag with `min_certificates` certificates.
     #[test]
-    fn test_max_limits_equivalent_to_min_certificates_subdag() {
+    fn test_min_limits_equivalent_to_min_certificates_subdag() {
         let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap();
         let v18_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V18).unwrap();
         let mut rng = TestRng::default();
@@ -660,16 +660,16 @@ mod tests {
                 "min_certificates must be 66% of two rounds at height {height}"
             );
 
-            // Equivalence: max_* is defined as the limit for a subdag with exactly min_certificates.
+            // Equivalence: min_* is defined as the limit for a subdag with exactly min_certificates.
             assert_eq!(
-                Subdag::<CurrentNetwork>::max_spend_limit(height),
+                Subdag::<CurrentNetwork>::min_spend_limit(height),
                 Subdag::<CurrentNetwork>::spend_limit_from_certificate_count(height, min_certs),
-                "max_spend_limit must match a min_certificates subdag at height {height}"
+                "min_spend_limit must match a min_certificates subdag at height {height}"
             );
             assert_eq!(
-                Subdag::<CurrentNetwork>::max_synthesis_limit(height),
+                Subdag::<CurrentNetwork>::min_synthesis_limit(height),
                 Subdag::<CurrentNetwork>::synthesis_limit_from_certificate_count(height, min_certs),
-                "max_synthesis_limit must match a min_certificates subdag at height {height}"
+                "min_synthesis_limit must match a min_certificates subdag at height {height}"
             );
 
             // Concrete subdags must use the same certificate-count formulas.
@@ -691,7 +691,7 @@ mod tests {
                 let n = 8u64;
                 let unit_limit = Subdag::<CurrentNetwork>::spend_limit_from_certificate_count(height, 1).unwrap();
                 assert_eq!(
-                    Subdag::<CurrentNetwork>::max_spend_limit(height),
+                    Subdag::<CurrentNetwork>::min_spend_limit(height),
                     Some(unit_limit.saturating_mul(min_certs)),
                 );
                 assert_eq!(

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -215,41 +215,80 @@ impl<N: Network> Subdag<N> {
         self.values().flatten()
     }
 
-    /// Returns the block spend limit for this subdag at `block_height`.
+    /// Returns the number of certificates in this subdag.
     #[inline]
     #[allow(clippy::cast_possible_truncation)]
-    pub fn spend_limit(&self, block_height: u32) -> Option<u64> {
+    pub fn certificate_count(&self) -> u64 {
+        self.values().map(|certificates| certificates.len() as u64).sum()
+    }
+
+    /// Returns the maximum number of certificates in a maximally dense subdag at `block_height`.
+    ///
+    /// This is `MAX_ROUNDS * MAX_CERTIFICATES(block_height)`, matching the bound checked in
+    /// `test_max_certificates`.
+    #[inline]
+    pub fn max_certificates(block_height: u32) -> u64 {
+        let max_certificates_per_round = consensus_config_value!(N, MAX_CERTIFICATES, block_height).unwrap() as u64;
+        Self::MAX_ROUNDS.saturating_mul(max_certificates_per_round)
+    }
+
+    /// Returns the block spend limit for `certificate_count` certificates at `block_height`.
+    #[inline]
+    pub fn spend_limit_from_certificate_count(block_height: u32, certificate_count: u64) -> Option<u64> {
         if block_height >= N::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap() {
-            // Compute the number of certificates in the subdag.
-            let subdag_certificates_count = self.values().map(|certificates| certificates.len() as u64).sum::<u64>();
-            // Compute the batch spend limit.
-            let batch_spend_limit = BatchHeader::<N>::batch_spend_limit(block_height);
-            // For each certificate in the subdag, we can spend up to the batch spend limit.
-            Some(subdag_certificates_count.saturating_mul(batch_spend_limit))
+            // For each certificate, we can spend up to the batch spend limit.
+            Some(certificate_count.saturating_mul(BatchHeader::<N>::batch_spend_limit(block_height)))
         } else {
             None
         }
     }
 
-    /// Returns the synthesis limit for this subdag at `block_height`.
-    // Note: This limit refers to the total number of non-zero entries across all circuits in all deployments in the subdag.
+    /// Returns the synthesis limit for `certificate_count` certificates at `block_height`.
+    ///
+    /// Note: This limit refers to the total number of non-zero entries across all circuits in all
+    /// deployments in the subdag.
     #[inline]
     #[allow(clippy::cast_possible_truncation)]
-    pub fn synthesis_limit(&self, block_height: u32) -> Option<u64> {
+    pub fn synthesis_limit_from_certificate_count(block_height: u32, certificate_count: u64) -> Option<u64> {
         if block_height >= N::CONSENSUS_HEIGHT(ConsensusVersion::V18).unwrap() {
             // One full round of consensus has a synthesis budget of 5 seconds.
             let synthesis_per_second_runtime = 5_f64 * N::SYNTHESIS_PER_SECOND_OF_RUNTIME as f64;
             // A certificate therefore has a synthesis budget of 5 seconds / MAX_CERTIFICATES.
             let synthesis_per_certificate = synthesis_per_second_runtime
                 / consensus_config_value!(N, MAX_CERTIFICATES, block_height).unwrap() as f64;
-            // Compute the number of certificates in the subdag.
-            let subdag_certificates_count =
-                self.values().map(|certificates| certificates.len() as u64).sum::<u64>() as f64;
             // The synthesis limit is the number of certificates times the synthesis budget per certificate.
-            Some((synthesis_per_certificate * subdag_certificates_count) as u64)
+            Some((synthesis_per_certificate * certificate_count as f64) as u64)
         } else {
             None
         }
+    }
+
+    /// Returns the block spend limit for this subdag at `block_height`.
+    #[inline]
+    pub fn spend_limit(&self, block_height: u32) -> Option<u64> {
+        Self::spend_limit_from_certificate_count(block_height, self.certificate_count())
+    }
+
+    /// Returns the synthesis limit for this subdag at `block_height`.
+    #[inline]
+    pub fn synthesis_limit(&self, block_height: u32) -> Option<u64> {
+        Self::synthesis_limit_from_certificate_count(block_height, self.certificate_count())
+    }
+
+    /// Returns the block spend limit for a maximally dense subdag at `block_height`.
+    ///
+    /// Used for beacon blocks, which have no subdag but must still enforce block-wide limits.
+    #[inline]
+    pub fn max_spend_limit(block_height: u32) -> Option<u64> {
+        Self::spend_limit_from_certificate_count(block_height, Self::max_certificates(block_height))
+    }
+
+    /// Returns the synthesis limit for a maximally dense subdag at `block_height`.
+    ///
+    /// Used for beacon blocks, which have no subdag but must still enforce block-wide limits.
+    #[inline]
+    pub fn max_synthesis_limit(block_height: u32) -> Option<u64> {
+        Self::synthesis_limit_from_certificate_count(block_height, Self::max_certificates(block_height))
     }
 
     /// Returns the leader certificate.
@@ -601,6 +640,58 @@ mod tests {
             let limit = subdag_with_cert_count(n, &mut rng).spend_limit(v16_height).unwrap();
             assert!(limit >= previous, "spend_limit must not decrease: n={n}, limit={limit}, previous={previous}");
             previous = limit;
+        }
+    }
+
+    /// Beacon max limits must equal the limits of a subdag with `max_certificates` certificates.
+    #[test]
+    fn test_max_limits_equivalent_to_maximally_dense_subdag() {
+        let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap();
+        let v18_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V18).unwrap();
+        let mut rng = TestRng::default();
+
+        for height in [v16_height, v18_height, v18_height.saturating_add(1), u32::MAX] {
+            let max_certs = Subdag::<CurrentNetwork>::max_certificates(height);
+
+            // Equivalence: max_* is defined as the limit for a subdag with exactly max_certificates.
+            assert_eq!(
+                Subdag::<CurrentNetwork>::max_spend_limit(height),
+                Subdag::<CurrentNetwork>::spend_limit_from_certificate_count(height, max_certs),
+                "max_spend_limit must match a maximally dense subdag at height {height}"
+            );
+            assert_eq!(
+                Subdag::<CurrentNetwork>::max_synthesis_limit(height),
+                Subdag::<CurrentNetwork>::synthesis_limit_from_certificate_count(height, max_certs),
+                "max_synthesis_limit must match a maximally dense subdag at height {height}"
+            );
+
+            // Concrete subdags must use the same certificate-count formulas.
+            for n in [0usize, 1, 7, 16] {
+                let subdag = subdag_with_cert_count(n, &mut rng);
+                assert_eq!(subdag.certificate_count(), n as u64);
+                assert_eq!(
+                    subdag.spend_limit(height),
+                    Subdag::<CurrentNetwork>::spend_limit_from_certificate_count(height, n as u64)
+                );
+                assert_eq!(
+                    subdag.synthesis_limit(height),
+                    Subdag::<CurrentNetwork>::synthesis_limit_from_certificate_count(height, n as u64)
+                );
+            }
+
+            // Linearity of spend_limit: scaling certificate count scales the limit.
+            if height >= v16_height {
+                let n = 8u64;
+                let unit_limit = Subdag::<CurrentNetwork>::spend_limit_from_certificate_count(height, 1).unwrap();
+                assert_eq!(
+                    Subdag::<CurrentNetwork>::max_spend_limit(height),
+                    Some(unit_limit.saturating_mul(max_certs)),
+                );
+                assert_eq!(
+                    Subdag::<CurrentNetwork>::spend_limit_from_certificate_count(height, n),
+                    Some(unit_limit.saturating_mul(n)),
+                );
+            }
         }
     }
 }

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -413,7 +413,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Determine if the block timestamp should be included.
         let next_block_timestamp =
             (next_height >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default()).then_some(next_timestamp);
-        // Beacon blocks have no subdag; enforce limits as if for a maximally dense subdag.
+        // Beacon blocks have no subdag; enforce limits as if for a subdag with min_certificates.
         let (block_spend_limit, block_synthesis_limit) = match subdag {
             Some(subdag) => (subdag.spend_limit(next_height), subdag.synthesis_limit(next_height)),
             None => (Subdag::<N>::max_spend_limit(next_height), Subdag::<N>::max_synthesis_limit(next_height)),

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -413,10 +413,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Determine if the block timestamp should be included.
         let next_block_timestamp =
             (next_height >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default()).then_some(next_timestamp);
-        let (block_spend_limit, block_synthesis_limit) = if let Some(subdag) = subdag {
-            (subdag.spend_limit(next_height), subdag.synthesis_limit(next_height))
-        } else {
-            (None, None)
+        // Beacon blocks have no subdag; enforce limits as if for a maximally dense subdag.
+        let (block_spend_limit, block_synthesis_limit) = match subdag {
+            Some(subdag) => (subdag.spend_limit(next_height), subdag.synthesis_limit(next_height)),
+            None => (Subdag::<N>::max_spend_limit(next_height), Subdag::<N>::max_synthesis_limit(next_height)),
         };
         // Construct the finalize state.
         let state = FinalizeGlobalState::new::<N>(

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -415,7 +415,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             (next_height >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default()).then_some(next_timestamp);
         // Beacon blocks have no subdag; enforce limits as if for a subdag with min_certificates.
         let (block_spend_limit, block_synthesis_limit) = match subdag {
+            #[cfg(not(feature = "test_limits"))]
             Some(subdag) => (subdag.spend_limit(next_height), subdag.synthesis_limit(next_height)),
+            #[cfg(feature = "test_limits")]
+            Some(_subdag) => (Subdag::<N>::min_spend_limit(next_height), Subdag::<N>::min_synthesis_limit(next_height)),
             None => (Subdag::<N>::min_spend_limit(next_height), Subdag::<N>::min_synthesis_limit(next_height)),
         };
         // Construct the finalize state.

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -416,7 +416,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Beacon blocks have no subdag; enforce limits as if for a subdag with min_certificates.
         let (block_spend_limit, block_synthesis_limit) = match subdag {
             Some(subdag) => (subdag.spend_limit(next_height), subdag.synthesis_limit(next_height)),
-            None => (Subdag::<N>::max_spend_limit(next_height), Subdag::<N>::max_synthesis_limit(next_height)),
+            None => (Subdag::<N>::min_spend_limit(next_height), Subdag::<N>::min_synthesis_limit(next_height)),
         };
         // Construct the finalize state.
         let state = FinalizeGlobalState::new::<N>(

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -232,7 +232,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
             .then_some(block.timestamp());
         // Determine the block's spend and synthesis limits.
-        // Beacon authorities use the maximally dense subdag limits.
+        // Beacon authorities use the min_certificates subdag limits.
         let (block_spend_limit, block_synthesis_limit) =
             (block.authority().spend_limit(block.height()), block.authority().synthesis_limit(block.height()));
 

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -230,36 +230,6 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             }
         }
 
-        // Determine if the block timestamp should be included.
-        let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
-            .then_some(block.timestamp());
-        // Determine the block's spend and synthesis limits.
-        // Beacon authorities use the min_certificates subdag limits.
-        let (block_spend_limit, block_synthesis_limit) =
-            (block.authority().spend_limit(block.height()), block.authority().synthesis_limit(block.height()));
-
-        // Construct the finalize state.
-        let state = FinalizeGlobalState::new::<N>(
-            block.round(),
-            block.height(),
-            block_timestamp,
-            block.cumulative_weight(),
-            block.cumulative_proof_target(),
-            block.previous_hash(),
-            block_spend_limit,
-            block_synthesis_limit,
-        )?;
-        // Ensure speculation over the unconfirmed transactions is correct and ensure each transaction is well-formed and unique.
-        let time_since_last_block = block.timestamp().saturating_sub(latest_block_timestamp);
-        let ratified_finalize_operations = self.vm.check_speculate(
-            state,
-            time_since_last_block,
-            block.ratifications(),
-            block.solutions(),
-            block.transactions(),
-            rng,
-        )?;
-
         // Retrieve the committee lookback.
         let committee_lookback = self
             .get_committee_lookback_for_round(block.round())?

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -231,12 +231,10 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         // Determine if the block timestamp should be included.
         let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
             .then_some(block.timestamp());
-        // Determine the block's spend limit.
-        let (block_spend_limit, block_synthesis_limit) = if let Authority::Quorum(subdag) = block.authority() {
-            (subdag.spend_limit(block.height()), subdag.synthesis_limit(block.height()))
-        } else {
-            (None, None)
-        };
+        // Determine the block's spend and synthesis limits.
+        // Beacon authorities use the maximally dense subdag limits.
+        let (block_spend_limit, block_synthesis_limit) =
+            (block.authority().spend_limit(block.height()), block.authority().synthesis_limit(block.height()));
 
         // Construct the finalize state.
         let state = FinalizeGlobalState::new::<N>(

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -308,11 +308,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
             .then_some(block.timestamp());
         // Determine the block's spend and synthesis limits.
-        let (block_spend_limit, block_synthesis_limit) = if let Authority::Quorum(subdag) = block.authority() {
-            (subdag.spend_limit(block.height()), subdag.synthesis_limit(block.height()))
-        } else {
-            (None, None)
-        };
+        let (block_spend_limit, block_synthesis_limit) = block.authority().limits(block.height());
         let state = FinalizeGlobalState::new::<N>(
             block.round(),
             block.height(),

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -44,7 +44,6 @@ use console::{
     },
     types::{Field, Group, U8, U64},
 };
-use snarkvm_ledger_authority::Authority;
 use snarkvm_ledger_block::{
     Block,
     ConfirmedTransaction,
@@ -325,11 +324,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Match the consensus path's gating: the timestamp is only included from V12 onward.
         let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
             .then_some(block.timestamp());
-        let (block_spend_limit, block_synthesis_limit) = if let Authority::Quorum(subdag) = block.authority() {
-            (subdag.spend_limit(block.height()), subdag.synthesis_limit(block.height()))
-        } else {
-            (None, None)
-        };
+        // Beacon authorities use the maximally dense subdag limits.
+        let (block_spend_limit, block_synthesis_limit) =
+            (block.authority().spend_limit(block.height()), block.authority().synthesis_limit(block.height()));
         FinalizeGlobalState::new::<N>(
             block.round(),
             block.height(),
@@ -613,11 +610,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
             .then_some(block.timestamp());
         // Determine the block spend and synthesis limits.
-        let (block_spend_limit, block_synthesis_limit) = if let Authority::Quorum(subdag) = block.authority() {
-            (subdag.spend_limit(block.height()), subdag.synthesis_limit(block.height()))
-        } else {
-            (None, None)
-        };
+        // Beacon authorities use the maximally dense subdag limits.
+        let (block_spend_limit, block_synthesis_limit) =
+            (block.authority().spend_limit(block.height()), block.authority().synthesis_limit(block.height()));
         // Construct the finalize state.
         let state = FinalizeGlobalState::new::<N>(
             block.round(),

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -324,7 +324,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Match the consensus path's gating: the timestamp is only included from V12 onward.
         let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
             .then_some(block.timestamp());
-        // Beacon authorities use the maximally dense subdag limits.
+        // Beacon authorities use the min_certificates subdag limits.
         let (block_spend_limit, block_synthesis_limit) =
             (block.authority().spend_limit(block.height()), block.authority().synthesis_limit(block.height()));
         FinalizeGlobalState::new::<N>(
@@ -610,7 +610,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
             .then_some(block.timestamp());
         // Determine the block spend and synthesis limits.
-        // Beacon authorities use the maximally dense subdag limits.
+        // Beacon authorities use the min_certificates subdag limits.
         let (block_spend_limit, block_synthesis_limit) =
             (block.authority().spend_limit(block.height()), block.authority().synthesis_limit(block.height()));
         // Construct the finalize state.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -325,8 +325,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
             .then_some(block.timestamp());
         // Beacon authorities use the min_certificates subdag limits.
-        let (block_spend_limit, block_synthesis_limit) =
-            (block.authority().spend_limit(block.height()), block.authority().synthesis_limit(block.height()));
+        let (block_spend_limit, block_synthesis_limit) = block.authority().limits(block.height());
         FinalizeGlobalState::new::<N>(
             block.round(),
             block.height(),
@@ -611,8 +610,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             .then_some(block.timestamp());
         // Determine the block spend and synthesis limits.
         // Beacon authorities use the min_certificates subdag limits.
-        let (block_spend_limit, block_synthesis_limit) =
-            (block.authority().spend_limit(block.height()), block.authority().synthesis_limit(block.height()));
+        let (block_spend_limit, block_synthesis_limit) = block.authority().limits(block.height());
         // Construct the finalize state.
         let state = FinalizeGlobalState::new::<N>(
             block.round(),

--- a/synthesizer/src/vm/tests/test_v16/block_spend_limit.rs
+++ b/synthesizer/src/vm/tests/test_v16/block_spend_limit.rs
@@ -21,7 +21,7 @@ use super::*;
 /// `Authority::spend_limit(height)` (see `VM::add_next_block_inner`).
 ///
 /// `Subdag::spend_limit` is `total_certificate_count * BatchHeader::batch_spend_limit(height)`.
-/// Beacon blocks use `Subdag::max_spend_limit` (`min_certificates` certificate count).
+/// Beacon blocks use `Subdag::min_spend_limit` (`min_certificates` certificate count).
 /// Using a limit of `compute_spend` for one `credits.aleo/transfer_public` execution models a
 /// quorum block whose DAG-derived ceiling equals a single such transaction; a second identical
 /// execution must then be aborted during speculation.

--- a/synthesizer/src/vm/tests/test_v16/block_spend_limit.rs
+++ b/synthesizer/src/vm/tests/test_v16/block_spend_limit.rs
@@ -21,7 +21,7 @@ use super::*;
 /// `Authority::spend_limit(height)` (see `VM::add_next_block_inner`).
 ///
 /// `Subdag::spend_limit` is `total_certificate_count * BatchHeader::batch_spend_limit(height)`.
-/// Beacon blocks use `Subdag::max_spend_limit` (maximally dense certificate count).
+/// Beacon blocks use `Subdag::max_spend_limit` (`min_certificates` certificate count).
 /// Using a limit of `compute_spend` for one `credits.aleo/transfer_public` execution models a
 /// quorum block whose DAG-derived ceiling equals a single such transaction; a second identical
 /// execution must then be aborted during speculation.

--- a/synthesizer/src/vm/tests/test_v16/block_spend_limit.rs
+++ b/synthesizer/src/vm/tests/test_v16/block_spend_limit.rs
@@ -18,9 +18,10 @@
 use super::*;
 
 /// Quorum blocks pass `block_spend_limit` into [`FinalizeGlobalState`] via
-/// `Authority::Quorum(subdag).spend_limit(height)` (see `VM::add_next_block_inner`).
+/// `Authority::spend_limit(height)` (see `VM::add_next_block_inner`).
 ///
 /// `Subdag::spend_limit` is `total_certificate_count * BatchHeader::batch_spend_limit(height)`.
+/// Beacon blocks use `Subdag::max_spend_limit` (maximally dense certificate count).
 /// Using a limit of `compute_spend` for one `credits.aleo/transfer_public` execution models a
 /// quorum block whose DAG-derived ceiling equals a single such transaction; a second identical
 /// execution must then be aborted during speculation.


### PR DESCRIPTION
## The issues

Beacon blocks did not apply block-wide `spend_limit` and `synthesis_limit`. Test quorum blocks with small committee sizes applied limits which were too low. Only production quorum blocks with a subdag applied the right limits.

## The solution
This change applies the limits appropriately for beacon blocks and test environments. The limits match a conservative minimally dense subdag (2 rounds, 0.66% of stake).

Production Quorum block behavior does not change.

## Test plan
- [x] `cargo test -p snarkvm-ledger-narwhal-subdag -- test_max_limits_equivalent_to_maximally_dense_subdag`
- [x] `cargo clippy -p snarkvm-ledger-narwhal-subdag -p snarkvm-ledger-authority -p snarkvm-ledger -p snarkvm-synthesizer --no-deps -- -D warnings`
