### PR TITLE
bump lru crate to 0.18.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,20 +1369,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1915,11 +1909,11 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -504,7 +504,7 @@ version = "1.4"
 version = "0.5"
 
 [workspace.dependencies.lru]
-version = "0.16"
+version = "0.18"
 
 [workspace.dependencies.num-traits]
 version = "0.2"
@@ -682,4 +682,3 @@ lto = "off"
 incremental = true
 debug = true
 debug-assertions = true
-


### PR DESCRIPTION
`lru 0.16.x` started getting flagged by cargo audit due to https://rustsec.org/advisories/RUSTSEC-2026-0253, this PR upgrades to the version containing the fix for this advisory. 