### PR TITLE
Bump the Rust toolchain to 1.96 and clear the resulting lints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ executors:
   # The default docker image used in the main-workflow
   rust-docker:
     docker:
-      - image: cimg/rust:1.88.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+      - image: cimg/rust:1.96.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
     environment:
       RUSTFLAGS: "" # override the config.toml flags
 
@@ -51,17 +51,17 @@ commands:
                 Write-Host "rustup not found, installing..."
                 $rustupPath = "$env:TEMP\rustup-init.exe"
                 Invoke-WebRequest -Uri "https://win.rustup.rs/" -OutFile $rustupPath
-                & $rustupPath -y --default-toolchain "1.88.0-x86_64-pc-windows-msvc" --no-modify-path --profile minimal
+                & $rustupPath -y --default-toolchain "1.96.0-x86_64-pc-windows-msvc" --no-modify-path --profile minimal
             } else {
-                Write-Host "rustup already installed, ensuring toolchain 1.88.0-x86_64-pc-windows-msvc is present..."
-                rustup toolchain install 1.88.0-x86_64-pc-windows-msvc
+                Write-Host "rustup already installed, ensuring toolchain 1.96.0-x86_64-pc-windows-msvc is present..."
+                rustup toolchain install 1.96.0-x86_64-pc-windows-msvc
             }
 
             # Put cargo/rustup first in PATH for this step and subsequent steps
             $Env:Path = "$Env:USERPROFILE\.cargo\bin;$Env:Path"
 
             # Select the toolchain
-            rustup default 1.88.0-x86_64-pc-windows-msvc
+            rustup default 1.96.0-x86_64-pc-windows-msvc
 
             # Verify the installation.
             cargo --version --verbose
@@ -90,7 +90,7 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: v4.7.3-rust-1.88.0-snarkvm-cache
+        default: v4.7.3-rust-1.96.0-snarkvm-cache
     steps:
       - run:
           name: Prepare environment variables and install dependencies
@@ -134,8 +134,8 @@ commands:
               clang libclang-dev llvm-dev llvm lld pkg-config xz-utils make libssl-dev
       - restore_cache:
           keys:
-            - v4.7.3-rust-1.88.0-deps-{{ checksum "Cargo.lock" }}-
-            - v4.7.3-rust-1.88.0-deps-
+            - v4.7.3-rust-1.96.0-deps-{{ checksum "Cargo.lock" }}-
+            - v4.7.3-rust-1.96.0-deps-
       - restore_cache:
           keys:
             - << parameters.cache_key >>
@@ -145,11 +145,11 @@ commands:
     parameters:
       cache_key:
         type: string
-        default: v4.7.3-rust-1.88.0-snarkvm-cache
+        default: v4.7.3-rust-1.96.0-snarkvm-cache
     steps:
       - run: set +e
       - save_cache:
-          key: v4.7.3-rust-1.88.0-deps-{{ checksum "Cargo.lock" }}
+          key: v4.7.3-rust-1.96.0-deps-{{ checksum "Cargo.lock" }}
           paths:
             - /home/circleci/.cache/sccache
             - /home/circleci/.cargo/registry
@@ -188,7 +188,7 @@ commands:
           condition: << parameters.use_cache >>
           steps:
             - setup_environment:
-                cache_key: v4.7.3-rust-1.88.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
+                cache_key: v4.7.3-rust-1.96.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
 
       - run:
           name: Install debian packages (always)
@@ -470,7 +470,7 @@ commands:
           condition: << parameters.use_cache >>
           steps:
             - clear_environment:
-                cache_key: v4.7.3-rust-1.88.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
+                cache_key: v4.7.3-rust-1.96.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
 
   install_rust_nightly:
     description: "Install Rust nightly toolchain"
@@ -1093,7 +1093,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.7.3-rust-1.88.0-snarkvm-wasm-cache
+          cache_key: v4.7.3-rust-1.96.0-snarkvm-wasm-cache
       - run:
           no_output_timeout: 30m
           command: |
@@ -1114,7 +1114,7 @@ jobs:
             # Run the tests
             cd wasm && wasm-pack test --node
       - clear_environment:
-          cache_key: v4.7.3-rust-1.88.0-snarkvm-wasm-cache
+          cache_key: v4.7.3-rust-1.96.0-snarkvm-wasm-cache
 
   check-fmt:
     executor: rust-docker
@@ -1123,13 +1123,13 @@ jobs:
       - checkout
       - install_rust_nightly
       - setup_environment:
-          cache_key: v4.7.3-rust-1.88.0-snarkvm-fmt-cache
+          cache_key: v4.7.3-rust-1.96.0-snarkvm-fmt-cache
       - run:
           name: Check style
           no_output_timeout: 35m
           command: cargo +nightly fmt --all -- --check
       - clear_environment:
-          cache_key: v4.7.3-rust-1.88.0-snarkvm-fmt-cache
+          cache_key: v4.7.3-rust-1.96.0-snarkvm-fmt-cache
 
   check-unused-dependencies:
     executor: rust-docker
@@ -1137,7 +1137,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.7.3-rust-1.88.0-machete-cache
+          cache_key: v4.7.3-rust-1.96.0-machete-cache
       - run:
           name: Check for unused dependencies
           no_output_timeout: 10m
@@ -1148,7 +1148,7 @@ jobs:
             fi
             cargo machete
       - clear_environment:
-          cache_key: v4.7.3-rust-1.88.0-machete-cache
+          cache_key: v4.7.3-rust-1.96.0-machete-cache
 
   check-cargo-audit:
     executor: rust-docker
@@ -1156,7 +1156,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.7.3-rust-1.88.0-cargo-audit-cache
+          cache_key: v4.7.3-rust-1.96.0-cargo-audit-cache
       - run:
           name:  Check for security vulnerabilities
           no_output_timeout: 10m
@@ -1164,7 +1164,7 @@ jobs:
             cargo install cargo-audit@0.22.0 --locked --force
             cargo audit -D warnings
       - clear_environment:
-          cache_key: v4.7.3-rust-1.88.0-cargo-audit-cache
+          cache_key: v4.7.3-rust-1.96.0-cargo-audit-cache
 
   check-cargo-semver-checks:
     executor: rust-docker
@@ -1173,14 +1173,14 @@ jobs:
       - checkout:
           method: full
       - setup_environment:
-          cache_key: v4.7.3-rust-1.88.0-cargo-semver-checks-cache
+          cache_key: v4.7.3-rust-1.96.0-cargo-semver-checks-cache
       - run:
           name: Check for semver violations
           no_output_timeout: 15m
           command: |
             bash ./.circleci/semver-checks.sh
       - clear_environment:
-          cache_key: v4.7.3-rust-1.88.0-cargo-semver-checks-cache
+          cache_key: v4.7.3-rust-1.96.0-cargo-semver-checks-cache
 
   check-clippy:
     executor: rust-docker
@@ -1188,7 +1188,7 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.7.3-rust-1.88.0-snarkvm-clippy-cache
+          cache_key: v4.7.3-rust-1.96.0-snarkvm-clippy-cache
       - run:
           name: Check Clippy (default features)
           timeout: 20m
@@ -1200,7 +1200,7 @@ jobs:
           command: |
             cargo clippy --workspace --all-targets --all-features -- -D warnings
       - clear_environment:
-          cache_key: v4.7.3-rust-1.88.0-snarkvm-clippy-cache
+          cache_key: v4.7.3-rust-1.96.0-snarkvm-clippy-cache
 
   check-all-targets:
     executor: rust-docker
@@ -1208,13 +1208,13 @@ jobs:
     steps:
       - checkout
       - setup_environment:
-          cache_key: v4.7.3-rust-1.88.0-snarkvm-all-targets-cache
+          cache_key: v4.7.3-rust-1.96.0-snarkvm-all-targets-cache
       - run:
           name: Check all targets
           no_output_timeout: 35m
           command: cargo check --release --workspace --all-targets
       - clear_environment:
-          cache_key: v4.7.3-rust-1.88.0-snarkvm-all-targets-cache
+          cache_key: v4.7.3-rust-1.96.0-snarkvm-all-targets-cache
 
   verify-windows:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1324,7 +1324,7 @@ workflows:
       or pipeline.git.branch == "canary"
       or pipeline.git.branch == "testnet"
       or pipeline.git.branch == "mainnet"
