### PR TITLE
Harden deployment verification: seed remaining ambient RNG sources (follow-on to #3346)

### DIFF
--- a/synthesizer/process/src/stack/deploy.rs
+++ b/synthesizer/process/src/stack/deploy.rs
@@ -89,7 +89,10 @@ impl<N: Network> Stack<N> {
         &self,
         consensus_version: ConsensusVersion,
         deployment: &Deployment<N>,
-        rng: &mut R,
+        // Retained for API compatibility. Deployment verification is intentionally deterministic:
+        // all randomness is drawn from `seeded_rng` (seeded by the deployment ID) so that every
+        // validator computes the same result.
+        _rng: &mut R,
     ) -> Result<()> {
         let timer = timer!("Stack::verify_deployment");
 
@@ -202,7 +205,9 @@ impl<N: Network> Stack<N> {
                 is_root,
                 program_checksum,
                 false,
-                rng,
+                // Draw the request nonce from the seeded RNG as well, so no part of the
+                // `CheckDeployment` synthesis depends on the ambient RNG. See the burner note above.
+                &mut seeded_rng,
             )?;
             lap!(timer, "Compute the request for {}", function.name());
             // Initialize the assignments.
@@ -284,25 +289,33 @@ impl<N: Network> Stack<N> {
                 .iter()
                 .map(|(record_name, _record_type)| {
                     // Construct a random `TranslationAssignment`.
+                    // Note: All randomness here is drawn from `seeded_rng` (seeded by the deployment
+                    // ID), not the ambient `_rng`, so that the translation assignment — and thus the
+                    // certificate check below — is identical across all validators.
                     let program_id = *self.program_id();
-                    let function_id = Field::<N>::from_u64(Uniform::rand(rng));
+                    let function_id = Field::<N>::from_u64(Uniform::rand(&mut seeded_rng));
                     let record_name = *record_name;
-                    let record_static = self.sample_record(&Address::rand(rng), &record_name, Group::rand(rng), rng)?;
+                    let record_static = self.sample_record(
+                        &Address::rand(&mut seeded_rng),
+                        &record_name,
+                        Group::rand(&mut seeded_rng),
+                        &mut seeded_rng,
+                    )?;
                     let record_dynamic = DynamicRecord::<N>::from_record(&record_static)?;
-                    let translation_index: u16 = Uniform::rand(rng);
-                    let tvk = Uniform::rand(rng);
-                    let record_register_index = Uniform::rand(rng);
-                    let record_view_key: Option<Field<N>> = UniformExt::rand_option(rng);
-                    let gamma: Option<Group<N>> = UniformExt::rand_option(rng);
+                    let translation_index: u16 = Uniform::rand(&mut seeded_rng);
+                    let tvk = Uniform::rand(&mut seeded_rng);
+                    let record_register_index = Uniform::rand(&mut seeded_rng);
+                    let record_view_key: Option<Field<N>> = UniformExt::rand_option(&mut seeded_rng);
+                    let gamma: Option<Group<N>> = UniformExt::rand_option(&mut seeded_rng);
                     let id_dynamic = compute_console_dynamic_or_external_record_id(
                         function_id,
                         record_dynamic.to_fields()?,
                         tvk,
                         U16::new(record_register_index),
                     )?;
-                    let is_to_static = Uniform::rand(rng);
-                    let is_external_record = Uniform::rand(rng);
-                    let id_static = Uniform::rand(rng);
+                    let is_to_static = Uniform::rand(&mut seeded_rng);
+                    let is_external_record = Uniform::rand(&mut seeded_rng);
+                    let id_static = Uniform::rand(&mut seeded_rng);
 
                     lap!(timer, "Sample the inputs to the translation circuit for record {record_name}");
 

--- a/synthesizer/program/src/logic/instruction/operation/get_record_dynamic.rs
+++ b/synthesizer/program/src/logic/instruction/operation/get_record_dynamic.rs
@@ -44,6 +44,8 @@ use console::{
         Value,
     },
 };
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
 
 use indexmap::IndexMap;
 
@@ -396,8 +398,17 @@ impl<N: Network> GetRecordDynamic<N> {
             }
             None => {
                 // Sample an arbitrary value for the entry, consistent with the specified type.
+                // Note: This MUST be deterministic across all validators verifying the same deployment.
+                // The not-present branch is reached during `CheckDeployment` synthesis (a sampled dynamic
+                // record carries no data), and the sampled value is stored to a register that a program
+                // can feed into a `call.dynamic` target. Drawing it from the ambient `rand::rng()` would
+                // let the same deployment verify on some validators and fail on others. We therefore seed
+                // a deterministic RNG from the (deterministic) record root and entry identifier; the
+                // concrete value is a dummy witness used only for synthesis, so only its determinism matters.
                 let value = {
-                    let rng = &mut rand::rng();
+                    let root_seed = u64::from_bytes_le(&root.to_bytes_le()?[0..8])?;
+                    let entry_seed = u64::from_bytes_le(&entry_identifier.to_field()?.to_bytes_le()?[0..8])?;
+                    let rng = &mut ChaChaRng::seed_from_u64(root_seed ^ entry_seed);
                     let address = Address::<N>::rand(rng);
                     stack.sample_value(&address, &RegisterType::Plaintext(plaintext_type.clone()), rng)?
                 };

--- a/synthesizer/program/src/logic/instruction/operation/get_record_dynamic.rs
+++ b/synthesizer/program/src/logic/instruction/operation/get_record_dynamic.rs
@@ -406,12 +406,13 @@ impl<N: Network> GetRecordDynamic<N> {
                 // a deterministic RNG from the (deterministic) record root and entry identifier; the
                 // concrete value is a dummy witness used only for synthesis, so only its determinism matters.
                 let value = {
-                    let root_seed = u64::from_bytes_le(&root.to_bytes_le()?[0..8])?;
-                    let entry_seed = u64::from_bytes_le(&entry_identifier.to_field()?.to_bytes_le()?[0..8])?;
-                    let rng = &mut ChaChaRng::seed_from_u64(root_seed ^ entry_seed);
-                    let address = Address::<N>::rand(rng);
-                    stack.sample_value(&address, &RegisterType::Plaintext(plaintext_type.clone()), rng)?
-                };
+                    let root_bytes = root.to_bytes_le()?;
+                    let entry_bytes = entry_identifier.to_field()?.to_bytes_le()?;
+                    let root_seed = u64::from_bytes_le(&root_bytes[..8])?;
+                    let entry_seed = u64::from_bytes_le(&entry_bytes[..8])?;
+                    let mut rng = ChaChaRng::seed_from_u64(root_seed ^ entry_seed);
+                    let address = Address::<N>::rand(&mut rng);
+                    stack.sample_value(&address, &RegisterType::Plaintext(plaintext_type.clone()), &mut rng)?
 
                 let entry = match value {
                     // When visibility is specified, the visibility bits are injected as constants in the circuit.

--- a/synthesizer/src/vm/tests/test_v19/get_record_dynamic_targets.rs
+++ b/synthesizer/src/vm/tests/test_v19/get_record_dynamic_targets.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+// Companion to `closure_dynamic_targets`, for a second, independent non-determinism source.
+//
+// `get.record.dynamic` samples a dummy entry value on its not-present branch (reached during
+// `CheckDeployment` synthesis, since a sampled dynamic record carries no data). This program points
+// the target of a `call.dynamic` instruction at a closure or a real function depending on the last
+// bit of that sampled value. If the value is drawn from the ambient RNG, different runs of
+// `verify_deployment` disagree on the same deployment — a validator fork. This program never reads
+// `self.signer`, so it is NOT covered by seeding the burner key; it exercises the
+// `get.record.dynamic` fix specifically.
+#[test]
+fn test_conditional_dynamic_call_target_deployment_via_get_record_dynamic() {
+    const N_EXPERIMENTS: usize = 10;
+
+    let rng = &mut TestRng::default();
+
+    // Create a program whose name contains the passed integer, so that different executions have
+    // different deployment IDs and therefore different deployment-check outcomes.
+    let parse_program = |i| {
+        Program::<CurrentNetwork>::from_str(&format!(
+            r"
+        program program_grd_{i}.aleo;
+
+        closure some_closure:
+            input r0 as u8;
+            add r0 r0 into r1;
+            output r1 as u8;
+
+        function sink:
+            input r0 as u8.public;
+            output r0 as u8.public;
+
+        function main:
+            input r0 as dynamic.record;
+            get.record.dynamic r0.secret into r1 as u8;
+            and r1 1u8 into r2;
+            is.eq r2 0u8 into r3;
+            cast 'some_closure' into r4 as field;
+            cast 'sink' into r5 as field;
+            ternary r3 r4 r5 into r6;
+            call.dynamic 'program_grd_{i}' 'aleo' r6 with r1 (as u8.public) into r7 (as u8.public);
+            output r7 as u8.public;
+
+        constructor:
+            assert.eq true true;
+        ",
+        ))
+        .unwrap()
+    };
+
+    let process = Process::<CurrentNetwork>::load().unwrap();
+
+    // About half of the calls to process.deploy should succeed. Among succeeded ones, about half
+    // should be accepted by process.verify_deployment, but the outcome for each fixed deployment
+    // must be the same across all calls to verify_deployment.
+    for i in 0..N_EXPERIMENTS {
+        let deployment_attempt = process.deploy::<CurrentAleo, _>(&parse_program(i), rng);
+
+        match deployment_attempt {
+            Ok(deployment) => {
+                println!(" - Deployment computation {i} succeeded with ID {}", deployment.to_deployment_id().unwrap());
+
+                // Ensure that different runs of verify_deployment agree on the result - even if it is a rejection.
+                let verification_successful =
+                    process.verify_deployment::<CurrentAleo, _>(ConsensusVersion::V19, &deployment, rng).is_ok();
+                for _ in 1..N_EXPERIMENTS {
+                    assert_eq!(
+                        verification_successful,
+                        process.verify_deployment::<CurrentAleo, _>(ConsensusVersion::V19, &deployment, rng).is_ok(),
+                        "Verifier disagreement during deployment verification (get.record.dynamic)",
+                    );
+                }
+                println!("   All verifiers {}", if verification_successful { "accepted" } else { "rejected" });
+            }
+            Err(error) => {
+                println!(" - Deployment computation {i} failed: {error}");
+            }
+        }
+    }
+}

--- a/synthesizer/src/vm/tests/test_v19/mod.rs
+++ b/synthesizer/src/vm/tests/test_v19/mod.rs
@@ -20,6 +20,9 @@ mod translated_type_checks;
 // ConsensusVersion::V19-gated, but they were introduced at that point in time.
 mod closure_dynamic_targets;
 
+// Companion test covering the independent `get.record.dynamic` non-determinism source.
+mod get_record_dynamic_targets;
+
 use super::*;
 
 use super::test_v14::add_and_test_with_costs;


### PR DESCRIPTION
## Motivation

Follow-on hardening for #3346:

PR #3346 makes the `CheckDeployment` burner — and thus `self.signer` — deterministic, closing the fork in which a `call.dynamic` target chosen from `self.signer` makes the same deployment verify on some validators and abort on others. Since that change already alters `CheckDeployment` synthesis for every deployment, this PR closes additional ambient-RNG sources reachable during deployment verification, so that verification is a pure function of the deployment. (This fixes all such similar issues that I could find at this time.)

- **`get.record.dynamic` — an independent second instance of the same fork.** `compute_or_sample_path` samples its dummy entry value from `rand::rng()` on the not-present branch, which is reached during `CheckDeployment` synthesis (a sampled dynamic record carries `data = None`). That value is stored to a register a program can feed into a `call.dynamic` target (closure vs. non-closure), so the same deployment can verify on some validators and abort on others. Because the exploiting program never reads `self.signer`, **#3346's burner fix does not close it.** It is now drawn from a `ChaChaRng` seeded by the record root and entry identifier, both deterministic across validators verifying the same deployment.

- **`Request::sign` nonce and record-translation sampling** in `verify_deployment` are now drawn from the deployment-ID-seeded RNG rather than the ambient `rng`. These are defense-in-depth: once the burner key is seeded neither currently changes a verification outcome, but this removes any remaining dependence of verification on the ambient RNG. The now-unused `rng` argument is renamed `_rng` (signature retained for API compatibility, but we could also remove it in this PR if reviewers want).

Deliberately left out of scope: the Synthesize-mode (key-generation) burner in `synthesize.rs` also uses the ambient RNG, but `synthesize_key` runs during `deploy()`/proving — never during validator block verification — so it is not a consensus-fork source.

## Test Plan

Adds `synthesizer/src/vm/tests/test_v19/get_record_dynamic_targets.rs`, mirroring #3346's `closure_dynamic_targets.rs` but driving the `call.dynamic` target from a `get.record.dynamic` read instead of from `self.signer`. It deploys such programs and asserts repeated runs of `verify_deployment` agree on each fixed deployment. It fails on #3346 as-is (the `get.record.dynamic` value is still ambient) and passes with this fix.

```
cargo test -p snarkvm-synthesizer --features test --lib \
  test_conditional_dynamic_call_target_deployment_via_get_record_dynamic -- --nocapture
```

## Backwards compatibility

For the same reason as #3346 doesn't gate this behind a `ConsensusVersion` change, this one doesn't need that either. The change only alters the verification outcome of future deployments, and only for programs that would have caused the consensus network to fork.
