### PR TITLE
[Perf] Release the MerkleTree read lock as quickly as possible when dumping the tree cache

### DIFF
--- a/console/collections/src/merkle_tree/mod.rs
+++ b/console/collections/src/merkle_tree/mod.rs
@@ -88,6 +88,22 @@ pub struct MerkleTreeState<'a, E: Environment> {
     number_of_leaves: usize,
 }
 
+impl<E: Environment> MerkleTreeState<'_, E> {
+    /// Converts the state into one that borrows nothing, cloning the tree's nodes if needed.
+    ///
+    /// This is what allows a state taken from a [`MerkleTree`] behind a lock to be used after the
+    /// lock is released - most importantly, to be serialized without holding it for the duration of
+    /// the write. It is a no-op for a state that already owns its nodes, such as a deserialized one.
+    pub fn into_owned(self) -> MerkleTreeState<'static, E> {
+        MerkleTreeState {
+            root: self.root,
+            tree: Cow::Owned(self.tree.into_owned()),
+            empty_hash: self.empty_hash,
+            number_of_leaves: self.number_of_leaves,
+        }
+    }
+}
+
 impl<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash<Hash = Field<E>>, const DEPTH: u8> Clone
     for MerkleTree<E, LH, PH, DEPTH>
 {
@@ -200,6 +216,11 @@ impl<E: Environment, LH: LeafHash<Hash = PH::Hash>, PH: PathHash<Hash = Field<E>
     ///
     /// This borrows from the tree, so it is cheap even for very large trees; use
     /// [`Self::from_state`] to recreate the tree from the returned state.
+    ///
+    /// note: The borrow lasts as long as the state does, so a state obtained through a lock guard
+    /// keeps that guard alive. Serializing such a state therefore holds the lock for the entire
+    /// write, which for a large tree is far longer than taking it; [`MerkleTreeState::into_owned`]
+    /// trades a copy of the tree for the ability to release the lock first.
     pub fn to_state(&self) -> MerkleTreeState<'_, E> {
         MerkleTreeState {
             root: self.root,

--- a/console/collections/src/merkle_tree/tests/state.rs
+++ b/console/collections/src/merkle_tree/tests/state.rs
@@ -54,6 +54,27 @@ fn check_state_round_trip<
         assert!(proof.verify(leaf_hasher, path_hasher, recreated.root(), leaf));
     }
 
+    // Taking ownership must be indistinguishable on the wire; it exists only so that the state can
+    // outlive the borrow, not to describe the tree differently.
+    let serialized_owned = bincode::serialize(&merkle_tree.to_state().into_owned())?;
+    assert_eq!(serialized, serialized_owned);
+
+    // ...and it must recreate the same tree.
+    let owned_state: MerkleTreeState<E> = bincode::deserialize(&serialized_owned)?;
+    let from_owned = MerkleTree::<E, LH, PH, DEPTH>::from_state(leaf_hasher, path_hasher, owned_state)?;
+    assert_eq!(recreated.root(), from_owned.root());
+    assert_eq!(recreated.tree(), from_owned.tree());
+
+    // An owned state borrows nothing, so it may be used after the tree it came from is gone.
+    let outliving_state = merkle_tree.to_state().into_owned();
+    drop(merkle_tree);
+    let from_outliving = MerkleTree::<E, LH, PH, DEPTH>::from_state(leaf_hasher, path_hasher, outliving_state)?;
+    assert_eq!(recreated.root(), from_outliving.root());
+
+    // Taking ownership of an already-owned state is a no-op.
+    let twice_owned = from_outliving.to_state().into_owned().into_owned();
+    assert_eq!(serialized, bincode::serialize(&twice_owned)?);
+
     Ok(())
 }
 

--- a/ledger/store/src/block/mod.rs
+++ b/ledger/store/src/block/mod.rs
@@ -1269,7 +1269,17 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
             bail!("Failed to determine the block tree cache path");
         };
 
-        // Create the target file.
+        // Take an owned snapshot of the tree, so that the read lock is released before the write
+        // begins. Serializing a borrowed state would instead hold the lock for the entire write,
+        // which can take seconds - and `Self::insert` needs the write lock for every block, so that
+        // is a stall in block processing. The cost is one extra copy of the tree's nodes, held only
+        // until the write concludes.
+        let state = self.tree.read().to_state().into_owned();
+
+        // Create the target file. Truncating the previous cache in place is fine: it is consumed
+        // and deleted on startup (see `BlockStorage::create_block_tree`), so a cache from an older
+        // height is never reused, and an interrupted write leaves a file that fails to load and
+        // falls back to constructing the tree from scratch - exactly what no file at all does.
         let file = fs::File::create(&path)?;
         // The block tree can become quite large, so use a BufWriter in order to
         // not have to keep the entire serialized tree in memory, and to reduce
@@ -1279,12 +1289,12 @@ impl<N: Network, B: BlockStorage<N>> BlockStore<N, B> {
         writer.write_all(BLOCK_TREE_CACHE_PREFIX)?;
         // Note: only the contents of the tree are cached, not its hashers; the latter are
         // deterministic, and recreating them is far cheaper than deserializing them.
-        bincode::serialize_into(&mut writer, &self.tree.read().to_state())?;
+        bincode::serialize_into(&mut writer, &state)?;
         writer.flush()?;
-        // TODO(ljedrz): this operation can already take ~2.5s, so we may want
-        // to perform chunking and parallel serialization. This may be useful
-        // for other applications, so it should be implemented as a common
-        // utility.
+        // TODO(ljedrz): the serialization itself can still take ~2.5s, so we may want to perform
+        // chunking and parallel serialization. Now that it no longer holds the block tree lock,
+        // this is purely a matter of the background write finishing sooner. This may be useful for
+        // other applications, so it should be implemented as a common utility.
 
         tracing::debug!("Cached the current block tree to {}", path.display());
 


### PR DESCRIPTION
Partially addresses https://github.com/ProvableHQ/snarkOS/issues/4318.