### PR TITLE
Lower testnet MAX_CERTIFICATES to 40 at consensus V19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3904,6 +3904,7 @@ dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-puzzle",
  "snarkvm-ledger-test-helpers",
+ "snarkvm-metrics",
  "snarkvm-slipstream-plugin-manager",
  "snarkvm-synthesizer-program",
  "snarkvm-synthesizer-snark",

--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -169,21 +169,23 @@ impl Network for CanaryV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::canary::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 100),
         (ConsensusVersion::V5, 100),
         (ConsensusVersion::V6, 100),
         (ConsensusVersion::V9, 100),
+        (ConsensusVersion::V19, 100),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 25),
         (ConsensusVersion::V3, 25),
         (ConsensusVersion::V5, 25),
         (ConsensusVersion::V6, 25),
         (ConsensusVersion::V9, 25),
+        (ConsensusVersion::V19, 25),
     ];
     /// The (long) network name.
     const NAME: &'static str = "Aleo Canary (v0)";

--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -69,8 +69,8 @@ pub enum ConsensusVersion {
     /// V18: Enables native credits record translation, introduces block-wide deployment limits,
     ///      and enforces canonical subDAG certificate ordering.
     V18 = 18,
-    /// V19: Adds more accurate type checking for the root call, and bounds the size of every
-    /// `PlaintextType` declared in a deployed program.
+    /// V19: Adds more accurate type checking for the root call, bounds the size of every
+    /// `PlaintextType` declared in a deployed program, and updates the number of validators.
     V19 = 19,
     /// V20: TBD
     V20 = 20,
@@ -490,10 +490,13 @@ mod tests {
 
     /// Ensure that `MAX_CERTIFICATES` increases and is correctly defined.
     /// See the constant declaration for an explanation why.
-    fn max_certificates_increasing<N: Network>() {
+    /// The versions in `exempt_versions` are permitted to decrease the value.
+    fn max_certificates_increasing<N: Network>(exempt_versions: &[ConsensusVersion]) {
         let mut previous_value = N::MAX_CERTIFICATES.first().unwrap().1;
-        for (_, value) in N::MAX_CERTIFICATES.iter().skip(1) {
-            assert!(*value >= previous_value);
+        for (version, value) in N::MAX_CERTIFICATES.iter().skip(1) {
+            if !exempt_versions.contains(version) {
+                assert!(*value >= previous_value, "MAX_CERTIFICATES must not decrease at {version:?}");
+            }
             previous_value = *value;
         }
     }
@@ -609,8 +612,10 @@ mod tests {
         consensus_config_returns_some::<TestnetV0>();
         consensus_config_returns_some::<CanaryV0>();
 
-        max_certificates_increasing::<MainnetV0>();
-        max_certificates_increasing::<CanaryV0>();
+        max_certificates_increasing::<MainnetV0>(&[]);
+        // Testnet lowers the maximum committee size at `V19`.
+        max_certificates_increasing::<TestnetV0>(&[ConsensusVersion::V19]);
+        max_certificates_increasing::<CanaryV0>(&[]);
 
         max_array_elements_increasing::<MainnetV0>();
         max_array_elements_increasing::<TestnetV0>();

--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -610,7 +610,6 @@ mod tests {
         consensus_config_returns_some::<CanaryV0>();
 
         max_certificates_increasing::<MainnetV0>();
-        max_certificates_increasing::<TestnetV0>();
         max_certificates_increasing::<CanaryV0>();
 
         max_array_elements_increasing::<MainnetV0>();

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -311,7 +311,7 @@ pub trait Network:
     //  Decreasing this value will break backwards compatibility of serialization without explicit
     //  declaration of migration based on round number rather than block height.
     //  Increasing this value will require a migration to prevent forking during network upgrades.
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6];
 
     /// Returns the list of consensus versions.
     #[allow(non_snake_case)]

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -174,21 +174,23 @@ impl Network for MainnetV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 16),
         (ConsensusVersion::V3, 25),
         (ConsensusVersion::V5, 30),
         (ConsensusVersion::V6, 35),
         (ConsensusVersion::V9, 40),
+        (ConsensusVersion::V19, 40),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 101),
         (ConsensusVersion::V5, 102),
         (ConsensusVersion::V6, 103),
         (ConsensusVersion::V9, 104),
+        (ConsensusVersion::V19, 105),
     ];
     /// The (long) network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -169,21 +169,23 @@ impl Network for TestnetV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::testnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 100),
         (ConsensusVersion::V5, 100),
         (ConsensusVersion::V6, 100),
         (ConsensusVersion::V9, 100),
+        (ConsensusVersion::V19, 40),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 25),
         (ConsensusVersion::V3, 25),
         (ConsensusVersion::V5, 25),
         (ConsensusVersion::V6, 25),
         (ConsensusVersion::V9, 25),
+        (ConsensusVersion::V19, 25),
     ];
     /// The (long) network name.
     const NAME: &'static str = "Aleo Testnet (v0)";


### PR DESCRIPTION
## Summary

- Set testnet `MAX_CERTIFICATES` to 40 when consensus V19 activates.
- Before V19, testnet keeps the current limit of 100 certificates per batch.
- Mainnet and canary keep their current limits at V19 (40 and 100).
- Update consensus constant tests so testnet can lower this limit at a new version.

## Why

Testnet currently allows up to 100 certificates per batch. Mainnet caps this at 40. Lowering testnet to 40 at V19 aligns testnet with mainnet and allows us to use a higher synthesis and spend limit.

## Backwards compatibility

The code contains a comment:
```
    //  Note: This value must **not** decrease without considering the impact on serialization.
    //  Decreasing this value will break backwards compatibility of serialization without explicit
    //  declaration of migration based on round number rather than block height.
```
Based on manual and AI review I don't see any issues because we only have 26 validators active on testnet. @ljedrz can you double check problematic usage of `LATEST_MAX_CERTIFICATES` in snarkOS? 

## Test plan

- [x] Pre-commit hook passes (`cargo clippy` and `cargo fmt --check`)
- [x] `cargo test -p snarkvm-console-network --lib consensus_constants --features test`