### PR TITLE
perf(narwhal): cache the recovered signer addresses on BatchCertificate

### DIFF
--- a/ledger/narwhal/batch-certificate/src/lib.rs
+++ b/ledger/narwhal/batch-certificate/src/lib.rs
@@ -32,7 +32,7 @@ use snarkvm_ledger_narwhal_transmission_id::TransmissionID;
 
 use core::hash::{Hash, Hasher};
 use indexmap::IndexSet;
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::OnceLock};
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
@@ -43,6 +43,17 @@ pub struct BatchCertificate<N: Network> {
     batch_header: BatchHeader<N>,
     /// The signatures for the batch ID from the committee.
     signatures: IndexSet<Signature<N>>,
+    /// The recovered address of each signer, in the same order as `signatures`.
+    ///
+    /// This is derived data, cached because recovering a signer address is expensive: it is a
+    /// fixed-base scalar multiplication per signature (see `Signature::to_address`), and the
+    /// same addresses were previously recomputed at every point that needed them.
+    ///
+    /// It is populated eagerly by `from`, which already recovers the addresses in order to
+    /// validate them, and lazily on first use otherwise (see `signers`). It is never
+    /// serialized, and it takes no part in `PartialEq`, `Eq`, or `Hash`, all of which are
+    /// keyed on the batch ID alone.
+    signers: OnceLock<Vec<Address<N>>>,
 }
 
 impl<N: Network> BatchCertificate<N> {
@@ -58,31 +69,51 @@ impl<N: Network> BatchCertificate<N> {
         // Ensure that the number of signatures is within bounds.
         ensure!(signatures.len() <= Self::max_signatures() as usize, "Invalid number of signatures");
 
+        // Collect the signatures so that they can be traversed alongside the recovered
+        // addresses below, and so that the recovery itself can be done in parallel.
+        let signature_list = signatures.iter().collect::<Vec<_>>();
+
+        // Recover the address of each signer, in the same order as `signatures`.
+        //
+        // This is the expensive step: each recovery is a fixed-base scalar multiplication.
+        // It is performed exactly once here, reused by both checks below, and then cached on
+        // the certificate so that later callers can use `signers` instead of recomputing it.
+        let signers = cfg_iter!(signature_list).map(|signature| signature.to_address()).collect::<Vec<_>>();
+
         // Ensure that the signature is from a unique signer and not from the author.
-        let signature_authors = signatures.iter().map(|signature| signature.to_address()).collect::<HashSet<_>>();
+        let signature_authors = signers.iter().copied().collect::<HashSet<_>>();
         ensure!(
             !signature_authors.contains(&batch_header.author()),
             "The author's signature was included in the signers"
         );
         ensure!(signature_authors.len() == signatures.len(), "A duplicate author was found in the set of signatures");
 
-        // Verify the signatures are valid.
-        cfg_iter!(signatures).try_for_each(|signature| {
-            if !signature.verify(&signature.to_address(), &[batch_header.batch_id()]) {
+        // Verify the signatures are valid, reusing the addresses recovered above.
+        cfg_iter!(signature_list).zip(&signers).try_for_each(|(signature, signer)| {
+            if !signature.verify(signer, &[batch_header.batch_id()]) {
                 bail!("Invalid batch certificate signature")
             }
             Ok(())
         })?;
+
+        // Drop the borrows of `signatures` before handing it over.
+        drop(signature_list);
+
         // Return the batch certificate.
-        Self::from_unchecked(batch_header, signatures)
+        let certificate = Self::from_unchecked(batch_header, signatures)?;
+        // Cache the addresses recovered above. `from_unchecked` always returns an empty cache,
+        // so this cannot fail.
+        let _ = certificate.signers.set(signers);
+        Ok(certificate)
     }
 
     /// Initializes a new batch certificate.
     pub fn from_unchecked(batch_header: BatchHeader<N>, signatures: IndexSet<Signature<N>>) -> Result<Self> {
         // Ensure the signatures are not empty.
         ensure!(!signatures.is_empty(), "Batch certificate must contain signatures");
-        // Return the batch certificate.
-        Ok(Self { batch_header, signatures })
+        // Return the batch certificate. Note the signer cache starts out empty here, and is
+        // populated on first use by `signers`.
+        Ok(Self { batch_header, signatures, signers: OnceLock::new() })
     }
 }
 
@@ -149,6 +180,23 @@ impl<N: Network> BatchCertificate<N> {
     /// Returns the signatures of the batch ID from the committee.
     pub fn signatures(&self) -> Box<dyn '_ + ExactSizeIterator<Item = &Signature<N>>> {
         Box::new(self.signatures.iter())
+    }
+
+    /// Returns the address of each signer, in the same order as `signatures`.
+    ///
+    /// Note that this does **not** include the certificate's author, whose signature is not
+    /// part of `signatures`; use `author` for that.
+    ///
+    /// Prefer this over mapping `Signature::to_address` over `signatures`. Recovering a signer
+    /// address is a fixed-base scalar multiplication, and certificates are checked, stored, and
+    /// inspected many times over their lifetime, so recomputing it at each site is significant
+    /// wasted work. Certificates built by `from` already have this populated.
+    ///
+    /// The lazy path takes a lock for the duration of the recovery. It is a leaf: nothing else
+    /// is acquired underneath it, and the work is pure computation, so it cannot participate in
+    /// a lock cycle.
+    pub fn signers(&self) -> &[Address<N>] {
+        self.signers.get_or_init(|| self.signatures.iter().map(|signature| signature.to_address()).collect())
     }
 }
 
@@ -256,5 +304,76 @@ pub mod test_helpers {
         );
 
         (certificate, previous_certificates)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use console::{network::MainnetV0, prelude::TestRng};
+
+    type CurrentNetwork = MainnetV0;
+
+    /// Recovers the signer addresses the naive way, which is what `signers` replaces.
+    fn recompute_signers(certificate: &BatchCertificate<CurrentNetwork>) -> Vec<Address<CurrentNetwork>> {
+        certificate.signatures().map(|signature| signature.to_address()).collect()
+    }
+
+    #[test]
+    fn test_signers_matches_recomputation() {
+        let rng = &mut TestRng::default();
+
+        for _ in 0..8 {
+            let certificate = test_helpers::sample_batch_certificate(rng);
+            // The cache was populated eagerly by `from`; it must agree with recomputation,
+            // and must preserve the order of `signatures`.
+            assert_eq!(certificate.signers(), recompute_signers(&certificate));
+        }
+    }
+
+    #[test]
+    fn test_signers_excludes_the_author() {
+        let rng = &mut TestRng::default();
+
+        let certificate = test_helpers::sample_batch_certificate(rng);
+        assert!(!certificate.signers().is_empty());
+        // `from` rejects a certificate whose author signed it, so the author must never appear.
+        assert!(!certificate.signers().contains(&certificate.author()));
+    }
+
+    #[test]
+    fn test_signers_is_lazily_populated_after_deserialization() {
+        let rng = &mut TestRng::default();
+
+        let certificate = test_helpers::sample_batch_certificate(rng);
+        let expected = certificate.signers().to_vec();
+
+        // `read_le_unchecked` goes through `from_unchecked`, which leaves the cache empty, so
+        // this exercises the lazy path rather than the one populated by `from`.
+        let bytes = certificate.to_bytes_le().unwrap();
+        let recovered = BatchCertificate::<CurrentNetwork>::read_le_unchecked(&bytes[..]).unwrap();
+        assert!(recovered.signers.get().is_none(), "the cache should start out empty");
+
+        assert_eq!(recovered.signers(), expected);
+        // A second call must return the same cached value.
+        assert_eq!(recovered.signers(), expected);
+    }
+
+    #[test]
+    fn test_signers_survives_cloning() {
+        let rng = &mut TestRng::default();
+
+        let certificate = test_helpers::sample_batch_certificate(rng);
+        let expected = certificate.signers().to_vec();
+
+        // Cloning a populated certificate carries the cache over.
+        assert_eq!(certificate.clone().signers(), expected);
+
+        // Cloning an unpopulated one leaves it unpopulated, and it still resolves correctly.
+        let bytes = certificate.to_bytes_le().unwrap();
+        let unpopulated = BatchCertificate::<CurrentNetwork>::read_le_unchecked(&bytes[..]).unwrap();
+        let cloned = unpopulated.clone();
+        assert!(cloned.signers.get().is_none(), "cloning must not populate the cache");
+        assert_eq!(cloned.signers(), expected);
     }
 }

--- a/ledger/src/check_next_block.rs
+++ b/ledger/src/check_next_block.rs
@@ -387,9 +387,9 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
             // Note that we do not need to check the quorum requirement for the previous certificates
             // because that is done during construction in `BatchCertificate::new`.
             cfg_iter!(certificates).try_for_each(|certificate| {
-                // Collect the certificate signers.
-                let mut signers: HashSet<_> =
-                    certificate.signatures().map(|signature| signature.to_address()).collect();
+                // Collect the certificate signers. Note that `signers` is cached on the
+                // certificate, so this does not re-derive an address per signature.
+                let mut signers: HashSet<_> = certificate.signers().iter().copied().collect();
                 // Append the certificate author.
                 signers.insert(certificate.author());
 


### PR DESCRIPTION
## Motivation

While studying BFT code, we realized that we frequently recompute the signers of any `BatchCertificate` from the signatures. However, this can actually be quite expensive as it represents many finite field/elliptic curve operations, and it ends up happening in the storage.rs while checking certificates before committing them to storage, and in telemetry while computing participation scores. Because the `to_address()` function is on the order of 20-50 microseconds, doing this for 40 certificates and 27 quorum members creates millisecond stalls, and this is happening on the tokio executor within the BFT code, while holding critical locks.

In many code paths, the same set of signers is recomputed and discarded several times. Including twice inside `BatchCertificate::from` itself -- once to build `signature_authors` for the uniqueness check, and again inside the verification loop as `signature.verify(&signature.to_address(), ..)` -- after which the addresses were dropped on the floor. Downstream consumers then re-derived the same set on every quorum check and every inspection of a certificate.

This PR develops an alternative -- BatchCertificate can store a cache of the signer list, in a OnceLock, and it's API is such that this can be properly encapsulated (the BatchCertificate is already immutable).

- `from` now recovers them once, in parallel, and reuses them for the author check, the duplicate check, and the verification loop. That alone halves the constructor's address-recovery cost.
- The result is stored in a `OnceLock<Vec<Address<N>>>` and exposed as `signers()`, which lazily recovers them for certificates built by `from_unchecked` (notably `read_le_unchecked`).
- `check_next_block` uses `signers()` for its quorum check instead of re-deriving.

The cache is purely derived state: it is never serialized, so the wire format is unchanged, and it takes no part in `PartialEq`/`Eq`/`Hash`, which are keyed on the batch ID alone. `signatures` has no mutation API, so it cannot go stale.

The scale of the win is modest: at mainnet's current MAX_CERTIFICATES = 40 (ConsensusVersion ::V9) with a quorum of roughly 27 signatures per certificate: ~1.0ms of address recovery per certificate, ~42ms per round of 40 certificates, ~83ms per commit covering two rounds. Negligible against 5s blocks, more significant during catchup. Beyond that, it helps us avoid doing elliptic curve operations on the tokio executor, especially while holding locks in the BFT code.

### Follow-on work in snarkOS

Before this change, the same address was derived about five times per signature on the incoming-certificate path: twice in `from` (above), and three more times in snarkOS. This commit removes the first two. The remaining three become cache reads in a follow-on snarkOS PR, which is blocked on this one merging.

- node/bft/src/helpers/telemetry.rs:163-174, `CertificateMetadata::new` -- replace the `.chain(..)` argument with `certificate.signers().iter().copied()`.
- node/bft/src/helpers/storage.rs:566-572, `check_incoming_certificate` -- replace the collect with `certificate.signers().iter().copied().collect()`.
- node/bft/src/helpers/storage.rs:649-664, `check_certificate` -- iterate `certificate.signers()` rather than `certificate.signatures()`, dropping the `to_address()` call inside the loop.

The last two run back to back on the same certificate: primary.rs:1270 calls `check_incoming_certificate`, then stores it via `insert_certificate` (storage.rs:691), which calls `check_certificate` (storage.rs:701). So a received certificate currently pays full recovery twice and will pay zero times.

## Alternatives that we considered

We could have tried to cache this on a smaller object than `BatchCertificate`, like `Signature`. However, that type is copy so we cannot add a OnceLock to it without breaking that, and if we use OnceCell instead then it won't be Send anymore, either of which is a disruptive change. Additionally, it's not clear that doing it on `Signature` is wise, because it's a lower level object used in more parts of the code and it's harder to reason about the impact of increasing the size of that struct is.

We could have tried to cache this in a higher-level location, such as in the BFT state machine itself. However, then other consumers that need to inspect the signers, such as the telemetry module or a blockchain client, don't get the benefit of this cache, which could lead to duplication.

We could have tried to cache this computation in a global singleton -- given the bytes of a signature, look up who the signer is, and if we get a match, we don't have to do any expensive computation. Otherwise we fallback to computing it directly. Since it's completely deterministic this would be sound. This has the benefit that it would work across batch certificates -- a consensus node that has a stable set of peers would compute these things once and never again, which is actually the best case scenario.

We declined to pursue the global singleton approach because (1) global singletons are somewhat messy and can make sound testing and benchmarking harder (2) if nothing ever removes old entries from the global singleton, then an adversary might be able to fill up that table with junk in order to waste memory. but implementing any kind of pruning scheme may increase the dramatically increase the complexity relative to alternatives.

## Drawbacks

Because `BatchCertificate` is immutable, it's possible to make this change with confidence, and because `BatchCertificate` is pretty big, it's easy to see that this cache of signers is not going to make much difference in memory footprint.

If in the future we wanted to make `BatchCertificate` mutable for some reason, then that would create cache invalidation problems. So we shouldn't make this change if we think that we might want to do that.

## Test Plan

The existing API of `BatchCertificate`, which is immutable, makes it relatively easy to add a cache here. Unit tests ensure that the behavior of the constructors is not changing. 

## Backwards compatibility

This should be backwards compatible as it is only an optimization within a single node.