-      or pipeline.git.branch == "fix_ci_integration"
+      or pipeline.git.branch == "chore/rust-1.96-toolchain"
     jobs:
       - check-unused-dependencies # This can be cleaned up before releases
       - check-cargo-semver-checks # This can be cleaned up before releases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 include = [ "Cargo.toml", "vm", "README.md", "LICENSE.md" ]
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.88.0" # Attention - Change the MSRV in rust-toolchain and in .circleci/config.yml as well
+rust-version = "1.96.0" # Attention - Change the MSRV in rust-toolchain and in .circleci/config.yml as well
 
 [workspace]
 members = [

--- a/algorithms/src/crypto_hash/poseidon.rs
+++ b/algorithms/src/crypto_hash/poseidon.rs
@@ -275,7 +275,7 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
                 (num_elements_remaining / RATE) +
                 // And also add 1 if the last chunk is non-empty
                 // (i.e. if `num_elements_remaining` is not a multiple of `RATE`)
-                usize::from((num_elements_remaining % RATE) != 0);
+                usize::from(!num_elements_remaining.is_multiple_of(RATE));
 
             // Absorb the input elements, `RATE` elements at a time, except for the first
             // chunk, which is of size `RATE - rate_start`.
@@ -313,7 +313,7 @@ impl<F: PrimeField, const RATE: usize> PoseidonSponge<F, RATE, 1> {
                 (num_output_remaining / RATE) +
                 // And also add 1 if the last chunk is non-empty
                 // (i.e. if `num_output_remaining` is not a multiple of `RATE`)
-                usize::from((num_output_remaining % RATE) != 0);
+                usize::from(!num_output_remaining.is_multiple_of(RATE));
 
             // Absorb the input output, `RATE` output at a time, except for the first chunk,
             // which is of size `RATE - rate_start`.

--- a/algorithms/src/msm/variable_base/batched.rs
+++ b/algorithms/src/msm/variable_base/batched.rs
@@ -43,8 +43,8 @@ impl Ord for BucketPosition {
     }
 }
 
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for BucketPosition {
-    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         self.bucket_index.partial_cmp(&other.bucket_index)
     }
@@ -338,7 +338,7 @@ fn batched_window<G: AffineCurve>(
     c: usize,
 ) -> (G::Projective, usize) {
     // We don't need the "zero" bucket, so we only have 2^c - 1 buckets
-    let window_size = if (w_start % c) != 0 { w_start % c } else { c };
+    let window_size = if !w_start.is_multiple_of(c) { w_start % c } else { c };
     let num_buckets = (1 << window_size) - 1;
 
     let mut bucket_positions: Vec<_> = scalars

--- a/algorithms/src/msm/variable_base/standard.rs
+++ b/algorithms/src/msm/variable_base/standard.rs
@@ -57,7 +57,7 @@ fn standard_window<G: AffineCurve>(
     }
 
     // We don't need the "zero" bucket, so we only have 2^c - 1 buckets
-    let window_size = if (w_start % c) != 0 { w_start % c } else { c };
+    let window_size = if !w_start.is_multiple_of(c) { w_start % c } else { c };
     let mut buckets = vec![G::Projective::zero(); (1 << window_size) - 1];
     scalars
         .iter()

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -440,12 +440,12 @@ impl<E: PairingEngine> KZG10<E> {
             if enforced_degree_bounds.binary_search(&bound).is_err() {
                 Err(PCError::UnsupportedDegreeBound(bound))
             } else if bound < p.degree() || bound > max_degree {
-                return Err(PCError::IncorrectDegreeBound {
+                Err(PCError::IncorrectDegreeBound {
                     poly_degree: p.degree(),
                     degree_bound: p.degree_bound().unwrap(),
                     max_degree,
                     label: p.label().to_string(),
-                });
+                })
             } else {
                 Ok(())
             }
@@ -496,7 +496,7 @@ mod tests {
             pp: &UniversalParams<E>,
             mut supported_degree: usize,
             hiding_bound: Option<usize>,
-        ) -> (Powers<E>, VerifierKey<E>) {
+        ) -> (Powers<'_, E>, VerifierKey<E>) {
             if supported_degree == 1 {
                 supported_degree += 1;
             }

--- a/algorithms/src/polycommit/sonic_pc/data_structures.rs
+++ b/algorithms/src/polycommit/sonic_pc/data_structures.rs
@@ -276,7 +276,7 @@ impl<E: PairingEngine> ToBytes for CommitterKey<E> {
 
 impl<E: PairingEngine> CommitterKey<E> {
     fn len(&self) -> usize {
-        if self.shifted_powers_of_beta_g.is_some() { self.shifted_powers_of_beta_g.as_ref().unwrap().len() } else { 0 }
+        self.shifted_powers_of_beta_g.as_ref().map_or(0, |powers| powers.len())
     }
 }
 
@@ -309,7 +309,7 @@ pub struct CommitterUnionKey<'a, E: PairingEngine> {
 
 impl<'a, E: PairingEngine> CommitterUnionKey<'a, E> {
     /// Obtain powers for the underlying KZG10 construction
-    pub fn powers(&self) -> kzg10::Powers<E> {
+    pub fn powers(&self) -> kzg10::Powers<'_, E> {
         kzg10::Powers {
             powers_of_beta_g: self.powers_of_beta_g.unwrap().as_slice().into(),
             powers_of_beta_times_gamma_g: self.powers_of_beta_times_gamma_g.unwrap().as_slice().into(),
@@ -317,7 +317,7 @@ impl<'a, E: PairingEngine> CommitterUnionKey<'a, E> {
     }
 
     /// Obtain powers for committing to shifted polynomials.
-    pub fn shifted_powers_of_beta_g(&self, degree_bound: impl Into<Option<usize>>) -> Option<kzg10::Powers<E>> {
+    pub fn shifted_powers_of_beta_g(&self, degree_bound: impl Into<Option<usize>>) -> Option<kzg10::Powers<'_, E>> {
         match (&self.shifted_powers_of_beta_g, &self.shifted_powers_of_beta_times_gamma_g) {
             (Some(shifted_powers_of_beta_g), Some(shifted_powers_of_beta_times_gamma_g)) => {
                 let max_bound = self.enforced_degree_bounds.as_ref().unwrap().last().unwrap();
@@ -342,7 +342,7 @@ impl<'a, E: PairingEngine> CommitterUnionKey<'a, E> {
 
     /// Obtain elements of the SRS in the lagrange basis powers, for use with
     /// the underlying KZG10 construction.
-    pub fn lagrange_basis(&self, domain: EvaluationDomain<E::Fr>) -> Option<kzg10::LagrangeBasis<E>> {
+    pub fn lagrange_basis(&self, domain: EvaluationDomain<E::Fr>) -> Option<kzg10::LagrangeBasis<'_, E>> {
         self.lagrange_bases_at_beta_g.get(&domain.size()).map(|basis| kzg10::LagrangeBasis {
             lagrange_basis_at_beta_g: Cow::Borrowed(basis),
             powers_of_beta_times_gamma_g: Cow::Borrowed(self.powers_of_beta_times_gamma_g.unwrap()),

--- a/algorithms/src/polycommit/sonic_pc/polynomial.rs
+++ b/algorithms/src/polycommit/sonic_pc/polynomial.rs
@@ -105,7 +105,7 @@ impl<F: Field> LabeledPolynomial<F> {
     }
 
     /// Retrieve the polynomial from `self`.
-    pub fn polynomial(&self) -> &Polynomial<F> {
+    pub fn polynomial(&self) -> &Polynomial<'_, F> {
         &self.polynomial
     }
 

--- a/algorithms/src/snark/varuna/ahp/ahp.rs
+++ b/algorithms/src/snark/varuna/ahp/ahp.rs
@@ -136,10 +136,10 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             .max_by_key(|d| d.size())
             .ok_or(anyhow!("could not find max domain"))?;
         let mut max_non_zero_domain = Some(new_candidate);
-        if let Some(max_candidate) = max_candidate {
-            if max_candidate.size() > new_candidate.size() {
-                max_non_zero_domain = Some(max_candidate);
-            }
+        if let Some(max_candidate) = max_candidate
+            && max_candidate.size() > new_candidate.size()
+        {
+            max_non_zero_domain = Some(max_candidate);
         }
         Ok(NonZeroDomains { max_non_zero_domain, domain_a, domain_b, domain_c })
     }

--- a/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
+++ b/algorithms/src/snark/varuna/ahp/indexer/indexer.rs
@@ -250,7 +250,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             let lagrange_coefficients_at_point = domain.evaluate_all_lagrange_coefficients(point);
             let evals_at_point = evals.evaluate(&lagrange_coefficients_at_point)?;
             ensure!(labels.len() == evals_at_point.len());
-            all_evals.push(labels.into_iter().zip_eq(evals_at_point.into_iter()));
+            all_evals.push(labels.into_iter().zip_eq(evals_at_point));
         }
         let sorted_evals = all_evals.into_iter().flatten().sorted_unstable_by(|(l1, _), (l2, _)| l1.cmp(l2));
         for (label, eval) in sorted_evals {

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/mod.rs
@@ -70,7 +70,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         }
         let indices_and_assignments = circuits_to_constraints
             .iter()
-            .zip_eq(randomizing_assignments.into_iter())
+            .zip_eq(randomizing_assignments)
             .map(|((circuit, constraints), circuit_rand_assignments)| {
                 let assignments = constraints
                     .iter()

--- a/circuit/account/src/signature/mod.rs
+++ b/circuit/account/src/signature/mod.rs
@@ -82,7 +82,7 @@ impl<A: Aleo> Eject for Signature<A> {
 impl<A: Aleo> Parser for Signature<A> {
     /// Parses a string into a signature circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the signature from the string.
         let (string, signature) = console::Signature::parse(string)?;
         // Parse the mode from the string.

--- a/circuit/algorithms/src/keccak/hash.rs
+++ b/circuit/algorithms/src/keccak/hash.rs
@@ -27,7 +27,7 @@ impl<E: Environment, const TYPE: u8, const VARIANT: usize> Hash for Keccak<E, TY
         // and the bit rate is the width (1600 in our case) minus the capacity.
         let bitrate = PERMUTATION_WIDTH - 2 * VARIANT;
         debug_assert!(bitrate < PERMUTATION_WIDTH, "The bitrate must be less than the permutation width");
-        debug_assert!(bitrate % 8 == 0, "The bitrate must be a multiple of 8");
+        debug_assert!(bitrate.is_multiple_of(8), "The bitrate must be a multiple of 8");
 
         // Ensure the input is not empty.
         if input.is_empty() {

--- a/circuit/environment/src/helpers/linear_combination.rs
+++ b/circuit/environment/src/helpers/linear_combination.rs
@@ -188,7 +188,7 @@ impl<F: PrimeField> From<Variable<F>> for LinearCombination<F> {
 
 impl<F: PrimeField> From<&Variable<F>> for LinearCombination<F> {
     fn from(variable: &Variable<F>) -> Self {
-        Self::from(&[variable.clone()])
+        Self::from(std::slice::from_ref(variable))
     }
 }
 

--- a/circuit/environment/src/helpers/mode.rs
+++ b/circuit/environment/src/helpers/mode.rs
@@ -42,7 +42,7 @@ impl Mode {
 
     /// Parses a string into a mode.
     #[inline]
-    pub fn parse(string: &str) -> ParserResult<Self> {
+    pub fn parse(string: &str) -> ParserResult<'_, Self> {
         alt((
             map(tag("constant"), |_| Self::Constant),
             map(tag("public"), |_| Self::Public),

--- a/circuit/program/src/data/access/mod.rs
+++ b/circuit/program/src/data/access/mod.rs
@@ -68,7 +68,7 @@ impl<A: Aleo> Eject for Access<A> {
 impl<A: Aleo> Parser for Access<A> {
     /// Parses a UTF-8 string into an access.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the identifier from the string.
         let (string, access) = console::Access::parse(string)?;
 

--- a/circuit/program/src/data/identifier/mod.rs
+++ b/circuit/program/src/data/identifier/mod.rs
@@ -99,7 +99,7 @@ impl<A: Aleo> Eject for Identifier<A> {
 impl<A: Aleo> Parser for Identifier<A> {
     /// Parses a UTF-8 string into an identifier.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the identifier from the string.
         let (string, identifier) = console::Identifier::parse(string)?;
 

--- a/circuit/program/src/data/literal/cast/boolean.rs
+++ b/circuit/program/src/data/literal/cast/boolean.rs
@@ -93,7 +93,7 @@ mod tests {
         mode: Mode,
         _: &mut TestRng,
     ) -> (console_root::types::Boolean<MainnetV0>, Boolean<Circuit>) {
-        (console_root::types::Boolean::new(i % 2 == 0), Boolean::new(mode, i % 2 == 0))
+        (console_root::types::Boolean::new(i.is_multiple_of(2)), Boolean::new(mode, i.is_multiple_of(2)))
     }
 
     impl_check_cast!(cast, Boolean<Circuit>, console_root::types::Boolean::<MainnetV0>);

--- a/circuit/program/src/data/literal/cast_lossy/boolean.rs
+++ b/circuit/program/src/data/literal/cast_lossy/boolean.rs
@@ -90,7 +90,7 @@ mod tests {
         mode: Mode,
         _: &mut TestRng,
     ) -> (console_root::types::Boolean<MainnetV0>, Boolean<Circuit>) {
-        (console_root::types::Boolean::new(i % 2 == 0), Boolean::new(mode, i % 2 == 0))
+        (console_root::types::Boolean::new(i.is_multiple_of(2)), Boolean::new(mode, i.is_multiple_of(2)))
     }
 
     check_cast_lossy!(cast_lossy, Boolean<Circuit>, console_root::types::Boolean::<MainnetV0>);

--- a/circuit/program/src/data/literal/mod.rs
+++ b/circuit/program/src/data/literal/mod.rs
@@ -184,7 +184,7 @@ impl<A: Aleo> Eject for Literal<A> {
 impl<A: Aleo> Parser for Literal<A> {
     /// Parses a string into a literal.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         alt((
             map(Address::parse, |literal| Self::Address(literal)),
             map(Boolean::parse, |literal| Self::Boolean(literal)),

--- a/circuit/program/src/request/verify.rs
+++ b/circuit/program/src/request/verify.rs
@@ -74,7 +74,7 @@ impl<A: Aleo> Request<A> {
         // Verify the transition public key and commitments are well-formed.
         let tpk_checks = {
             // Compute the transition commitment as `Hash(tvk)`.
-            let tcm = A::hash_psd2(&[self.tvk.clone()]);
+            let tcm = A::hash_psd2(std::slice::from_ref(&self.tvk));
             // Compute the signer commitment as `Hash(signer || root_tvk)`.
             let scm = A::hash_psd2(&[self.signer.to_field(), root_tvk]);
 

--- a/circuit/types/address/src/lib.rs
+++ b/circuit/types/address/src/lib.rs
@@ -76,7 +76,7 @@ impl<E: Environment> Eject for Address<E> {
 impl<E: Environment> Parser for Address<E> {
     /// Parses a string into an address circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the address from the string.
         let (string, address) = console::Address::parse(string)?;
         // Parse the mode from the string.

--- a/circuit/types/boolean/src/lib.rs
+++ b/circuit/types/boolean/src/lib.rs
@@ -104,7 +104,7 @@ impl<E: Environment> Eject for Boolean<E> {
 impl<E: Environment> Parser for Boolean<E> {
     /// Parses a string into a boolean circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the boolean from the string.
         let (string, boolean) = console::Boolean::<E::Network>::parse(string)?;
         // Parse the mode from the string.

--- a/circuit/types/field/src/lib.rs
+++ b/circuit/types/field/src/lib.rs
@@ -90,7 +90,7 @@ impl<E: Environment> Eject for Field<E> {
 impl<E: Environment> Parser for Field<E> {
     /// Parses a string into a field circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the field from the string.
         let (string, field) = console::Field::parse(string)?;
         // Parse the mode from the string.

--- a/circuit/types/group/src/lib.rs
+++ b/circuit/types/group/src/lib.rs
@@ -166,7 +166,7 @@ impl<E: Environment> Eject for Group<E> {
 impl<E: Environment> Parser for Group<E> {
     /// Parses a string into a group circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the group from the string.
         let (string, group) = console::Group::parse(string)?;
         // Parse the mode from the string.

--- a/circuit/types/integers/src/lib.rs
+++ b/circuit/types/integers/src/lib.rs
@@ -137,7 +137,7 @@ impl<E: Environment, I: IntegerType> Eject for Integer<E, I> {
 impl<E: Environment, I: IntegerType> Parser for Integer<E, I> {
     /// Parses a string into an integer circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the integer from the string.
         let (string, integer) = console::Integer::parse(string)?;
         // Parse the mode from the string.

--- a/circuit/types/scalar/src/lib.rs
+++ b/circuit/types/scalar/src/lib.rs
@@ -83,7 +83,7 @@ impl<E: Environment> Eject for Scalar<E> {
 impl<E: Environment> Parser for Scalar<E> {
     /// Parses a string into a scalar circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the scalar from the string.
         let (string, scalar) = console::Scalar::parse(string)?;
         // Parse the mode from the string.

--- a/circuit/types/string/src/helpers/from_bits.rs
+++ b/circuit/types/string/src/helpers/from_bits.rs
@@ -45,7 +45,7 @@ impl<E: Environment> StringType<E> {
     fn inject_size_in_bytes(mode: Mode, bits: &[Boolean<E>]) -> Field<E> {
         // Ensure the bits are byte-aligned.
         let num_bits = bits.len();
-        if num_bits % 8 != 0 {
+        if !num_bits.is_multiple_of(8) {
             E::halt(format!("Attempted to instantiate a {num_bits}-bit string, which is not byte-aligned"))
         }
 

--- a/circuit/types/string/src/identifier_literal/mod.rs
+++ b/circuit/types/string/src/identifier_literal/mod.rs
@@ -90,7 +90,7 @@ impl<E: Environment> Eject for IdentifierLiteral<E> {
 impl<E: Environment> Parser for IdentifierLiteral<E> {
     /// Parses a string into an identifier literal circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the content from the string.
         let (string, content) = console::IdentifierLiteral::parse(string)?;
         // Parse the mode from the string.

--- a/circuit/types/string/src/lib.rs
+++ b/circuit/types/string/src/lib.rs
@@ -101,7 +101,7 @@ impl<E: Environment> Eject for StringType<E> {
 impl<E: Environment> Parser for StringType<E> {
     /// Parses a string into a string circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the content from the string.
         let (string, content) = console::StringType::parse(string)?;
         // Parse the mode from the string.

--- a/console/account/src/signature/parse.rs
+++ b/console/account/src/signature/parse.rs
@@ -20,7 +20,7 @@ static SIGNATURE_PREFIX: &str = "sign";
 impl<N: Network> Parser for Signature<N> {
     /// Parses a string into an signature.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Prepare a parser for the Aleo signature.
         let parse_signature = recognize(pair(
             pair(tag(SIGNATURE_PREFIX), tag("1")),

--- a/console/algorithms/src/bhp/hasher/hash_uncompressed.rs
+++ b/console/algorithms/src/bhp/hasher/hash_uncompressed.rs
@@ -48,7 +48,7 @@ impl<E: Environment, const NUM_WINDOWS: u8, const WINDOW_SIZE: u8> HashUncompres
             let padding = BHP_CHUNK_SIZE - (input.len() % BHP_CHUNK_SIZE);
             let mut padded_input = vec![false; input.len() + padding];
             padded_input[..input.len()].copy_from_slice(input);
-            ensure!((padded_input.len() % BHP_CHUNK_SIZE) == 0, "Input must be a multiple of {BHP_CHUNK_SIZE}");
+            ensure!(padded_input.len().is_multiple_of(BHP_CHUNK_SIZE), "Input must be a multiple of {BHP_CHUNK_SIZE}");
             Cow::Owned(padded_input)
         } else {
             Cow::Borrowed(input)

--- a/console/algorithms/src/blake2xs/mod.rs
+++ b/console/algorithms/src/blake2xs/mod.rs
@@ -44,7 +44,7 @@ impl Blake2Xs {
         for node_offset in 0..num_rounds {
             // Calculate the digest length for this round.
             let is_final_round = node_offset == num_rounds - 1;
-            let has_remainder = xof_digest_length % 32 != 0;
+            let has_remainder = !xof_digest_length.is_multiple_of(32);
             let digest_length = match is_final_round && has_remainder {
                 true => (xof_digest_length % 32) as usize,
                 false => 32,

--- a/console/algorithms/src/poseidon/helpers/sponge.rs
+++ b/console/algorithms/src/poseidon/helpers/sponge.rs
@@ -165,7 +165,7 @@ impl<E: Environment, const RATE: usize, const CAPACITY: usize> PoseidonSponge<E,
                 (num_elements_remaining / RATE) +
                 // And also add 1 if the last chunk is non-empty
                 // (i.e. if `num_elements_remaining` is not a multiple of `RATE`)
-                usize::from((num_elements_remaining % RATE) != 0);
+                usize::from(!num_elements_remaining.is_multiple_of(RATE));
 
             // Absorb the input elements, `RATE` elements at a time, except for the first chunk, which
             // is of size `RATE - rate_start`.
@@ -203,7 +203,7 @@ impl<E: Environment, const RATE: usize, const CAPACITY: usize> PoseidonSponge<E,
                 (num_output_remaining / RATE) +
                 // And also add 1 if the last chunk is non-empty
                 // (i.e. if `num_output_remaining` is not a multiple of `RATE`)
-                usize::from((num_output_remaining % RATE) != 0);
+                usize::from(!num_output_remaining.is_multiple_of(RATE));
 
             // Absorb the input output, `RATE` output at a time, except for the first chunk, which
             // is of size `RATE - rate_start`.

--- a/console/collections/src/kary_merkle_tree/tests/mod.rs
+++ b/console/collections/src/kary_merkle_tree/tests/mod.rs
@@ -26,7 +26,6 @@ macro_rules! run_tests {
         $( assert!(run_test::<$i, $i>($rng).is_ok()); )*
     };
 }
-use run_tests;
 
 /// Runs the following test:
 /// 1. Construct the Merkle tree for the leaves.

--- a/console/network/environment/src/helpers/sanitizer.rs
+++ b/console/network/environment/src/helpers/sanitizer.rs
@@ -29,22 +29,22 @@ pub struct Sanitizer;
 
 impl Sanitizer {
     /// Removes all leading whitespaces and comments from the given input, returning the sanitized input.
-    pub fn parse(string: &str) -> ParserResult<&str> {
+    pub fn parse(string: &str) -> ParserResult<'_, &str> {
         preceded(Self::parse_whitespaces, Self::parse_comments)(string)
     }
 
     /// Removes leading whitespaces from the given input.
-    pub fn parse_whitespaces(string: &str) -> ParserResult<&str> {
+    pub fn parse_whitespaces(string: &str) -> ParserResult<'_, &str> {
         recognize(Self::many0_(alt((multispace1, tag("\\\n")))))(string)
     }
 
     /// Removes multiple leading comments from the given input.
-    pub fn parse_comments(string: &str) -> ParserResult<&str> {
+    pub fn parse_comments(string: &str) -> ParserResult<'_, &str> {
         recognize(Self::many0_(terminated(Self::parse_comment, Self::parse_whitespaces)))(string)
     }
 
     /// Removes the first leading comment from the given input.
-    pub fn parse_comment(string: &str) -> ParserResult<&str> {
+    pub fn parse_comment(string: &str) -> ParserResult<'_, &str> {
         preceded(
             char('/'),
             alt((preceded(char('/'), cut(Self::str_till_eol)), preceded(char('*'), cut(Self::str_till_star_slash)))),
@@ -63,7 +63,7 @@ impl Sanitizer {
     /// However, simple experiments show that it matches a Unicode character,
     /// e.g. attempting to parse `"\u{4141}"` yields one CJK character and exhausts the input,
     /// as opposed to returning `A` and leaving another `A` in the input.
-    pub fn parse_safe_char(string: &str) -> ParserResult<char> {
+    pub fn parse_safe_char(string: &str) -> ParserResult<'_, char> {
         fn is_safe(ch: &char) -> bool {
             is_char_supported(*ch)
         }
@@ -75,7 +75,7 @@ impl Sanitizer {
     /// End-of-input parser.
     ///
     /// Yields `()` if the parser is at the end of the input; an error otherwise.
-    fn eoi(string: &str) -> ParserResult<()> {
+    fn eoi(string: &str) -> ParserResult<'_, ()> {
         match string.is_empty() {
             true => Ok((string, ())),
             false => {
@@ -87,7 +87,7 @@ impl Sanitizer {
     /// A parser that accepts:
     /// - A newline, either `CR LF` or just `LF`.
     /// - The end of input.
-    fn eol(string: &str) -> ParserResult<()> {
+    fn eol(string: &str) -> ParserResult<'_, ()> {
         alt((
             Self::eoi, // this one goes first because it’s very cheap
             value((), line_ending),
@@ -119,7 +119,7 @@ impl Sanitizer {
     /// Return the body of the comment, i.e. what is between `//` and the end of line.
     /// If the line ends with `CR LF`, the `CR` is included in the returned body.
     /// The `LF`, if present, is never included in the returned body.
-    fn str_till_eol(string: &str) -> ParserResult<&str> {
+    fn str_till_eol(string: &str) -> ParserResult<'_, &str> {
         // A heuristic approach is applied here in order to avoid costly parsing operations in the
         // most common scenarios: non-parsing methods are used to verify if the string has multiple
         // lines and if there are any unsafe characters.
@@ -165,7 +165,7 @@ impl Sanitizer {
     /// This is used to parse the body of a block comment, after the opening `/*`.
     ///
     /// Return the body of the comment, i.e. what is between `/*` and `*/`.
-    fn str_till_star_slash(string: &str) -> ParserResult<&str> {
+    fn str_till_star_slash(string: &str) -> ParserResult<'_, &str> {
         map(recognize(Self::till(value((), Sanitizer::parse_safe_char), tag("*/"))), |i| {
             &i[0..i.len() - 2] // subtract 2 to discard the closing `*/`
         })(string)

--- a/console/network/environment/src/traits/parse.rs
+++ b/console/network/environment/src/traits/parse.rs
@@ -36,7 +36,7 @@ pub fn convert_result<'a, O>(result: ParserResult<'a, O>, input: &'a str) -> Str
 /// Operations to parse a string literal into an object.
 pub trait Parser: core::fmt::Display + core::str::FromStr {
     /// Parses a string literal into an object.
-    fn parse(string: &str) -> ParserResult<Self>
+    fn parse(string: &str) -> ParserResult<'_, Self>
     where
         Self: Sized;
 }

--- a/console/network/environment/src/traits/parse_string.rs
+++ b/console/network/environment/src/traits/parse_string.rs
@@ -229,7 +229,7 @@ pub mod string_parser {
 #[test]
 fn test_parse_string() {
     // to use parse_string_wrapper instead of string_parser::parse_string::<nom::error::VerboseError<&str>> in the tests below:
-    fn parse_string_wrapper(input: &str) -> crate::ParserResult<String> {
+    fn parse_string_wrapper(input: &str) -> crate::ParserResult<'_, String> {
         string_parser::parse_string(input)
     }
 

--- a/console/program/src/data/access/parse.rs
+++ b/console/program/src/data/access/parse.rs
@@ -16,7 +16,7 @@
 use super::*;
 
 impl<N: Network> Parser for Access<N> {
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         alt((
             map(pair(tag("["), pair(U32::parse, tag("]"))), |(_, (index, _))| Self::Index(index)),
             map(pair(tag("."), Identifier::parse), |(_, identifier)| Self::Member(identifier)),

--- a/console/program/src/data/ciphertext/parse.rs
+++ b/console/program/src/data/ciphertext/parse.rs
@@ -20,7 +20,7 @@ static CIPHERTEXT_PREFIX: &str = "ciphertext";
 impl<N: Network> Parser for Ciphertext<N> {
     /// Parses a string into an ciphertext.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Prepare a parser for the Aleo ciphertext.
         let parse_ciphertext = recognize(pair(
             pair(tag(CIPHERTEXT_PREFIX), tag("1")),

--- a/console/program/src/data/dynamic/future/parse.rs
+++ b/console/program/src/data/dynamic/future/parse.rs
@@ -22,7 +22,7 @@ impl<N: Network> Parser for DynamicFuture<N> {
     /// - Human-readable: `{ _program_id: foo.aleo, _function_name: bar, _checksum: 0field }`
     /// - Raw field: `{ _program_name: 0field, _program_network: 0field, _function_name: 0field, _checksum: 0field }`
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Try to parse the human-readable format first.
         if let Ok(result) = Self::parse_human_readable(string) {
             return Ok(result);
@@ -34,7 +34,7 @@ impl<N: Network> Parser for DynamicFuture<N> {
 
 impl<N: Network> DynamicFuture<N> {
     /// Parses the human-readable format: `{ _program_id: foo.aleo, _function_name: bar, _checksum: 0field }`.
-    fn parse_human_readable(string: &str) -> ParserResult<Self> {
+    fn parse_human_readable(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the "{" from the string.
@@ -102,7 +102,7 @@ impl<N: Network> DynamicFuture<N> {
     }
 
     /// Parses the raw field format: `{ _program_name: 0field, _program_network: 0field, _function_name: 0field, _checksum: 0field }`.
-    fn parse_raw_fields(string: &str) -> ParserResult<Self> {
+    fn parse_raw_fields(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the "{" from the string.
@@ -217,14 +217,14 @@ impl<N: Network> Display for DynamicFuture<N> {
         let function_name_id = Identifier::<N>::from_field(&self.function_name);
 
         // If all conversions succeed, display human-readable format.
-        if let (Ok(name), Ok(network), Ok(function)) = (program_name_id, program_network_id, function_name_id) {
-            if let Ok(program_id) = ProgramID::try_from((name, network)) {
-                return write!(
-                    f,
-                    "{{ _program_id: {program_id}, _function_name: {function}, _checksum: {} }}",
-                    self.checksum()
-                );
-            }
+        if let (Ok(name), Ok(network), Ok(function)) = (program_name_id, program_network_id, function_name_id)
+            && let Ok(program_id) = ProgramID::try_from((name, network))
+        {
+            return write!(
+                f,
+                "{{ _program_id: {program_id}, _function_name: {function}, _checksum: {} }}",
+                self.checksum()
+            );
         }
 
         // Fall back to raw field format.

--- a/console/program/src/data/dynamic/record/parse.rs
+++ b/console/program/src/data/dynamic/record/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for DynamicRecord<N> {
     /// Parses a string as a dynamic record: `{ owner: address, _root: field, _nonce: group, _version: u8 }`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the "{" from the string.

--- a/console/program/src/data/future/parse.rs
+++ b/console/program/src/data/future/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for Future<N> {
     /// Parses a string into a future value.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the future from the string.
         Self::parse_internal(string, 0)
     }
@@ -26,7 +26,7 @@ impl<N: Network> Parser for Future<N> {
 
 impl<N: Network> Future<N> {
     /// Parses an array of future arguments: `[arg_0, ..., arg_1]`, while tracking the depth of the data.
-    fn parse_arguments(string: &str, depth: usize) -> ParserResult<Vec<Argument<N>>> {
+    fn parse_arguments(string: &str, depth: usize) -> ParserResult<'_, Vec<Argument<N>>> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the "[" from the string.
@@ -52,7 +52,7 @@ impl<N: Network> Future<N> {
 
     /// Parses a string into a future value, while tracking the depth of the data.
     #[inline]
-    fn parse_internal(string: &str, depth: usize) -> ParserResult<Self> {
+    fn parse_internal(string: &str, depth: usize) -> ParserResult<'_, Self> {
         // Ensure that the depth is within the maximum limit.
         // Note: `N::MAX_DATA_DEPTH` is an upper bound on the number of nested futures.
         //  The true maximum is defined by `Transaction::<N>::MAX_TRANSITIONS`, however, that object is not accessible in this crate.

--- a/console/program/src/data/identifier/parse.rs
+++ b/console/program/src/data/identifier/parse.rs
@@ -23,7 +23,7 @@ impl<N: Network> Parser for Identifier<N> {
     /// The identifier must not start with a number.
     /// The identifier must not be a keyword.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Check for alphanumeric characters and underscores.
         map_res(recognize(pair(alpha1, many0(alt((alphanumeric1, tag("_")))))), |identifier: &str| {
             Self::from_str(identifier)

--- a/console/program/src/data/literal/parse.rs
+++ b/console/program/src/data/literal/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for Literal<N> {
     /// Parses a string into a literal.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         alt((
             map(Address::<N>::parse, |literal| Self::Address(literal)),
             map(Boolean::<N>::parse, |literal| Self::Boolean(literal)),

--- a/console/program/src/data/plaintext/parse.rs
+++ b/console/program/src/data/plaintext/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for Plaintext<N> {
     /// Parses a string into a plaintext value.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the string into a plaintext value.
         Self::parse_internal(string, 0)
     }
@@ -26,7 +26,7 @@ impl<N: Network> Parser for Plaintext<N> {
 
 impl<N: Network> Plaintext<N> {
     /// Parses a sanitized pair: `identifier: plaintext`.
-    fn parse_pair(string: &str, depth: usize) -> ParserResult<(Identifier<N>, Self)> {
+    fn parse_pair(string: &str, depth: usize) -> ParserResult<'_, (Identifier<N>, Self)> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the identifier from the string.
@@ -44,7 +44,7 @@ impl<N: Network> Plaintext<N> {
     }
 
     /// Parses a plaintext as a struct: `{ identifier_0: plaintext_0, ..., identifier_n: plaintext_n }`.
-    fn parse_struct(string: &str, depth: usize) -> ParserResult<Self> {
+    fn parse_struct(string: &str, depth: usize) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the "{" from the string.
@@ -71,7 +71,7 @@ impl<N: Network> Plaintext<N> {
     }
 
     /// Parses a plaintext as an array: `[plaintext_0, ..., plaintext_n]`.
-    fn parse_array(string: &str, depth: usize) -> ParserResult<Self> {
+    fn parse_array(string: &str, depth: usize) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the "[" from the string.
@@ -87,7 +87,7 @@ impl<N: Network> Plaintext<N> {
     }
 
     /// Parses a string into a plaintext value, while tracking the depth of the data.
-    fn parse_internal(string: &str, depth: usize) -> ParserResult<Self> {
+    fn parse_internal(string: &str, depth: usize) -> ParserResult<'_, Self> {
         // Ensure that the depth is within the maximum limit.
         if depth > N::MAX_DATA_DEPTH {
             return map_res(take(0usize), |_| {

--- a/console/program/src/data/record/entry/parse.rs
+++ b/console/program/src/data/record/entry/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for Entry<N, Plaintext<N>> {
     /// Parses a string into the entry.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// A helper enum encoding the visibility.
         #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
         enum Mode {
@@ -28,7 +28,7 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
         }
 
         /// Parses a sanitized pair: `identifier: entry`, while tracking the depth of the data.
-        fn parse_pair<N: Network>(string: &str, depth: usize) -> ParserResult<(Identifier<N>, Plaintext<N>, Mode)> {
+        fn parse_pair<N: Network>(string: &str, depth: usize) -> ParserResult<'_, (Identifier<N>, Plaintext<N>, Mode)> {
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the identifier from the string.
@@ -55,7 +55,7 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
         }
 
         /// Parses an entry as a literal: `literal.visibility`, while tracking the depth of the data.
-        fn parse_literal<N: Network>(string: &str, depth: usize) -> ParserResult<(Plaintext<N>, Mode)> {
+        fn parse_literal<N: Network>(string: &str, depth: usize) -> ParserResult<'_, (Plaintext<N>, Mode)> {
             // Ensure that the depth is within the maximum limit.
             if depth > N::MAX_DATA_DEPTH {
                 return map_res(take(0usize), |_| {
@@ -71,7 +71,7 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
 
         /// Parses an entry as a struct: `{ identifier_0: plaintext_0.visibility, ..., identifier_n: plaintext_n.visibility }`, while tracking the depth of the data.
         /// Observe the `visibility` is the same for all members of the plaintext value.
-        fn parse_struct<N: Network>(string: &str, depth: usize) -> ParserResult<(Plaintext<N>, Mode)> {
+        fn parse_struct<N: Network>(string: &str, depth: usize) -> ParserResult<'_, (Plaintext<N>, Mode)> {
             // Ensure that the depth is within the maximum limit.
             if depth > N::MAX_DATA_DEPTH {
                 return map_res(take(0usize), |_| {
@@ -114,7 +114,7 @@ impl<N: Network> Parser for Entry<N, Plaintext<N>> {
 
         /// Parses an entry as an array: `[plaintext_0.visibility, ..., plaintext_n.visibility]`, while tracking the depth of the data.
         /// Observe the `visibility` is the same for all members of the plaintext value.
-        fn parse_array<N: Network>(string: &str, depth: usize) -> ParserResult<(Plaintext<N>, Mode)> {
+        fn parse_array<N: Network>(string: &str, depth: usize) -> ParserResult<'_, (Plaintext<N>, Mode)> {
             // Ensure that the depth is within the maximum limit.
             if depth > N::MAX_DATA_DEPTH {
                 return map_res(take(0usize), |_| {

--- a/console/program/src/data/record/parse_ciphertext.rs
+++ b/console/program/src/data/record/parse_ciphertext.rs
@@ -20,7 +20,7 @@ static RECORD_CIPHERTEXT_PREFIX: &str = "record";
 impl<N: Network> Parser for Record<N, Ciphertext<N>> {
     /// Parses a string into an ciphertext.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Prepare a parser for the record ciphertext.
         let parse_record_ciphertext = recognize(pair(
             pair(tag(RECORD_CIPHERTEXT_PREFIX), tag("1")),

--- a/console/program/src/data/record/parse_plaintext.rs
+++ b/console/program/src/data/record/parse_plaintext.rs
@@ -18,10 +18,10 @@ use super::*;
 impl<N: Network> Parser for Record<N, Plaintext<N>> {
     /// Parses a string as a record: `{ owner: address, identifier_0: entry_0, ..., identifier_n: entry_n, _nonce: field, _version: u8 }`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Parses a sanitized pair: `identifier: entry`.
         #[allow(clippy::type_complexity)]
-        fn parse_pair<N: Network>(string: &str) -> ParserResult<(Identifier<N>, Entry<N, Plaintext<N>>)> {
+        fn parse_pair<N: Network>(string: &str) -> ParserResult<'_, (Identifier<N>, Entry<N, Plaintext<N>>)> {
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the identifier from the string.

--- a/console/program/src/data/register/parse.rs
+++ b/console/program/src/data/register/parse.rs
@@ -19,7 +19,7 @@ impl<N: Network> Parser for Register<N> {
     /// Parses a string into a register.
     /// The register is of the form `r{locator}` or `r{locator}.{identifier}`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the register character from the string.
         let (string, _) = tag("r")(string)?;
         // Parse the locator from the string.

--- a/console/program/src/data/value/parse.rs
+++ b/console/program/src/data/value/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for Value<N> {
     /// Parses a string into a value.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Note that the order of the parsers matters.
         alt((
             map(Future::parse, Value::Future),

--- a/console/program/src/data_types/array_type/parse.rs
+++ b/console/program/src/data_types/array_type/parse.rs
@@ -19,9 +19,9 @@ use crate::{Identifier, LiteralType, Locator};
 impl<N: Network> Parser for ArrayType<N> {
     /// Parses a string into a literal type.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // A helper function to parse the innermost element type.
-        fn parse_inner_element_type<N: Network>(string: &str) -> ParserResult<PlaintextType<N>> {
+        fn parse_inner_element_type<N: Network>(string: &str) -> ParserResult<'_, PlaintextType<N>> {
             // Order matters - we shouldn't try to parse Identifier before Locator.
             alt((
                 map(Locator::parse, PlaintextType::from),
@@ -31,7 +31,7 @@ impl<N: Network> Parser for ArrayType<N> {
         }
 
         // A helper function to parse the length of each dimension.
-        fn parse_length<N: Network>(string: &str) -> ParserResult<U32<N>> {
+        fn parse_length<N: Network>(string: &str) -> ParserResult<'_, U32<N>> {
             // Parse the whitespaces from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Parse the semicolon from the string.

--- a/console/program/src/data_types/finalize_type/parse.rs
+++ b/console/program/src/data_types/finalize_type/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for FinalizeType<N> {
     /// Parses a string into a finalize type.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the mode from the string (ordering matters).
         alt((
             map(tag("dynamic.future"), |_| Self::DynamicFuture),

--- a/console/program/src/data_types/literal_type/parse.rs
+++ b/console/program/src/data_types/literal_type/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl Parser for LiteralType {
     /// Parses a string into a literal type.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the type from the string.
         alt((
             map(tag(Self::Address.type_name()), |_| Self::Address),

--- a/console/program/src/data_types/plaintext_type/parse.rs
+++ b/console/program/src/data_types/plaintext_type/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for PlaintextType<N> {
     /// Parses a string into a plaintext type.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse to determine the plaintext type (order matters).
         alt((
             // Order matters - we shouldn't try to parse Identifier before Locator.

--- a/console/program/src/data_types/record_type/entry_type/parse.rs
+++ b/console/program/src/data_types/record_type/entry_type/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for EntryType<N> {
     /// Parses a string into the entry type.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the mode from the string.
         alt((
             map(pair(PlaintextType::parse, tag(".constant")), |(plaintext_type, _)| Self::Constant(plaintext_type)),

--- a/console/program/src/data_types/record_type/parse.rs
+++ b/console/program/src/data_types/record_type/parse.rs
@@ -23,9 +23,9 @@ impl<N: Network> Parser for RecordType<N> {
     ///       user_defined as u64.public;
     /// ```
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Parses a string into a tuple.
-        fn parse_entry<N: Network>(string: &str) -> ParserResult<(Identifier<N>, EntryType<N>)> {
+        fn parse_entry<N: Network>(string: &str) -> ParserResult<'_, (Identifier<N>, EntryType<N>)> {
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the identifier from the string.

--- a/console/program/src/data_types/register_type/parse.rs
+++ b/console/program/src/data_types/register_type/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for RegisterType<N> {
     /// Parses a string into a register type.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the mode from the string (ordering matters).
         alt((
             map(tag("dynamic.record"), |_| Self::DynamicRecord),

--- a/console/program/src/data_types/struct_type/parse.rs
+++ b/console/program/src/data_types/struct_type/parse.rs
@@ -23,9 +23,9 @@ impl<N: Network> Parser for StructType<N> {
     ///       amount as u64;
     /// ```
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Parses a string into a tuple.
-        fn parse_tuple<N: Network>(string: &str) -> ParserResult<(Identifier<N>, PlaintextType<N>)> {
+        fn parse_tuple<N: Network>(string: &str) -> ParserResult<'_, (Identifier<N>, PlaintextType<N>)> {
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
             // Parse the identifier from the string.

--- a/console/program/src/data_types/value_type/parse.rs
+++ b/console/program/src/data_types/value_type/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for ValueType<N> {
     /// Parses the string into a value type.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the mode from the string.
         // Note that the order of the parsers matters.
         alt((

--- a/console/program/src/id/parse.rs
+++ b/console/program/src/id/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for ProgramID<N> {
     /// Parses a string into a program ID of the form `{name}.{network}`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the name, ".", and network-level domain (NLD) from the string.
         map_res(pair(Identifier::parse, pair(tag("."), Identifier::parse)), |(name, (_, network))| {
             // Return the program ID.

--- a/console/program/src/locator/parse.rs
+++ b/console/program/src/locator/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for Locator<N> {
     /// Parses a string into a locator of the form `{program_id}/{resource}`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the program ID from the string.
         let (string, id) = ProgramID::parse(string)?;
         // Parse the "/" and resource from the string.

--- a/console/program/src/state_path/mod.rs
+++ b/console/program/src/state_path/mod.rs
@@ -82,14 +82,14 @@ impl<N: Network> StatePath<N> {
     ) -> Result<Self> {
         // Compute an arbitrary transactions path.
         let local_state_root_bits = local_state_root.to_bits_le();
-        let transactions_tree: TransactionsTree<N> = N::merkle_tree_bhp(&[local_state_root_bits.clone()])?;
+        let transactions_tree: TransactionsTree<N> = N::merkle_tree_bhp(std::slice::from_ref(&local_state_root_bits))?;
         let transactions_path = transactions_tree.prove(0, &local_state_root_bits)?;
         let transactions_root = transactions_tree.root();
 
         // Compute an arbitrary block header path.
         let header_leaf = HeaderLeaf::<N>::new(0, *transactions_root);
         let header_leaf_bits = header_leaf.to_bits_le();
-        let header_tree: HeaderTree<N> = N::merkle_tree_bhp(&[header_leaf_bits.clone()])?;
+        let header_tree: HeaderTree<N> = N::merkle_tree_bhp(std::slice::from_ref(&header_leaf_bits))?;
         let header_path = header_tree.prove(0, &header_leaf_bits)?;
         let header_root = *header_tree.root();
 
@@ -97,7 +97,7 @@ impl<N: Network> StatePath<N> {
         let previous_block_hash: N::BlockHash = Field::<N>::zero().into();
         let block_hash: N::BlockHash = previous_block_hash;
         let block_hash_bits = block_hash.to_bits_le();
-        let block_tree: BlockTree<N> = N::merkle_tree_bhp(&[block_hash_bits.clone()])?;
+        let block_tree: BlockTree<N> = N::merkle_tree_bhp(std::slice::from_ref(&block_hash_bits))?;
         let block_path = block_tree.prove(0, &block_hash_bits)?;
 
         // Return the state path.

--- a/console/program/src/state_path/parse.rs
+++ b/console/program/src/state_path/parse.rs
@@ -20,7 +20,7 @@ static STATE_PATH_PREFIX: &str = "path";
 impl<N: Network> Parser for StatePath<N> {
     /// Parses a string into the state path.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Prepare a parser for the Aleo state path.
         let parse_state_path = recognize(pair(
             pair(tag(STATE_PATH_PREFIX), tag("1")),

--- a/console/types/address/src/parse.rs
+++ b/console/types/address/src/parse.rs
@@ -20,7 +20,7 @@ static ADDRESS_PREFIX: &str = "aleo";
 impl<E: Environment> Parser for Address<E> {
     /// Parses a string into an address.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Prepare a parser for the Aleo address.
         let parse_address = recognize(pair(
             tag("aleo1"),

--- a/console/types/boolean/src/parse.rs
+++ b/console/types/boolean/src/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<E: Environment> Parser for Boolean<E> {
     /// Parses a string into a boolean.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the boolean from the string.
         let (string, value) = alt((map(tag("true"), |_| true), map(tag("false"), |_| false)))(string)?;
 

--- a/console/types/field/src/parse.rs
+++ b/console/types/field/src/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<E: Environment> Parser for Field<E> {
     /// Parses a string into a field circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the optional negative sign '-' from the string.
         let (string, negation) = map(opt(tag("-")), |neg: Option<&str>| neg.is_some())(string)?;
         // Parse the digits from the string.

--- a/console/types/group/src/parse.rs
+++ b/console/types/group/src/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<E: Environment> Parser for Group<E> {
     /// Parses a string into a group circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the optional negative sign '-' from the string.
         let (string, negation) = map(opt(tag("-")), |neg: Option<&str>| neg.is_some())(string)?;
         // Parse the digits from the string.

--- a/console/types/integers/src/parse.rs
+++ b/console/types/integers/src/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<E: Environment, I: IntegerType> Parser for Integer<E, I> {
     /// Parses a string into a integer circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the negative sign '-' from the string.
         let (string, negation) = map(opt(tag("-")), |neg: Option<&str>| neg.unwrap_or_default().to_string())(string)?;
         // Parse the digits from the string.

--- a/console/types/scalar/src/parse.rs
+++ b/console/types/scalar/src/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<E: Environment> Parser for Scalar<E> {
     /// Parses a string into a scalar circuit.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the optional negative sign '-' from the string.
         let (string, negation) = map(opt(tag("-")), |neg: Option<&str>| neg.is_some())(string)?;
         // Parse the digits from the string.

--- a/console/types/string/src/identifier_literal/parse.rs
+++ b/console/types/string/src/identifier_literal/parse.rs
@@ -19,7 +19,7 @@ impl<E: Environment> Parser for IdentifierLiteral<E> {
     /// Parses a string into an identifier literal.
     /// Syntax: `'<identifier>'` where identifier matches `[a-zA-Z][a-zA-Z0-9_]*`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Match the opening single quote.
         let (string, _) = tag("'")(string)?;
         // Match identifier content: starts with a letter, followed by alphanumeric or underscore.

--- a/console/types/string/src/parse.rs
+++ b/console/types/string/src/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<E: Environment> Parser for StringType<E> {
     /// Parses a string into a string type.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the starting and ending quote '"' keyword from the string.
         let (string, value) = string_parser::parse_string(string)?;
 

--- a/fields/src/fp12_2over3over2.rs
+++ b/fields/src/fp12_2over3over2.rs
@@ -247,10 +247,10 @@ impl<P: Fp12Parameters> Field for Fp12<P> {
     #[inline]
     fn from_random_bytes_with_flags<F: Flags>(bytes: &[u8]) -> Option<(Self, F)> {
         let split_at = bytes.len() / 2;
-        if let Some(c0) = Fp6::<P::Fp6Params>::from_random_bytes(&bytes[..split_at]) {
-            if let Some((c1, flags)) = Fp6::<P::Fp6Params>::from_random_bytes_with_flags::<F>(&bytes[split_at..]) {
-                return Some((Fp12::new(c0, c1), flags));
-            }
+        if let Some(c0) = Fp6::<P::Fp6Params>::from_random_bytes(&bytes[..split_at])
+            && let Some((c1, flags)) = Fp6::<P::Fp6Params>::from_random_bytes_with_flags::<F>(&bytes[split_at..])
+        {
+            return Some((Fp12::new(c0, c1), flags));
         }
         None
     }

--- a/fields/src/fp2.rs
+++ b/fields/src/fp2.rs
@@ -133,10 +133,10 @@ impl<P: Fp2Parameters> Field for Fp2<P> {
     #[inline]
     fn from_random_bytes_with_flags<F: Flags>(bytes: &[u8]) -> Option<(Self, F)> {
         let split_at = bytes.len() / 2;
-        if let Some(c0) = P::Fp::from_random_bytes(&bytes[..split_at]) {
-            if let Some((c1, flags)) = P::Fp::from_random_bytes_with_flags::<F>(&bytes[split_at..]) {
-                return Some((Fp2::new(c0, c1), flags));
-            }
+        if let Some(c0) = P::Fp::from_random_bytes(&bytes[..split_at])
+            && let Some((c1, flags)) = P::Fp::from_random_bytes_with_flags::<F>(&bytes[split_at..])
+        {
+            return Some((Fp2::new(c0, c1), flags));
         }
         None
     }

--- a/fields/src/fp6_3over2.rs
+++ b/fields/src/fp6_3over2.rs
@@ -195,14 +195,11 @@ impl<P: Fp6Parameters> Field for Fp6<P> {
     #[inline]
     fn from_random_bytes_with_flags<F: Flags>(bytes: &[u8]) -> Option<(Self, F)> {
         let split_at = bytes.len() / 3;
-        if let Some(c0) = Fp2::<P::Fp2Params>::from_random_bytes(&bytes[..split_at]) {
-            if let Some(c1) = Fp2::<P::Fp2Params>::from_random_bytes(&bytes[split_at..2 * split_at]) {
-                if let Some((c2, flags)) =
-                    Fp2::<P::Fp2Params>::from_random_bytes_with_flags::<F>(&bytes[2 * split_at..])
-                {
-                    return Some((Fp6::new(c0, c1, c2), flags));
-                }
-            }
+        if let Some(c0) = Fp2::<P::Fp2Params>::from_random_bytes(&bytes[..split_at])
+            && let Some(c1) = Fp2::<P::Fp2Params>::from_random_bytes(&bytes[split_at..2 * split_at])
+            && let Some((c2, flags)) = Fp2::<P::Fp2Params>::from_random_bytes_with_flags::<F>(&bytes[2 * split_at..])
+        {
+            return Some((Fp6::new(c0, c1, c2), flags));
         }
         None
     }

--- a/fields/src/fp_256.rs
+++ b/fields/src/fp_256.rs
@@ -25,8 +25,6 @@ use crate::{
     PrimeField,
     SquareRootField,
     Zero,
-    impl_add_sub_from_field_ref,
-    impl_mul_div_from_field_ref,
 };
 use snarkvm_utilities::{
     FromBytes,

--- a/fields/src/fp_384.rs
+++ b/fields/src/fp_384.rs
@@ -25,8 +25,6 @@ use crate::{
     PrimeField,
     SquareRootField,
     Zero,
-    impl_add_sub_from_field_ref,
-    impl_mul_div_from_field_ref,
 };
 use snarkvm_utilities::{
     FromBytes,

--- a/fields/src/traits/fft_field.rs
+++ b/fields/src/traits/fft_field.rs
@@ -90,7 +90,7 @@ pub trait FftField: Field + From<u128> + From<u64> + From<u32> + From<u16> + Fro
     fn k_adicity(k: usize, mut n: usize) -> u32 {
         let mut r = 0;
         while n > 1 {
-            if n % k == 0 {
+            if n.is_multiple_of(k) {
                 r += 1;
                 n /= k;
             } else {

--- a/ledger/block/src/transaction/merkle.rs
+++ b/ledger/block/src/transaction/merkle.rs
@@ -50,14 +50,14 @@ impl<N: Network> Transaction<N> {
             }
             Self::Execute(_, _, execution, fee) => {
                 // Check if the ID is the transition ID for the fee.
-                if let Some(fee) = fee {
-                    if *id == **fee.id() {
-                        // Return the transaction leaf.
-                        return Ok(TransactionLeaf::new_execution(
-                            u16::try_from(execution.len())?, // The last index.
-                            *id,
-                        ));
-                    }
+                if let Some(fee) = fee
+                    && *id == **fee.id()
+                {
+                    // Return the transaction leaf.
+                    return Ok(TransactionLeaf::new_execution(
+                        u16::try_from(execution.len())?, // The last index.
+                        *id,
+                    ));
                 }
 
                 // Iterate through the transitions in the execution.

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -163,7 +163,7 @@ impl<N: Network> Subdag<N> {
             "Subdag cannot exceed the maximum number of rounds"
         );
         // Ensure the anchor round is even.
-        ensure!(subdag.iter().next_back().map_or(0, |(r, _)| *r) % 2 == 0, "Anchor round must be even");
+        ensure!(subdag.iter().next_back().map_or(0, |(r, _)| *r).is_multiple_of(2), "Anchor round must be even");
         // Ensure there is only one leader certificate.
         ensure!(subdag.iter().next_back().map_or(0, |(_, c)| c.len()) == 1, "Subdag cannot have multiple leaders");
         // Ensure the rounds are sequential.

--- a/ledger/puzzle/src/lib.rs
+++ b/ledger/puzzle/src/lib.rs
@@ -252,10 +252,10 @@ impl<N: Network> Puzzle<N> {
         // Compute the proof target.
         let proof_target = self.get_proof_target_from_partial_solution(&partial_solution)?;
         // Check that the minimum proof target is met.
-        if let Some(minimum_proof_target) = minimum_proof_target {
-            if proof_target < minimum_proof_target {
-                bail!("Solution was below the minimum proof target ({proof_target} < {minimum_proof_target})")
-            }
+        if let Some(minimum_proof_target) = minimum_proof_target
+            && proof_target < minimum_proof_target
+        {
+            bail!("Solution was below the minimum proof target ({proof_target} < {minimum_proof_target})")
         }
 
         // Construct the solution.

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -156,7 +156,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // If the block is the start of a new epoch, or the epoch hash has not been set,
         // update the current epoch hash and clear the epoch prover cache.
-        if block.height() % N::NUM_BLOCKS_PER_EPOCH == 0 || self.current_epoch_hash.read().is_none() {
+        if block.height().is_multiple_of(N::NUM_BLOCKS_PER_EPOCH) || self.current_epoch_hash.read().is_none() {
             // Update and log the current epoch hash.
             match self.get_epoch_hash(block.height()).ok() {
                 Some(epoch_hash) => {

--- a/ledger/src/get.rs
+++ b/ledger/src/get.rs
@@ -73,7 +73,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
 
         // Get the round number for the previous committee. Note, we subtract 2 from odd rounds,
         // because committees are updated in even rounds.
-        let previous_round = match round % 2 == 0 {
+        let previous_round = match round.is_multiple_of(2) {
             true => round.saturating_sub(1),
             false => round.saturating_sub(2),
         };

--- a/ledger/src/test_helpers/chain_builder.rs
+++ b/ledger/src/test_helpers/chain_builder.rs
@@ -421,7 +421,7 @@ impl<N: Network> TestChainBuilder<N> {
                 cert_count += 1;
 
                 // Check if this batch was an anchor.
-                if round % 2 == 0 {
+                if round.is_multiple_of(2) {
                     let leader = committee.get_leader(round).unwrap();
                     if leader == Address::try_from(private_key_1).unwrap() {
                         created_anchor = true;
@@ -430,7 +430,7 @@ impl<N: Network> TestChainBuilder<N> {
             }
 
             // Anchor was confirmed by more than a third of the validators.
-            if created_anchor && round % 2 == 0 && self.last_block_round < round {
+            if created_anchor && round.is_multiple_of(2) && self.last_block_round < round {
                 self.last_block_round = round;
                 break;
             }

--- a/ledger/src/tests.rs
+++ b/ledger/src/tests.rs
@@ -2168,7 +2168,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &first_private_key,
             ("credits.aleo", "bond_validator"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&first_withdrawal_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
                 Value::<CurrentNetwork>::from_str("10u8").unwrap(),
@@ -2212,7 +2212,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &second_private_key,
             ("credits.aleo", "bond_validator"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&second_withdrawal_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
                 Value::<CurrentNetwork>::from_str("10u8").unwrap(),
@@ -2260,7 +2260,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &first_withdrawal_private_key,
             ("credits.aleo", "unbond_public"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&first_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
             ]
@@ -2278,7 +2278,7 @@ fn test_max_committee_limit_with_bonds() {
         .execute(
             &second_private_key,
             ("credits.aleo", "bond_validator"),
-            vec![
+            [
                 Value::<CurrentNetwork>::from_str(&second_withdrawal_address.to_string()).unwrap(),
                 Value::<CurrentNetwork>::from_str(&format!("{MIN_VALIDATOR_STAKE}u64")).unwrap(),
                 Value::<CurrentNetwork>::from_str("10u8").unwrap(),
@@ -2467,7 +2467,7 @@ finalize foo:
         let mut confirmed_transaction_ids = transactions.iter().map(Transaction::id).collect::<Vec<_>>();
 
         // Randomly insert the aborted transactions.
-        let mut aborted_transactions = vec![aborted_transfer.clone(), aborted_deployment.clone()];
+        let mut aborted_transactions = [aborted_transfer.clone(), aborted_deployment.clone()];
         aborted_transactions.shuffle(rng);
 
         // Randomly insert the aborted transactions.
@@ -3691,8 +3691,8 @@ fn test_forged_block_subdags() -> Result<()> {
         // Build new set of transmissions that matches the modified DAG
         // (we cannot just remove it, because transmissions might be in other batches as well)
         let transmissions: IndexMap<_, _> = subdag
-            .iter()
-            .flat_map(|(_, batches)| batches.iter())
+            .values()
+            .flat_map(|batches| batches.iter())
             .flat_map(|batch| batch.transmission_ids().iter())
             .map(|tid| (*tid, block_2_transmissions.get(tid).unwrap().clone()))
             .collect();
@@ -3776,8 +3776,8 @@ fn test_subdag_with_gc_length() -> Result<()> {
         // Build new set of transmissions that matches the modified DAG
         // (we cannot just remove it, because transmissions might be in other batches as well)
         let transmissions: IndexMap<_, _> = forged_subdag
-            .iter()
-            .flat_map(|(_, batches)| batches.iter())
+            .values()
+            .flat_map(|batches| batches.iter())
             .flat_map(|batch| batch.transmission_ids().iter())
             .map(|tid| (*tid, transmissions.get(tid).unwrap().clone()))
             .collect();
@@ -3945,7 +3945,7 @@ function create_and_consume:
     let record = block.records().collect_vec().last().unwrap().1.decrypt(&view_key).unwrap();
     let transaction = ledger
         .vm()
-        .execute(&private_key, ("child.aleo", "burn"), vec![Value::Record(record)].iter(), None, 0, None, rng)
+        .execute(&private_key, ("child.aleo", "burn"), [Value::Record(record)].iter(), None, 0, None, rng)
         .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transaction], rng).unwrap();
@@ -3994,7 +3994,7 @@ function create_and_consume:
         .execute(
             &private_key,
             ("parent.aleo", "consume_without_call"),
-            vec![Value::Record(mint_record.clone())].iter(),
+            [Value::Record(mint_record.clone())].iter(),
             None,
             0,
             None,
@@ -4018,7 +4018,7 @@ function create_and_consume:
     // Call the `consume` function.
     let transaction = ledger
         .vm()
-        .execute(&private_key, ("parent.aleo", "consume"), vec![Value::Record(mint_record)].iter(), None, 0, None, rng)
+        .execute(&private_key, ("parent.aleo", "consume"), [Value::Record(mint_record)].iter(), None, 0, None, rng)
         .unwrap();
     let block =
         ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![transaction], rng).unwrap();

--- a/ledger/store/src/helpers/rocksdb/internal/map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/map.rs
@@ -625,7 +625,7 @@ impl<K: Serialize + DeserializeOwned, V: Serialize + DeserializeOwned> DataMap<K
         Ok(raw_key)
     }
 
-    fn get_raw<Q>(&self, key: &Q) -> Result<Option<rocksdb::DBPinnableSlice>>
+    fn get_raw<Q>(&self, key: &Q) -> Result<Option<rocksdb::DBPinnableSlice<'_>>>
     where
         K: Borrow<Q>,
         Q: Serialize + ?Sized,

--- a/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/nested_map.rs
@@ -77,7 +77,7 @@ impl<M: Serialize + DeserializeOwned, K: Serialize + DeserializeOwned, V: Serial
     }
 
     #[inline]
-    fn get_map_key_raw(&self, map: &M, key: &K) -> Result<Option<rocksdb::DBPinnableSlice>> {
+    fn get_map_key_raw(&self, map: &M, key: &K) -> Result<Option<rocksdb::DBPinnableSlice<'_>>> {
         let raw_map_key = self.create_prefixed_map_key(map, key)?;
         match self.database.get_pinned_opt(&raw_map_key, &self.database.default_readopts)? {
             Some(data) => Ok(Some(data)),

--- a/ledger/store/src/helpers/rocksdb/internal/tests.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/tests.rs
@@ -183,7 +183,7 @@ fn test_iterator_ordering() {
     map.insert(4, "e".to_string()).expect("Failed to insert");
 
     // Define the expected order of the iterator.
-    let expected_order = vec![
+    let expected_order = [
         (1, "h".to_string()),
         (2, "g".to_string()),
         (3, "f".to_string()),

--- a/ledger/store/src/program/committee.rs
+++ b/ledger/store/src/program/committee.rs
@@ -197,10 +197,10 @@ pub trait CommitteeStorage<N: Network>: 'static + Clone + Send + Sync {
         if is_latest_committee {
             while next_current_round > 0 {
                 // If the next current height is less than the current height, then we have found the next current round.
-                if let Some(next_current_height) = self.get_height_for_round(next_current_round)? {
-                    if next_current_height < current_height {
-                        break;
-                    }
+                if let Some(next_current_height) = self.get_height_for_round(next_current_round)?
+                    && next_current_height < current_height
+                {
+                    break;
                 }
                 // Otherwise, decrement the next current round.
                 next_current_round = next_current_round.saturating_sub(1);

--- a/ledger/store/src/program/finalize.rs
+++ b/ledger/store/src/program/finalize.rs
@@ -841,19 +841,19 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
         }
 
         let spm_guard = self.slipstream_plugin_manager.read();
-        if let Some(mgr) = spm_guard.as_ref() {
-            if mgr.has_subscribers(BroadcastEventKind::StakingReward) {
-                // Address serializes to a fixed 32-byte array; this cannot fail.
-                let staker_bytes = staker.to_bytes_le().expect("Address::to_bytes_le is infallible");
-                let validator_bytes = validator.to_bytes_le().expect("Address::to_bytes_le is infallible");
-                mgr.broadcast(BroadcastEvent::StakingReward {
-                    staker: &staker_bytes,
-                    validator: &validator_bytes,
-                    reward,
-                    new_stake,
-                    block_height,
-                });
-            }
+        if let Some(mgr) = spm_guard.as_ref()
+            && mgr.has_subscribers(BroadcastEventKind::StakingReward)
+        {
+            // Address serializes to a fixed 32-byte array; this cannot fail.
+            let staker_bytes = staker.to_bytes_le().expect("Address::to_bytes_le is infallible");
+            let validator_bytes = validator.to_bytes_le().expect("Address::to_bytes_le is infallible");
+            mgr.broadcast(BroadcastEvent::StakingReward {
+                staker: &staker_bytes,
+                validator: &validator_bytes,
+                reward,
+                new_stake,
+                block_height,
+            });
         }
     }
 

--- a/ledger/store/src/transition/input.rs
+++ b/ledger/store/src/transition/input.rs
@@ -594,7 +594,7 @@ mod tests {
             assert!(candidate.is_empty());
 
             // Insert the transition input.
-            input_store.insert(transition_id, &[input.clone()]).unwrap();
+            input_store.insert(transition_id, std::slice::from_ref(&input)).unwrap();
 
             // Retrieve the transition input.
             let candidate = input_store.get(&transition_id).unwrap();
@@ -625,7 +625,7 @@ mod tests {
             assert!(candidate.is_none());
 
             // Insert the transition input.
-            input_store.insert(transition_id, &[input.clone()]).unwrap();
+            input_store.insert(transition_id, std::slice::from_ref(&input)).unwrap();
 
             // Find the transition ID.
             let candidate = input_store.find_transition_id(input.id()).unwrap();

--- a/ledger/store/src/transition/output.rs
+++ b/ledger/store/src/transition/output.rs
@@ -272,13 +272,13 @@ pub trait OutputStorage<N: Network>: Clone + Send + Sync {
                 self.reverse_id_map().remove(&output_id)?;
 
                 // If the output is a record, remove the record nonce and record sender.
-                if let Some(record) = self.record_map().get_confirmed(&output_id)? {
-                    if let Some(record) = &record.1 {
-                        // Remove the record nonce.
-                        self.record_nonce_map().remove(record.nonce())?;
-                        // Remove the record sender, if it exists.
-                        self.record_sender_map().remove(record.nonce())?;
-                    }
+                if let Some(record) = self.record_map().get_confirmed(&output_id)?
+                    && let Some(record) = &record.1
+                {
+                    // Remove the record nonce.
+                    self.record_nonce_map().remove(record.nonce())?;
+                    // Remove the record sender, if it exists.
+                    self.record_sender_map().remove(record.nonce())?;
                 }
 
                 // Remove the output.
@@ -731,7 +731,7 @@ mod tests {
             assert!(candidate.is_empty());
 
             // Insert the transition output.
-            output_store.insert(transition_id, &[output.clone()]).unwrap();
+            output_store.insert(transition_id, std::slice::from_ref(&output)).unwrap();
 
             // Retrieve the transition output.
             let candidate = output_store.get(&transition_id).unwrap();
@@ -762,7 +762,7 @@ mod tests {
             assert!(candidate.is_none());
 
             // Insert the transition output.
-            output_store.insert(transition_id, &[output.clone()]).unwrap();
+            output_store.insert(transition_id, std::slice::from_ref(&output)).unwrap();
 
             // Find the transition ID.
             let candidate = output_store.find_transition_id(output.id()).unwrap();

--- a/ledger/tests/pending_blocks.rs
+++ b/ledger/tests/pending_blocks.rs
@@ -114,7 +114,7 @@ fn test_prefix_with_duplicate_block_error() {
     assert!(matches!(result, Err(CheckBlockError::InvalidHeight { expected: 2, actual: 3 })));
 
     // But succeed with the prefix.
-    let block3 = ledger.check_block_subdag(block3, &[block2.clone()]).unwrap();
+    let block3 = ledger.check_block_subdag(block3, std::slice::from_ref(&block2)).unwrap();
 
     // Create a forth block
     let block4 = builder.generate_block(rng);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel="1.88"
+channel="1.96"
 components=["cargo", "rustc", "clippy", "rustfmt"]

--- a/synthesizer/benches/check_transaction_multirecord/main.rs
+++ b/synthesizer/benches/check_transaction_multirecord/main.rs
@@ -252,7 +252,7 @@ fn main() {
         println!("Deploying program one_to_many_records.aleo (generating block)");
         let deployment = vm.deploy(&private_key, &program, None, 0, None, rng).unwrap();
 
-        let deployment_block = sample_next_block(&vm, &private_key, &[deployment.clone()], rng).unwrap();
+        let deployment_block = sample_next_block(&vm, &private_key, std::slice::from_ref(&deployment), rng).unwrap();
         assert_eq!(deployment_block.transactions().num_accepted(), 1);
         vm.add_next_block(&deployment_block).unwrap();
 

--- a/synthesizer/process/src/stack/authorization/mod.rs
+++ b/synthesizer/process/src/stack/authorization/mod.rs
@@ -553,13 +553,7 @@ pub(crate) mod test_helpers {
 
         // Generate the Authorization
         let authorization = process
-            .authorize::<CurrentAleo, _>(
-                &private_key,
-                &program_id,
-                &function_name,
-                vec![destination, amount].iter(),
-                rng,
-            )
+            .authorize::<CurrentAleo, _>(&private_key, &program_id, &function_name, [destination, amount].iter(), rng)
             .unwrap();
 
         // Assert there is only 1 transition

--- a/synthesizer/process/src/stack/call/dynamic.rs
+++ b/synthesizer/process/src/stack/call/dynamic.rs
@@ -740,7 +740,7 @@ impl<N: Network> CallTrait<N> for CallDynamic<N> {
             // Inject the `tcm` (from the request) as `Mode::Public`.
             let tcm = circuit::Field::new(circuit::Mode::Public, request.tcm);
             // Compute the transition commitment as `Hash(tvk)`.
-            let candidate_tcm = A::hash_psd2(&[tvk.clone()]);
+            let candidate_tcm = A::hash_psd2(std::slice::from_ref(&tvk));
             // Ensure the transition commitment matches the computed transition commitment.
             A::assert_eq(&tcm, candidate_tcm)?;
 

--- a/synthesizer/process/src/stack/call/standard.rs
+++ b/synthesizer/process/src/stack/call/standard.rs
@@ -506,7 +506,7 @@ impl<N: Network> CallTrait<N> for Call<N> {
             // Inject the `tcm` (from the request) as `Mode::Public`.
             let tcm = circuit::Field::new(circuit::Mode::Public, *request.tcm());
             // Compute the transition commitment as `Hash(tvk)`.
-            let candidate_tcm = A::hash_psd2(&[tvk.clone()]);
+            let candidate_tcm = A::hash_psd2(std::slice::from_ref(&tvk));
             // Ensure the transition commitment matches the computed transition commitment.
             A::assert_eq(&tcm, candidate_tcm)?;
             // Inject the input IDs (from the request) as `Mode::Public`.

--- a/synthesizer/process/src/stack/finalize_types/initialize.rs
+++ b/synthesizer/process/src/stack/finalize_types/initialize.rs
@@ -238,10 +238,10 @@ impl<N: Network> FinalizeTypes<N> {
             // program ID, ensure that the program ID is imported by the current program.
             match operand {
                 Operand::Checksum(program_id) | Operand::Edition(program_id) | Operand::ProgramOwner(program_id) => {
-                    if let Some(program_id) = program_id {
-                        if stack.get_external_stack(program_id).is_err() {
-                            bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id());
-                        }
+                    if let Some(program_id) = program_id
+                        && stack.get_external_stack(program_id).is_err()
+                    {
+                        bail!("External program '{program_id}' is not imported by '{}'.", stack.program_id());
                     }
                 }
                 // If the operand is `Operand::ComponentChecksum`, ensure the referenced component exists.
@@ -866,9 +866,7 @@ impl<N: Network> FinalizeTypes<N> {
         };
 
         // Insert the destination register.
-        for (destination, destination_type) in
-            instruction.destinations().into_iter().zip_eq(destination_types.into_iter())
-        {
+        for (destination, destination_type) in instruction.destinations().into_iter().zip_eq(destination_types) {
             // Ensure the destination register is a locator (and does not reference an access).
             ensure!(matches!(destination, Register::Locator(..)), "Destination '{destination}' must be a locator.");
             // Ensure that the destination type is a plaintext type.

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -184,16 +184,16 @@ impl<N: Network> RegisterTypes<N> {
                 future_registers.pop();
                 // Check only the register operands that are `future` types.
                 for operand in async_.operands() {
-                    if let Operand::Register(register) = operand {
-                        if matches!(
+                    if let Operand::Register(register) = operand
+                        && matches!(
                             register_types.get_type(stack, register)?,
                             RegisterType::Future(_) | RegisterType::DynamicFuture
-                        ) {
-                            ensure!(
-                                future_registers.swap_remove(&register.clone()),
-                                "Could not find future register '{register}' produced before the 'async' instruction.",
-                            );
-                        }
+                        )
+                    {
+                        ensure!(
+                            future_registers.swap_remove(&register.clone()),
+                            "Could not find future register '{register}' produced before the 'async' instruction.",
+                        );
                     }
                 }
                 // Ensure that all the futures created are consumed in the async call.
@@ -377,9 +377,7 @@ impl<N: Network> RegisterTypes<N> {
         let destination_types = instruction.output_types(stack, &operand_types)?;
 
         // Insert the destination register.
-        for (destination, destination_type) in
-            instruction.destinations().into_iter().zip_eq(destination_types.into_iter())
-        {
+        for (destination, destination_type) in instruction.destinations().into_iter().zip_eq(destination_types) {
             // Ensure the destination register is a locator (and does not reference an access).
             ensure!(matches!(destination, Register::Locator(..)), "Destination '{destination}' must be a locator.");
             // Insert the destination register.

--- a/synthesizer/process/src/tests/test_serializers.rs
+++ b/synthesizer/process/src/tests/test_serializers.rs
@@ -143,7 +143,7 @@ function test_serde_equivalence:
             assert_eq!(bits.len(), num_bits as usize, "The number of bits does not match the expected size");
 
             // Construct the inputs.
-            let inputs = vec![Value::Plaintext(plaintext.clone())];
+            let inputs = [Value::Plaintext(plaintext.clone())];
 
             // Generate an authorization.
             let authorization =

--- a/synthesizer/process/src/view.rs
+++ b/synthesizer/process/src/view.rs
@@ -176,7 +176,7 @@ pub(crate) fn evaluate_view_inner<N: Network>(
     }
 
     // Store the inputs.
-    for (input_stmt, value) in view.inputs().iter().zip(inputs.into_iter()) {
+    for (input_stmt, value) in view.inputs().iter().zip(inputs) {
         registers.store(stack, input_stmt.register(), value)?;
     }
 

--- a/synthesizer/program/src/closure/input/parse.rs
+++ b/synthesizer/program/src/closure/input/parse.rs
@@ -22,7 +22,7 @@ impl<N: Network> Parser for Input<N> {
     /// # Errors
     /// This function will halt if the given register is a register member.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the input keyword from the string.

--- a/synthesizer/program/src/closure/output/parse.rs
+++ b/synthesizer/program/src/closure/output/parse.rs
@@ -19,7 +19,7 @@ impl<N: Network> Parser for Output<N> {
     /// Parses a string into an output statement.
     /// The output statement is of the form `output {operand} as {register_type};`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the output keyword from the string.

--- a/synthesizer/program/src/closure/parse.rs
+++ b/synthesizer/program/src/closure/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for ClosureCore<N> {
     /// Parses a string into a closure.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the 'closure' keyword from the string.

--- a/synthesizer/program/src/constructor/parse.rs
+++ b/synthesizer/program/src/constructor/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for ConstructorCore<N> {
     /// Parses a string into constructor.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the 'constructor' keyword from the string.

--- a/synthesizer/program/src/finalize/input/parse.rs
+++ b/synthesizer/program/src/finalize/input/parse.rs
@@ -22,7 +22,7 @@ impl<N: Network> Parser for Input<N> {
     /// # Errors
     /// This finalize will halt if the given register is a register member.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the input keyword from the string.

--- a/synthesizer/program/src/finalize/mod.rs
+++ b/synthesizer/program/src/finalize/mod.rs
@@ -107,10 +107,10 @@ impl<N: Network> FinalizeCore<N> {
     /// Returns `true` if the finalize scope contains an identifier type in its inputs or commands.
     pub fn contains_identifier_type(&self) -> Result<bool> {
         for input_type in self.input_types() {
-            if let FinalizeType::Plaintext(plaintext_type) = input_type {
-                if plaintext_type.contains_identifier_type()? {
-                    return Ok(true);
-                }
+            if let FinalizeType::Plaintext(plaintext_type) = input_type
+                && plaintext_type.contains_identifier_type()?
+            {
+                return Ok(true);
             }
         }
         // Check commands for identifier types in cast destinations.

--- a/synthesizer/program/src/finalize/parse.rs
+++ b/synthesizer/program/src/finalize/parse.rs
@@ -19,7 +19,7 @@ use crate::Command;
 impl<N: Network> Parser for FinalizeCore<N> {
     /// Parses a string into finalize.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the 'finalize' keyword from the string.

--- a/synthesizer/program/src/function/input/parse.rs
+++ b/synthesizer/program/src/function/input/parse.rs
@@ -22,7 +22,7 @@ impl<N: Network> Parser for Input<N> {
     /// # Errors
     /// This function will halt if the given register is a register member.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the input keyword from the string.

--- a/synthesizer/program/src/function/mod.rs
+++ b/synthesizer/program/src/function/mod.rs
@@ -121,10 +121,10 @@ impl<N: Network> FunctionCore<N> {
                 return Ok(true);
             }
         }
-        if let Some(finalize) = &self.finalize_logic {
-            if finalize.contains_identifier_type()? {
-                return Ok(true);
-            }
+        if let Some(finalize) = &self.finalize_logic
+            && finalize.contains_identifier_type()?
+        {
+            return Ok(true);
         }
         Ok(false)
     }

--- a/synthesizer/program/src/function/output/parse.rs
+++ b/synthesizer/program/src/function/output/parse.rs
@@ -19,7 +19,7 @@ impl<N: Network> Parser for Output<N> {
     /// Parses a string into an output statement.
     /// The output statement is of the form `output {operand} as {value_type};`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the output keyword from the string.

--- a/synthesizer/program/src/function/parse.rs
+++ b/synthesizer/program/src/function/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for FunctionCore<N> {
     /// Parses a string into a function.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the 'function' keyword from the string.
@@ -59,11 +59,11 @@ impl<N: Network> Parser for FunctionCore<N> {
                 eprintln!("{error}");
                 return Err(error);
             }
-            if let Some(finalize) = &finalize {
-                if let Err(error) = function.add_finalize(finalize.clone()) {
-                    eprintln!("{error}");
-                    return Err(error);
-                }
+            if let Some(finalize) = &finalize
+                && let Err(error) = function.add_finalize(finalize.clone())
+            {
+                eprintln!("{error}");
+                return Err(error);
             }
             Ok::<_, Error>(function)
         })(string)

--- a/synthesizer/program/src/import/parse.rs
+++ b/synthesizer/program/src/import/parse.rs
@@ -19,7 +19,7 @@ impl<N: Network> Parser for Import<N> {
     /// Parses a string into an import statement of the form `import {name}.{network};`.
     /// If no `network`-level domain is specified, the default network is used.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the import keyword from the string.

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -977,10 +977,10 @@ impl<N: Network> ProgramCore<N> {
         let mut record_names_iter = record_names.iter();
         let mut previous_record_name = record_names_iter.next();
         for record_name in record_names_iter {
-            if let Some(previous) = previous_record_name {
-                if record_name.starts_with(previous) {
-                    bail!("Record name '{previous}' can't be a prefix of record name '{record_name}'.");
-                }
+            if let Some(previous) = previous_record_name
+                && record_name.starts_with(previous)
+            {
+                bail!("Record name '{previous}' can't be a prefix of record name '{record_name}'.");
             }
             previous_record_name = Some(record_name);
         }
@@ -1337,12 +1337,11 @@ impl<N: Network> ProgramCore<N> {
             {
                 return Ok(true);
             }
-            if let Some(finalize) = function.finalize_logic() {
-                if finalize.inputs().iter().any(|input| matches!(input.finalize_type(), FinalizeType::DynamicFuture))
-                    || finalize.commands().iter().any(is_v14_command)
-                {
-                    return Ok(true);
-                }
+            if let Some(finalize) = function.finalize_logic()
+                && (finalize.inputs().iter().any(|input| matches!(input.finalize_type(), FinalizeType::DynamicFuture))
+                    || finalize.commands().iter().any(is_v14_command))
+            {
+                return Ok(true);
             }
             if function.contains_identifier_type()? {
                 return Ok(true);

--- a/synthesizer/program/src/logic/command/await_.rs
+++ b/synthesizer/program/src/logic/command/await_.rs
@@ -60,7 +60,7 @@ impl<N: Network> Await<N> {
 impl<N: Network> Parser for Await<N> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/command/branch.rs
+++ b/synthesizer/program/src/logic/command/branch.rs
@@ -80,7 +80,7 @@ impl<N: Network, const VARIANT: u8> Branch<N, VARIANT> {
 impl<N: Network, const VARIANT: u8> Parser for Branch<N, VARIANT> {
     /// Parses a string into an command.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/command/contains/dynamic.rs
+++ b/synthesizer/program/src/logic/command/contains/dynamic.rs
@@ -143,7 +143,7 @@ impl<N: Network> ContainsDynamic<N> {
 impl<N: Network> Parser for ContainsDynamic<N> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/command/contains/standard.rs
+++ b/synthesizer/program/src/logic/command/contains/standard.rs
@@ -104,7 +104,7 @@ impl<N: Network> Contains<N> {
 
 impl<N: Network> Parser for Contains<N> {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/command/get/dynamic.rs
+++ b/synthesizer/program/src/logic/command/get/dynamic.rs
@@ -167,7 +167,7 @@ impl<N: Network> GetDynamic<N> {
 impl<N: Network> Parser for GetDynamic<N> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/command/get/standard.rs
+++ b/synthesizer/program/src/logic/command/get/standard.rs
@@ -113,7 +113,7 @@ impl<N: Network> Get<N> {
 impl<N: Network> Parser for Get<N> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/command/get_or_use/dynamic.rs
+++ b/synthesizer/program/src/logic/command/get_or_use/dynamic.rs
@@ -186,7 +186,7 @@ impl<N: Network> GetOrUseDynamic<N> {
 impl<N: Network> Parser for GetOrUseDynamic<N> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/command/get_or_use/standard.rs
+++ b/synthesizer/program/src/logic/command/get_or_use/standard.rs
@@ -121,7 +121,7 @@ impl<N: Network> GetOrUse<N> {
 impl<N: Network> Parser for GetOrUse<N> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/command/mod.rs
+++ b/synthesizer/program/src/logic/command/mod.rs
@@ -432,7 +432,7 @@ impl<N: Network> ToBytes for Command<N> {
 impl<N: Network> Parser for Command<N> {
     /// Parses the string into the command.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the command.
         // Note that the order of the parsers is important.
         alt((

--- a/synthesizer/program/src/logic/command/position.rs
+++ b/synthesizer/program/src/logic/command/position.rs
@@ -56,7 +56,7 @@ impl<N: Network> Position<N> {
 impl<N: Network> Parser for Position<N> {
     /// Parses a string into a command.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/command/rand_chacha.rs
+++ b/synthesizer/program/src/logic/command/rand_chacha.rs
@@ -164,9 +164,9 @@ impl<N: Network> RandChaCha<N> {
 impl<N: Network> Parser for RandChaCha<N> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Parses an operand from the string.
-        fn parse_operand<N: Network>(string: &str) -> ParserResult<Operand<N>> {
+        fn parse_operand<N: Network>(string: &str) -> ParserResult<'_, Operand<N>> {
             // Parse the whitespace from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Parse the operand from the string.

--- a/synthesizer/program/src/logic/command/remove.rs
+++ b/synthesizer/program/src/logic/command/remove.rs
@@ -80,7 +80,7 @@ impl<N: Network> Remove<N> {
 
 impl<N: Network> Parser for Remove<N> {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/command/set.rs
+++ b/synthesizer/program/src/logic/command/set.rs
@@ -92,7 +92,7 @@ impl<N: Network> Set<N> {
 
 impl<N: Network> Parser for Set<N> {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/instruction/mod.rs
+++ b/synthesizer/program/src/logic/instruction/mod.rs
@@ -25,7 +25,7 @@ pub use operation::*;
 mod bytes;
 mod parse;
 
-use crate::{FinalizeRegistersState, FinalizeStoreTrait, RegistersCircuit, RegistersSigner, StackTrait, instruction};
+use crate::{FinalizeRegistersState, FinalizeStoreTrait, RegistersCircuit, RegistersSigner, StackTrait};
 use console::{
     network::Network,
     prelude::{

--- a/synthesizer/program/src/logic/instruction/operand/parse.rs
+++ b/synthesizer/program/src/logic/instruction/operand/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for Operand<N> {
     /// Parses a string into a operand.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse to determine the operand (order matters).
         alt((
             // Parse special operands before literals, registers, and program IDs.

--- a/synthesizer/program/src/logic/instruction/operation/assert.rs
+++ b/synthesizer/program/src/logic/instruction/operation/assert.rs
@@ -200,7 +200,7 @@ impl<N: Network, const VARIANT: u8> AssertInstruction<N, VARIANT> {
 
 impl<N: Network, const VARIANT: u8> Parser for AssertInstruction<N, VARIANT> {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the opcode from the string.
         let (string, _) = tag(*Self::opcode())(string)?;
         // Parse the whitespace from the string.

--- a/synthesizer/program/src/logic/instruction/operation/async_.rs
+++ b/synthesizer/program/src/logic/instruction/operation/async_.rs
@@ -223,9 +223,9 @@ impl<N: Network> Async<N> {
 impl<N: Network> Parser for Async<N> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Parses an operand.
-        fn parse_operand<N: Network>(string: &str) -> ParserResult<Operand<N>> {
+        fn parse_operand<N: Network>(string: &str) -> ParserResult<'_, Operand<N>> {
             // Parse the whitespace from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Parse the operand from the string.

--- a/synthesizer/program/src/logic/instruction/operation/call/dynamic.rs
+++ b/synthesizer/program/src/logic/instruction/operation/call/dynamic.rs
@@ -245,9 +245,9 @@ impl<N: Network> CallDynamic<N> {
 impl<N: Network> Parser for CallDynamic<N> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Parses an operand from the string.
-        fn parse_operand<N: Network>(string: &str) -> ParserResult<Operand<N>> {
+        fn parse_operand<N: Network>(string: &str) -> ParserResult<'_, Operand<N>> {
             // Parse the whitespace from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Parse the operand from the string.
@@ -255,7 +255,7 @@ impl<N: Network> Parser for CallDynamic<N> {
         }
 
         /// Parses a destination register from the string.
-        fn parse_destination<N: Network>(string: &str) -> ParserResult<Register<N>> {
+        fn parse_destination<N: Network>(string: &str) -> ParserResult<'_, Register<N>> {
             // Parse the whitespace from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Parse the destination from the string.
@@ -263,7 +263,7 @@ impl<N: Network> Parser for CallDynamic<N> {
         }
 
         /// Parses a value type from the string.
-        fn parse_value_type<N: Network>(string: &str) -> ParserResult<ValueType<N>> {
+        fn parse_value_type<N: Network>(string: &str) -> ParserResult<'_, ValueType<N>> {
             // Parse the whitespace from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Parse the destination type from the string.
@@ -272,7 +272,7 @@ impl<N: Network> Parser for CallDynamic<N> {
 
         /// A helper function to parse a non-empty, parenthesis-delimited sequence of value types.
         /// For example, `(as u64.public dynamic.future)`.
-        fn parse_value_types<N: Network>(string: &str) -> ParserResult<Vec<ValueType<N>>> {
+        fn parse_value_types<N: Network>(string: &str) -> ParserResult<'_, Vec<ValueType<N>>> {
             // Parse the whitespace from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Parse the "(" from the string.

--- a/synthesizer/program/src/logic/instruction/operation/call/standard.rs
+++ b/synthesizer/program/src/logic/instruction/operation/call/standard.rs
@@ -40,7 +40,7 @@ pub enum CallOperator<N: Network> {
 impl<N: Network> Parser for CallOperator<N> {
     /// Parses a string into an operator.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         alt((map(Locator::parse, CallOperator::Locator), map(Identifier::parse, CallOperator::Resource)))(string)
     }
 }
@@ -373,9 +373,9 @@ impl<N: Network> Call<N> {
 impl<N: Network> Parser for Call<N> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Parses an operand from the string.
-        fn parse_operand<N: Network>(string: &str) -> ParserResult<Operand<N>> {
+        fn parse_operand<N: Network>(string: &str) -> ParserResult<'_, Operand<N>> {
             // Parse the whitespace from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Parse the operand from the string.
@@ -383,7 +383,7 @@ impl<N: Network> Parser for Call<N> {
         }
 
         /// Parses a destination register from the string.
-        fn parse_destination<N: Network>(string: &str) -> ParserResult<Register<N>> {
+        fn parse_destination<N: Network>(string: &str) -> ParserResult<'_, Register<N>> {
             // Parse the whitespace from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Parse the destination from the string.

--- a/synthesizer/program/src/logic/instruction/operation/cast.rs
+++ b/synthesizer/program/src/logic/instruction/operation/cast.rs
@@ -78,7 +78,7 @@ impl<N: Network> CastType<N> {
 }
 
 impl<N: Network> Parser for CastType<N> {
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the cast type from the string.
         alt((
             map(tag("group.x"), |_| Self::GroupXCoordinate),
@@ -1135,9 +1135,9 @@ impl<N: Network, const VARIANT: u8> CastOperation<N, VARIANT> {
 
 impl<N: Network, const VARIANT: u8> Parser for CastOperation<N, VARIANT> {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Parses an operand from the string.
-        fn parse_operand<N: Network>(string: &str) -> ParserResult<Operand<N>> {
+        fn parse_operand<N: Network>(string: &str) -> ParserResult<'_, Operand<N>> {
             // Parse the whitespace from the string.
             let (string, _) = Sanitizer::parse_whitespaces(string)?;
             // Parse the operand from the string.

--- a/synthesizer/program/src/logic/instruction/operation/commit.rs
+++ b/synthesizer/program/src/logic/instruction/operation/commit.rs
@@ -309,7 +309,7 @@ impl<N: Network, const VARIANT: u8> CommitInstruction<N, VARIANT> {
 
 impl<N: Network, const VARIANT: u8> Parser for CommitInstruction<N, VARIANT> {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the opcode from the string.
         let (string, _) = tag(*Self::opcode())(string)?;
         // Parse the whitespace from the string.

--- a/synthesizer/program/src/logic/instruction/operation/deserialize.rs
+++ b/synthesizer/program/src/logic/instruction/operation/deserialize.rs
@@ -788,9 +788,9 @@ impl<N: Network, const VARIANT: u8> DeserializeInstruction<N, VARIANT> {
 
 impl<N: Network, const VARIANT: u8> Parser for DeserializeInstruction<N, VARIANT> {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Parse the operands from the string.
-        fn parse_operands<N: Network>(string: &str, num_operands: usize) -> ParserResult<Vec<Operand<N>>> {
+        fn parse_operands<N: Network>(string: &str, num_operands: usize) -> ParserResult<'_, Vec<Operand<N>>> {
             let mut operands = Vec::with_capacity(num_operands);
             let mut string = string;
 

--- a/synthesizer/program/src/logic/instruction/operation/ecdsa_verify.rs
+++ b/synthesizer/program/src/logic/instruction/operation/ecdsa_verify.rs
@@ -520,7 +520,7 @@ impl<N: Network, const VARIANT: u8> ECDSAVerify<N, VARIANT> {
 impl<N: Network, const VARIANT: u8> Parser for ECDSAVerify<N, VARIANT> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the opcode from the string.
         let (string, _) = tag(*Self::opcode())(string)?;
         // Parse the whitespace from the string.

--- a/synthesizer/program/src/logic/instruction/operation/get_record_dynamic.rs
+++ b/synthesizer/program/src/logic/instruction/operation/get_record_dynamic.rs
@@ -427,7 +427,7 @@ impl<N: Network> GetRecordDynamic<N> {
 
 impl<N: Network> Parser for GetRecordDynamic<N> {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the opcode from the string.

--- a/synthesizer/program/src/logic/instruction/operation/hash.rs
+++ b/synthesizer/program/src/logic/instruction/operation/hash.rs
@@ -760,9 +760,9 @@ impl<N: Network, const VARIANT: u8> HashInstruction<N, VARIANT> {
 
 impl<N: Network, const VARIANT: u8> Parser for HashInstruction<N, VARIANT> {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Parse the operands from the string.
-        fn parse_operands<N: Network>(string: &str, num_operands: usize) -> ParserResult<Vec<Operand<N>>> {
+        fn parse_operands<N: Network>(string: &str, num_operands: usize) -> ParserResult<'_, Vec<Operand<N>>> {
             let mut operands = Vec::with_capacity(num_operands);
             let mut string = string;
 

--- a/synthesizer/program/src/logic/instruction/operation/is.rs
+++ b/synthesizer/program/src/logic/instruction/operation/is.rs
@@ -181,7 +181,7 @@ impl<N: Network, const VARIANT: u8> IsInstruction<N, VARIANT> {
 
 impl<N: Network, const VARIANT: u8> Parser for IsInstruction<N, VARIANT> {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the opcode from the string.
         let (string, _) = tag(*Self::opcode())(string)?;
         // Parse the whitespace from the string.

--- a/synthesizer/program/src/logic/instruction/operation/literals.rs
+++ b/synthesizer/program/src/logic/instruction/operation/literals.rs
@@ -201,7 +201,7 @@ impl<N: Network, O: Operation<N, Literal<N>, LiteralType, NUM_OPERANDS>, const N
     for Literals<N, O, NUM_OPERANDS>
 {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the opcode from the string.
         let (string, _) = tag(*O::OPCODE)(string)?;
         // Parse the whitespace from the string.

--- a/synthesizer/program/src/logic/instruction/operation/macros.rs
+++ b/synthesizer/program/src/logic/instruction/operation/macros.rs
@@ -413,6 +413,7 @@ mod tests {
                                 })+
 
                                 // Attempt to compute the invalid operand case.
+                                #[allow(clippy::cloned_ref_to_slice_refs)]
                                 let result_a = <$operation as $crate::Operation<_, _, _, 1>>::evaluate(&[literal_a.clone()]);
                                 // Ensure the computation failed.
                                 assert!(result_a.is_err(), "An invalid operand case (on iteration {i}) did not fail (console): {literal_a}");
@@ -453,6 +454,7 @@ mod tests {
                                 })+
 
                                 // Attempt to compute the invalid operand case.
+                                #[allow(clippy::cloned_ref_to_slice_refs)]
                                 let result_a = <$operation as $crate::Operation<_, _, _, 1>>::evaluate(&[literal_a.clone()]);
                                 // Ensure the computation failed.
                                 assert!(result_a.is_err(), "An invalid operand case (on iteration {i}) did not fail (console): {literal_a}");
@@ -654,6 +656,7 @@ mod tests {
                             // If the sampled values overflow on evaluation, ensure it halts.
                             else {
                                 // Halt the evaluation.
+                                #[allow(clippy::cloned_ref_to_slice_refs)]
                                 let result_a = std::panic::catch_unwind(|| <$operation as $crate::Operation<_, _, _, 1>>::evaluate(&[a.clone()]).unwrap());
                                 // Ensure the evaluation halted.
                                 assert!(result_a.is_err(), "Failure case (on iteration {i}) did not halt (console): {a}");

--- a/synthesizer/program/src/logic/instruction/operation/serialize.rs
+++ b/synthesizer/program/src/logic/instruction/operation/serialize.rs
@@ -344,9 +344,9 @@ impl<N: Network, const VARIANT: u8> SerializeInstruction<N, VARIANT> {
 
 impl<N: Network, const VARIANT: u8> Parser for SerializeInstruction<N, VARIANT> {
     /// Parses a string into an operation.
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Parse the operands from the string.
-        fn parse_operands<N: Network>(string: &str, num_operands: usize) -> ParserResult<Vec<Operand<N>>> {
+        fn parse_operands<N: Network>(string: &str, num_operands: usize) -> ParserResult<'_, Vec<Operand<N>>> {
             let mut operands = Vec::with_capacity(num_operands);
             let mut string = string;
 

--- a/synthesizer/program/src/logic/instruction/operation/sign_verify.rs
+++ b/synthesizer/program/src/logic/instruction/operation/sign_verify.rs
@@ -208,7 +208,7 @@ impl<N: Network> SignatureVerification<N> {
 impl<N: Network> Parser for SignatureVerification<N> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the opcode from the string.
         let (string, _) = tag(*Self::opcode())(string)?;
         // Parse the whitespace from the string.

--- a/synthesizer/program/src/logic/instruction/operation/snark_verify.rs
+++ b/synthesizer/program/src/logic/instruction/operation/snark_verify.rs
@@ -469,7 +469,7 @@ impl<N: Network, const VARIANT: u8> SnarkVerification<N, VARIANT> {
 impl<N: Network, const VARIANT: u8> Parser for SnarkVerification<N, VARIANT> {
     /// Parses a string into an operation.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the opcode from the string.
         let (string, _) = tag(*Self::opcode())(string)?;
         // Parse the whitespace from the string.

--- a/synthesizer/program/src/logic/instruction/parse.rs
+++ b/synthesizer/program/src/logic/instruction/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for Instruction<N> {
     /// Parses a string into an instruction.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         /// Create an alt parser that matches the instruction.
         ///
         /// `nom` documentation notes that alt supports a maximum of 21 parsers.

--- a/synthesizer/program/src/mapping/key/parse.rs
+++ b/synthesizer/program/src/mapping/key/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for MapKey<N> {
     /// Parses a string into a key statement of the form `key as {plaintext_type}.public;`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the keyword from the string.

--- a/synthesizer/program/src/mapping/parse.rs
+++ b/synthesizer/program/src/mapping/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for Mapping<N> {
     /// Parses a string into a mapping.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the 'mapping' keyword from the string.

--- a/synthesizer/program/src/mapping/value/parse.rs
+++ b/synthesizer/program/src/mapping/value/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for MapValue<N> {
     /// Parses a string into a value statement of the form `value as {plaintext_type}.public;`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the keyword from the string.

--- a/synthesizer/program/src/parse.rs
+++ b/synthesizer/program/src/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for ProgramCore<N> {
     /// Parses a string into a program.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // A helper to parse a program.
         enum P<N: Network> {
             Constructor(ConstructorCore<N>),
@@ -45,7 +45,7 @@ impl<N: Network> Parser for ProgramCore<N> {
         // Parse the semicolon ';' keyword from the string.
         let (string, _) = tag(";")(string)?;
 
-        fn intermediate<N: Network>(string: &str) -> ParserResult<P<N>> {
+        fn intermediate<N: Network>(string: &str) -> ParserResult<'_, P<N>> {
             // Parse the whitespace and comments from the string.
             let (string, _) = Sanitizer::parse(string)?;
 

--- a/synthesizer/program/src/view/input/parse.rs
+++ b/synthesizer/program/src/view/input/parse.rs
@@ -19,7 +19,7 @@ impl<N: Network> Parser for Input<N> {
     /// Parses a string into an input statement.
     /// The input statement is of the form `input {register} as {plaintext_type}.public;`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the input keyword from the string.

--- a/synthesizer/program/src/view/output/parse.rs
+++ b/synthesizer/program/src/view/output/parse.rs
@@ -19,7 +19,7 @@ impl<N: Network> Parser for Output<N> {
     /// Parses a string into an output statement.
     /// The output statement is of the form `output {operand} as {finalize_type};`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the output keyword from the string.

--- a/synthesizer/program/src/view/parse.rs
+++ b/synthesizer/program/src/view/parse.rs
@@ -18,7 +18,7 @@ use super::*;
 impl<N: Network> Parser for ViewCore<N> {
     /// Parses a string into a view function.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the whitespace and comments from the string.
         let (string, _) = Sanitizer::parse(string)?;
         // Parse the 'view' keyword from the string.

--- a/synthesizer/snark/src/certificate/parse.rs
+++ b/synthesizer/snark/src/certificate/parse.rs
@@ -20,7 +20,7 @@ static VK_CERTIFICATE_PREFIX: &str = "certificate";
 impl<N: Network> Parser for Certificate<N> {
     /// Parses a string into an certificate.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Prepare a parser for the Aleo certificate.
         let parse_certificate = recognize(pair(
             pair(tag(VK_CERTIFICATE_PREFIX), tag("1")),

--- a/synthesizer/snark/src/proof/parse.rs
+++ b/synthesizer/snark/src/proof/parse.rs
@@ -20,7 +20,7 @@ static PROOF_PREFIX: &str = "proof";
 impl<N: Network> Parser for Proof<N> {
     /// Parses a string into an proof.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Prepare a parser for the Aleo proof.
         let parse_proof = recognize(pair(
             pair(tag(PROOF_PREFIX), tag("1")),

--- a/synthesizer/snark/src/proving_key/parse.rs
+++ b/synthesizer/snark/src/proving_key/parse.rs
@@ -20,7 +20,7 @@ static PROVING_KEY: &str = "prover";
 impl<N: Network> Parser for ProvingKey<N> {
     /// Parses a string into the proving key.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Prepare a parser for the Aleo proving key.
         let parse_key = recognize(pair(
             pair(tag(PROVING_KEY), tag("1")),

--- a/synthesizer/snark/src/verifying_key/parse.rs
+++ b/synthesizer/snark/src/verifying_key/parse.rs
@@ -20,7 +20,7 @@ static VERIFYING_KEY: &str = "verifier";
 impl<N: Network> Parser for VerifyingKey<N> {
     /// Parses a string into the verifying key.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Prepare a parser for the Aleo verifying key.
         let parse_key = recognize(pair(
             pair(tag(VERIFYING_KEY), tag("1")),

--- a/synthesizer/src/restrictions/helpers/argument_locator.rs
+++ b/synthesizer/src/restrictions/helpers/argument_locator.rs
@@ -44,7 +44,7 @@ impl ArgumentLocator {
 impl Parser for ArgumentLocator {
     /// Parses a string into an argument locator of the form `{is_input}/{index}`.
     #[inline]
-    fn parse(string: &str) -> ParserResult<Self> {
+    fn parse(string: &str) -> ParserResult<'_, Self> {
         // Parse the `is_input` from the string.
         let (string, is_input) = alt((map(tag("true"), |_| true), map(tag("false"), |_| false)))(string)?;
         // Parse the `/` from the string.

--- a/synthesizer/src/restrictions/mod.rs
+++ b/synthesizer/src/restrictions/mod.rs
@@ -246,10 +246,10 @@ impl<N: Network> Restrictions<N> {
                                     Input::Constant(_, Some(plaintext)) | Input::Public(_, Some(plaintext)) => {
                                         match plaintext {
                                             Plaintext::Literal(literal, _) => {
-                                                if let Some(range) = arguments.get(literal) {
-                                                    if range.contains(block_height) {
-                                                        return true;
-                                                    }
+                                                if let Some(range) = arguments.get(literal)
+                                                    && range.contains(block_height)
+                                                {
+                                                    return true;
                                                 }
                                             }
                                             Plaintext::Struct(..) | Plaintext::Array(..) => continue,
@@ -265,10 +265,10 @@ impl<N: Network> Restrictions<N> {
                                     Output::Constant(_, Some(plaintext)) | Output::Public(_, Some(plaintext)) => {
                                         match plaintext {
                                             Plaintext::Literal(literal, _) => {
-                                                if let Some(range) = arguments.get(literal) {
-                                                    if range.contains(block_height) {
-                                                        return true;
-                                                    }
+                                                if let Some(range) = arguments.get(literal)
+                                                    && range.contains(block_height)
+                                                {
+                                                    return true;
                                                 }
                                             }
                                             Plaintext::Struct(..) | Plaintext::Array(..) => continue,

--- a/synthesizer/src/vm/execute.rs
+++ b/synthesizer/src/vm/execute.rs
@@ -1103,7 +1103,7 @@ constructor:
             .execute(
                 &caller_private_key,
                 (format!("test_{}.aleo", Transaction::<CurrentNetwork>::MAX_TRANSITIONS - 1), "test"),
-                vec![Value::from_str("0field").unwrap(), Value::from_str("1field").unwrap()].iter(),
+                [Value::from_str("0field").unwrap(), Value::from_str("1field").unwrap()].iter(),
                 None,
                 0,
                 None,

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -263,7 +263,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Committee lookback for `block.round()` semantics matching `Ledger::get_committee_lookback_for_round`.
     #[cfg(any(test, feature = "test"))]
     fn committee_lookback_for_round(&self, round: u64) -> Result<Option<Committee<N>>> {
-        let previous_round = match round % 2 == 0 {
+        let previous_round = match round.is_multiple_of(2) {
             true => round.saturating_sub(1),
             false => round.saturating_sub(2),
         };
@@ -659,15 +659,15 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         // per-certificate basis whether or not transactions
                         // exceed it.
                         if consensus_version >= ConsensusVersion::V16 {
-                            if let Some(block_spend_limit) = block_spend_limit {
-                                if block_spend.saturating_add(compute_spend) > block_spend_limit {
-                                    aborted.push((
-                                        transaction.clone(),
-                                        format!("Exceeds the block spend limit with compute_spend: '{compute_spend}'"),
-                                    ));
-                                    // Continue to the next transaction.
-                                    continue 'outer;
-                                }
+                            if let Some(block_spend_limit) = block_spend_limit
+                                && block_spend.saturating_add(compute_spend) > block_spend_limit
+                            {
+                                aborted.push((
+                                    transaction.clone(),
+                                    format!("Exceeds the block spend limit with compute_spend: '{compute_spend}'"),
+                                ));
+                                // Continue to the next transaction.
+                                continue 'outer;
                             }
                             // Track the compute_spend used so far.
                             block_spend = block_spend.saturating_add(compute_spend);
@@ -1375,12 +1375,12 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // If the transaction is a deployment, ensure that it is not another deployment in the block from the same public fee payer.
         if let Transaction::Deploy(_, _, _, _, fee) = transaction {
             // If any public deployment payer has already deployed in this block, abort the transaction.
-            if let Some(payer) = fee.payer() {
-                if candidate_transaction_details.deployment_payers.contains(&payer) {
-                    return ShouldAbortResult::Abort(format!(
-                        "Another deployment in the block from the same public fee payer {payer}"
-                    ));
-                }
+            if let Some(payer) = fee.payer()
+                && candidate_transaction_details.deployment_payers.contains(&payer)
+            {
+                return ShouldAbortResult::Abort(format!(
+                    "Another deployment in the block from the same public fee payer {payer}"
+                ));
             }
         }
 
@@ -3963,7 +3963,7 @@ finalize compute:
 
         // Generate the next block.
         let next_block =
-            sample_next_block(&vm, validators.keys().next().unwrap(), &vec![transaction], &block, &mut vec![], rng)
+            sample_next_block(&vm, validators.keys().next().unwrap(), &[transaction], &block, &mut vec![], rng)
                 .unwrap();
 
         // Add the next block.
@@ -4001,15 +4001,9 @@ finalize compute:
             .unwrap();
 
         // Generate the next block.
-        let next_block = sample_next_block(
-            &vm,
-            validators.keys().next().unwrap(),
-            &vec![transaction],
-            &next_block,
-            &mut vec![],
-            rng,
-        )
-        .unwrap();
+        let next_block =
+            sample_next_block(&vm, validators.keys().next().unwrap(), &[transaction], &next_block, &mut vec![], rng)
+                .unwrap();
 
         // Add the next block.
         vm.add_next_block(&next_block).unwrap();

--- a/synthesizer/src/vm/helpers/rewards.rs
+++ b/synthesizer/src/vm/helpers/rewards.rs
@@ -276,7 +276,7 @@ mod tests {
         println!("staking_rewards: {}ms", timer.elapsed().as_millis());
         assert_eq!(next_stakers.len(), all_stakers.len());
         for ((staker, (validator, stake)), (next_staker, (next_validator, next_stake))) in
-            all_stakers.into_iter().zip(next_stakers.into_iter())
+            all_stakers.into_iter().zip(next_stakers)
         {
             assert_eq!(staker, next_staker);
             assert_eq!(validator, next_validator);
@@ -315,7 +315,7 @@ mod tests {
         println!("staking_rewards: {}ms", timer.elapsed().as_millis());
         assert_eq!(next_stakers.len(), stakers.len());
         for ((staker, (validator, stake)), (next_staker, (next_validator, next_stake))) in
-            stakers.clone().into_iter().zip(next_stakers.clone().into_iter())
+            stakers.clone().into_iter().zip(next_stakers.clone())
         {
             assert_eq!(staker, next_staker);
             assert_eq!(validator, next_validator);
@@ -384,7 +384,7 @@ mod tests {
         println!("staking_rewards: {}ms", timer.elapsed().as_millis());
         assert_eq!(next_stakers.len(), stakers.len());
         for ((staker, (validator, stake)), (next_staker, (next_validator, next_stake))) in
-            stakers.into_iter().zip(next_stakers.into_iter())
+            stakers.into_iter().zip(next_stakers)
         {
             assert_eq!(staker, next_staker);
             assert_eq!(validator, next_validator);

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -203,7 +203,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             })
             .collect::<Result<Vec<_>>>()?;
         // Sort the deployment transaction IDs by their block heights.
-        deployment_ids.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));
+        deployment_ids.sort_unstable_by_key(|(_, a)| *a);
 
         // Load the deployments in order of their block heights.
         const PARALLELIZATION_FACTOR: usize = 256;
@@ -1757,7 +1757,8 @@ function c:
             .unwrap();
 
         // Deploy the first program.
-        let deployment_block = sample_next_block(&vm, &caller_private_key, &[deployment_1.clone()], rng).unwrap();
+        let deployment_block =
+            sample_next_block(&vm, &caller_private_key, std::slice::from_ref(&deployment_1), rng).unwrap();
         vm.add_next_block(&deployment_block).unwrap();
 
         // Create the deployment for the second program.
@@ -1777,7 +1778,8 @@ function b:
             .unwrap();
 
         // Deploy the second program.
-        let deployment_block = sample_next_block(&vm, &caller_private_key, &[deployment_2.clone()], rng).unwrap();
+        let deployment_block =
+            sample_next_block(&vm, &caller_private_key, std::slice::from_ref(&deployment_2), rng).unwrap();
         vm.add_next_block(&deployment_block).unwrap();
 
         // Create the deployment for the third program.
@@ -3015,7 +3017,7 @@ finalize transfer_public_to_private:
         vm.check_transaction(&transaction, None, rng).unwrap();
 
         // Add the transaction to a block and update the VM.
-        let block = sample_next_block(&vm, &caller_private_key, &[transaction.clone()], rng).unwrap();
+        let block = sample_next_block(&vm, &caller_private_key, std::slice::from_ref(&transaction), rng).unwrap();
 
         // Update the VM.
         vm.add_next_block(&block).unwrap();
@@ -3704,13 +3706,7 @@ function check:
 
         // Generate the authorization that will contain multiple transitions
         let authorization = process
-            .authorize::<CurrentAleo, _>(
-                &private_key,
-                grandparent_program.id(),
-                &function_name,
-                vec![input].iter(),
-                rng,
-            )
+            .authorize::<CurrentAleo, _>(&private_key, grandparent_program.id(), &function_name, [input].iter(), rng)
             .unwrap();
 
         // Assert the Authorization has more than 1 transitions

--- a/synthesizer/src/vm/tests/test_v14/amendments.rs
+++ b/synthesizer/src/vm/tests/test_v14/amendments.rs
@@ -120,7 +120,7 @@ constructor:
     let v3_transaction = create_v3_deployment_transaction(&vm, &caller_private_key, &deployed_program, 0, rng)?;
 
     // Attempt to add the V3 deployment before V14 - it should be aborted.
-    let block = sample_next_block(&vm, &caller_private_key, &[v3_transaction.clone()], rng)?;
+    let block = sample_next_block(&vm, &caller_private_key, std::slice::from_ref(&v3_transaction), rng)?;
     assert_eq!(block.transactions().num_accepted(), 0, "V3 should be rejected before V14");
     assert_eq!(block.transactions().num_rejected(), 0);
     assert_eq!(block.aborted_transaction_ids().len(), 1, "V3 should be aborted before V14");

--- a/synthesizer/src/vm/tests/test_v14/call_dynamic.rs
+++ b/synthesizer/src/vm/tests/test_v14/call_dynamic.rs
@@ -911,7 +911,7 @@ fn test_complex_dynamic_graph_construction_internal(
     assert_eq!(graph[tids[6]], &[]);
     assert_eq!(graph[tids[7]], &[]);
 
-    add_and_test_with_costs(&vm, &caller_private_key, Some(&[&inputs]), &[transaction.clone()], rng);
+    add_and_test_with_costs(&vm, &caller_private_key, Some(&[&inputs]), std::slice::from_ref(&transaction), rng);
 }
 
 // Tests execution graph construction with all-static, all-dynamic, and random combinations of call types.
@@ -2397,7 +2397,7 @@ fn test_replay_attack_prevention_across_blocks() {
     let inputs = vec![Value::from_str("1000u64").unwrap()];
     let mint_tx =
         vm.execute(&caller_private_key, ("replay_base.aleo", "mint"), inputs.iter(), None, 0, None, rng).unwrap();
-    add_and_test_with_costs(&vm, &caller_private_key, Some(&[&inputs]), &[mint_tx.clone()], rng);
+    add_and_test_with_costs(&vm, &caller_private_key, Some(&[&inputs]), std::slice::from_ref(&mint_tx), rng);
 
     // Extract the minted record
     let record = mint_tx

--- a/synthesizer/src/vm/tests/test_v14/compare_calls_to_credits.rs
+++ b/synthesizer/src/vm/tests/test_v14/compare_calls_to_credits.rs
@@ -69,7 +69,7 @@ fn mint_record(
     let tx = vm
         .execute(caller_private_key, ("credits.aleo", "transfer_public_to_private"), inputs.iter(), None, 0, None, rng)
         .unwrap();
-    add_and_test_with_costs(vm, caller_private_key, Some(&[&inputs]), &[tx.clone()], rng);
+    add_and_test_with_costs(vm, caller_private_key, Some(&[&inputs]), std::slice::from_ref(&tx), rng);
     let record = extract_record(&tx, &view_key);
     (tx, record)
 }
@@ -271,7 +271,7 @@ fn test_compare_transfer_public() {
         )
         .unwrap();
 
-    let dynamic_inputs = vec![Value::from_str(&recipient.to_string()).unwrap(), Value::from_str(amount).unwrap()];
+    let dynamic_inputs = [Value::from_str(&recipient.to_string()).unwrap(), Value::from_str(amount).unwrap()];
     let dynamic_tx = vm
         .execute(
             &caller_private_key,
@@ -409,7 +409,7 @@ fn test_compare_transfer_public_as_signer() {
         )
         .unwrap();
 
-    let dynamic_inputs = vec![Value::from_str(&recipient.to_string()).unwrap(), Value::from_str(amount).unwrap()];
+    let dynamic_inputs = [Value::from_str(&recipient.to_string()).unwrap(), Value::from_str(amount).unwrap()];
     let dynamic_tx = vm
         .execute(
             &caller_private_key,
@@ -553,7 +553,7 @@ fn test_compare_transfer_public_to_private() {
         )
         .unwrap();
 
-    let dynamic_inputs = vec![Value::from_str(&recipient.to_string()).unwrap(), Value::from_str(amount).unwrap()];
+    let dynamic_inputs = [Value::from_str(&recipient.to_string()).unwrap(), Value::from_str(amount).unwrap()];
     let dynamic_tx = vm
         .execute(
             &caller_private_key,

--- a/synthesizer/src/vm/tests/test_v14/dynamic_futures.rs
+++ b/synthesizer/src/vm/tests/test_v14/dynamic_futures.rs
@@ -464,7 +464,7 @@ fn test_dynamic_future_finalize_failure() {
         )
         .unwrap();
 
-    let block = sample_next_block(&vm, &caller_private_key, &[transaction_fail.clone()], rng).unwrap();
+    let block = sample_next_block(&vm, &caller_private_key, std::slice::from_ref(&transaction_fail), rng).unwrap();
 
     // The transaction should be rejected due to finalize failure
     assert_eq!(block.transactions().num_accepted(), 0);

--- a/synthesizer/src/vm/tests/test_v14/translation.rs
+++ b/synthesizer/src/vm/tests/test_v14/translation.rs
@@ -288,7 +288,13 @@ fn test_translation(
         .unwrap();
 
     println!("Verifying transaction...");
-    add_and_test_with_costs(&vm, caller_private_key, Some(&[&computed_input_values]), &[transaction.clone()], rng);
+    add_and_test_with_costs(
+        &vm,
+        caller_private_key,
+        Some(&[&computed_input_values]),
+        std::slice::from_ref(&transaction),
+        rng,
+    );
 
     if let Some(expected_public_outputs) = expected_public_outputs {
         println!("Asserting output correctness on {} expected public outputs...", expected_public_outputs.len());

--- a/synthesizer/src/vm/tests/test_v15/record_existence.rs
+++ b/synthesizer/src/vm/tests/test_v15/record_existence.rs
@@ -595,7 +595,7 @@ fn test_existence_check() {
     let mint_planet_4_tx =
         vm.execute(&caller_private_key, ("base.aleo", "mint_rover"), inputs.iter(), None, 0, None, rng).unwrap();
 
-    add_and_test_with_costs(&vm, &caller_private_key, Some(&[&inputs]), &[mint_planet_4_tx.clone()], rng);
+    add_and_test_with_costs(&vm, &caller_private_key, Some(&[&inputs]), std::slice::from_ref(&mint_planet_4_tx), rng);
 
     let mint_planet_4_output = mint_planet_4_tx.transitions().next().unwrap().outputs().first().unwrap();
     let mint_planet_4_record = match mint_planet_4_output {

--- a/synthesizer/src/vm/tests/test_v16/block_spend_limit.rs
+++ b/synthesizer/src/vm/tests/test_v16/block_spend_limit.rs
@@ -100,7 +100,7 @@ fn test_quorum_block_spend_limit_aborts_excess_transactions() {
             None,
             Vec::new(),
             &Solutions::from(None),
-            vec![transaction_0.clone(), transaction_1.clone()].iter(),
+            [transaction_0.clone(), transaction_1.clone()].iter(),
             rng,
         )
         .unwrap();

--- a/synthesizer/src/vm/tests/test_v18/scalar_outputs.rs
+++ b/synthesizer/src/vm/tests/test_v18/scalar_outputs.rs
@@ -115,7 +115,7 @@ fn test_program_with_output_scalar_from_atomic() {
 
     let mut transactions = Vec::with_capacity(cases.len());
     for (function, input, expected) in cases {
-        let inputs = vec![Value::<CurrentNetwork>::from_str(input).unwrap()];
+        let inputs = [Value::<CurrentNetwork>::from_str(input).unwrap()];
         let transaction =
             vm.execute(&caller_private_key, ("test_0.aleo", function), inputs.iter(), None, 0, None, rng).unwrap();
         let expected_output = Plaintext::<CurrentNetwork>::from_str(expected).unwrap();
@@ -188,7 +188,7 @@ fn test_program_with_output_scalar_from_record() {
     let caller_view_key = ViewKey::try_from(&caller_private_key).unwrap();
     let mut records = Vec::with_capacity(2);
     for amount in ["7scalar", "8scalar"] {
-        let mint_inputs = vec![Value::<CurrentNetwork>::from_str(amount).unwrap()];
+        let mint_inputs = [Value::<CurrentNetwork>::from_str(amount).unwrap()];
         let mint_tx = vm
             .execute(&caller_private_key, ("test_scalar_record_0.aleo", "mint"), mint_inputs.iter(), None, 0, None, rng)
             .unwrap();
@@ -203,7 +203,7 @@ fn test_program_with_output_scalar_from_record() {
     }
 
     // Read the scalar entry with a public output and confirm its value.
-    let read_pub_inputs = vec![Value::Record(records[0].clone())];
+    let read_pub_inputs = [Value::Record(records[0].clone())];
     let read_pub_tx = vm
         .execute(
             &caller_private_key,
@@ -222,7 +222,7 @@ fn test_program_with_output_scalar_from_record() {
     );
 
     // Read the scalar entry with a private output.
-    let read_pri_inputs = vec![Value::Record(records[1].clone())];
+    let read_pri_inputs = [Value::Record(records[1].clone())];
     let read_pri_tx = vm
         .execute(
             &caller_private_key,
@@ -311,7 +311,7 @@ fn test_program_with_output_scalar_from_dynamic_record() {
     let caller_view_key = ViewKey::try_from(&caller_private_key).unwrap();
     let mut dynamic_records = Vec::with_capacity(2);
     for amount in ["9scalar", "10scalar"] {
-        let mint_inputs = vec![Value::<CurrentNetwork>::from_str(amount).unwrap()];
+        let mint_inputs = [Value::<CurrentNetwork>::from_str(amount).unwrap()];
         let mint_tx = vm
             .execute(
                 &caller_private_key,
@@ -335,7 +335,7 @@ fn test_program_with_output_scalar_from_dynamic_record() {
 
     // Read the scalar entry with a public output and confirm its value. The root
     // transition is the last one (the `call.dynamic` to `consume` comes first).
-    let read_pub_inputs = vec![Value::DynamicRecord(dynamic_records[0].clone())];
+    let read_pub_inputs = [Value::DynamicRecord(dynamic_records[0].clone())];
     let read_pub_tx = vm
         .execute(
             &caller_private_key,
@@ -354,7 +354,7 @@ fn test_program_with_output_scalar_from_dynamic_record() {
     );
 
     // Read the scalar entry with a private output.
-    let read_pri_inputs = vec![Value::DynamicRecord(dynamic_records[1].clone())];
+    let read_pri_inputs = [Value::DynamicRecord(dynamic_records[1].clone())];
     let read_pri_tx = vm
         .execute(
             &caller_private_key,
@@ -435,7 +435,7 @@ fn test_program_with_output_scalar_from_array() {
 
     // Execute the array-reading functions with a fixed `[scalar; 4]` input and confirm
     // the first element (`1scalar`) is returned by both the direct and closure paths.
-    let array_input = vec![Value::<CurrentNetwork>::from_str("[1scalar, 2scalar, 3scalar, 4scalar]").unwrap()];
+    let array_input = [Value::<CurrentNetwork>::from_str("[1scalar, 2scalar, 3scalar, 4scalar]").unwrap()];
     let expected_output = Plaintext::<CurrentNetwork>::from_str("1scalar").unwrap();
 
     let mut transactions = Vec::with_capacity(2);
@@ -529,7 +529,7 @@ fn test_program_with_output_scalar_from_struct() {
 
     // Execute the struct-reading functions with a fixed `wrapper` input and confirm
     // the scalar field (`1scalar`) is returned by both the direct and closure paths.
-    let struct_input = vec![Value::<CurrentNetwork>::from_str("{ amount: 1scalar }").unwrap()];
+    let struct_input = [Value::<CurrentNetwork>::from_str("{ amount: 1scalar }").unwrap()];
     let expected_output = Plaintext::<CurrentNetwork>::from_str("1scalar").unwrap();
 
     let mut transactions = Vec::with_capacity(2);

--- a/synthesizer/src/vm/tests/test_v20/translated_type_checks.rs
+++ b/synthesizer/src/vm/tests/test_v20/translated_type_checks.rs
@@ -303,7 +303,7 @@ fn test_dynamic_id_variant_checks() {
             &caller_private_key,
             issuer.id(),
             "consume",
-            &[record_value.clone()],
+            std::slice::from_ref(&record_value),
             &["Incorrect input variant", "record_with_dynamic_id", "ticket.record"],
             |transitions| {
                 let index = transitions.len() - 1;

--- a/synthesizer/src/vm/tests/test_v9.rs
+++ b/synthesizer/src/vm/tests/test_v9.rs
@@ -2129,7 +2129,7 @@ function dummy2:",
     // Add 2 transactions individually to blocks.
     // They are expected to pass because the program has not been upgraded.
     for execution in &executions[0..2] {
-        let block = sample_next_block(&vm, &caller_private_key, &[execution.clone()], rng).unwrap();
+        let block = sample_next_block(&vm, &caller_private_key, std::slice::from_ref(execution), rng).unwrap();
         assert_eq!(block.transactions().num_accepted(), 1);
         assert_eq!(block.transactions().num_rejected(), 0);
         assert_eq!(block.aborted_transaction_ids().len(), 0);

--- a/synthesizer/src/vm/verify.rs
+++ b/synthesizer/src/vm/verify.rs
@@ -623,13 +623,13 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                                         "Invalid deployment transaction '{id}' - the existing program does not have a constructor, but the deployment program does"
                                     );
                                     // If the consensus version is V10 or greater, then check that each function's **record** output registers match the existing program.
-                                    if consensus_version >= ConsensusVersion::V10 {
-                                        if let Err(e) = check_output_register_indices_unchanged(
+                                    if consensus_version >= ConsensusVersion::V10
+                                        && let Err(e) = check_output_register_indices_unchanged(
                                             existing_program,
                                             deployment.program(),
-                                        ) {
-                                            bail!("Invalid deployment transaction '{id}' - {e}")
-                                        }
+                                        )
+                                    {
+                                        bail!("Invalid deployment transaction '{id}' - {e}")
                                     }
                                 }
                             }

--- a/synthesizer/tests/test_process_execute.rs
+++ b/synthesizer/tests/test_process_execute.rs
@@ -146,7 +146,6 @@ fn run_test(process: &Process<CurrentNetwork>, test: &ProgramTest) -> serde_yaml
                                     response
                                         .outputs()
                                         .iter()
-                                        .cloned()
                                         .map(|output| serde_yaml::Value::String(output.to_string()))
                                         .collect_vec(),
                                 ),

--- a/synthesizer/tests/test_vm_execute_and_finalize.rs
+++ b/synthesizer/tests/test_vm_execute_and_finalize.rs
@@ -88,7 +88,7 @@ fn run_test(test: &ProgramTest) -> serde_yaml::Mapping {
             .execute(
                 &genesis_private_key,
                 ("credits.aleo", "transfer_public"),
-                vec![
+                [
                     Value::Plaintext(Plaintext::from(Literal::Address(Address::try_from(key).unwrap()))),
                     Value::Plaintext(Plaintext::from(Literal::U64(U64::new(1_000_000_000_000)))),
                 ]
@@ -607,7 +607,7 @@ fn split<C: ConsensusStorage<CurrentNetwork>, R: Rng + CryptoRng>(
     amount: u64,
     rng: &mut R,
 ) -> (Vec<Record<CurrentNetwork, Plaintext<CurrentNetwork>>>, Vec<Transaction<CurrentNetwork>>) {
-    let inputs = vec![Value::Record(record), Value::Plaintext(Plaintext::from(Literal::U64(U64::new(amount))))];
+    let inputs = [Value::Record(record), Value::Plaintext(Plaintext::from(Literal::U64(U64::new(amount))))];
     let transaction = vm.execute(private_key, ("credits.aleo", "split"), inputs.iter(), None, 0, None, rng).unwrap();
     let records = transaction
         .records()

--- a/utilities/src/biginteger/bigint_256.rs
+++ b/utilities/src/biginteger/bigint_256.rs
@@ -52,7 +52,7 @@ impl crate::biginteger::BigInteger for BigInteger256 {
     #[inline]
     fn add_nocarry(&mut self, other: &Self) -> bool {
         #[cfg(target_arch = "x86_64")]
-        unsafe {
+        {
             use core::arch::x86_64::_addcarry_u64;
             let mut carry = 0;
             carry = _addcarry_u64(carry, self.0[0], other.0[0], &mut self.0[0]);
@@ -75,7 +75,7 @@ impl crate::biginteger::BigInteger for BigInteger256 {
     #[inline]
     fn sub_noborrow(&mut self, other: &Self) -> bool {
         #[cfg(target_arch = "x86_64")]
-        unsafe {
+        {
             use core::arch::x86_64::_subborrow_u64;
             let mut borrow = 0;
             borrow = _subborrow_u64(borrow, self.0[0], other.0[0], &mut self.0[0]);

--- a/utilities/src/biginteger/bigint_384.rs
+++ b/utilities/src/biginteger/bigint_384.rs
@@ -51,7 +51,7 @@ impl BigInteger for BigInteger384 {
     #[inline]
     fn add_nocarry(&mut self, other: &Self) -> bool {
         #[cfg(target_arch = "x86_64")]
-        unsafe {
+        {
             use core::arch::x86_64::_addcarry_u64;
             let mut carry = 0;
             carry = _addcarry_u64(carry, self.0[0], other.0[0], &mut self.0[0]);
@@ -78,7 +78,7 @@ impl BigInteger for BigInteger384 {
     #[inline]
     fn sub_noborrow(&mut self, other: &Self) -> bool {
         #[cfg(target_arch = "x86_64")]
-        unsafe {
+        {
             use core::arch::x86_64::_subborrow_u64;
             let mut borrow = 0;
             borrow = _subborrow_u64(borrow, self.0[0], other.0[0], &mut self.0[0]);


### PR DESCRIPTION
## Motivation

Updates the MSRV in rust-toolchain.toml, Cargo.toml, and .circleci/config.yml.

The immediate motivation is that some AVX-512 intrinsics are only stable from Rust 1.89.

But more generally, Rust 1.88 is from 1 year ago, and we may be missing compiler bug fixes or performance improvements.

The newer compiler reports 287 clippy findings in existing code.

Most are cleared mechanically by `cargo clippy --fix`; the bulk is `mismatched_lifetime_syntaxes` (149), plus collapsible `if`, useless `vec!`, and manual impls of derivable traits. The rest needed a human:

  - `cloned_ref_to_slice_refs` (28 sites): `&[x.clone()]` becomes `slice::from_ref(&x)`. Three sites in the instruction-operation macros are *not* convertible and the lint had to be suppressed instead.
  - `bigint_256.rs` / `bigint_384.rs`: `_addcarry_u64` and `_subborrow_u64` are safe functions on this toolchain, so the `unsafe` blocks wrapping them are now redundant.
  - `finalize.rs`: `notify_staking_reward` collapses into a let-chain.
  - `non_canonical_partial_ord_impl` now fires on the impl block rather than the method, so the existing allow moves with it.

## Test Plan

clippy and fmt fix and the tests are passing locally

## Backwards compatibility

No behavioural change is intended; every edit is a lint fix.

Note: we likely shouldn't merge this until the *next* release cycle