### PR TITLE
Fix/memoize size in bits and types equivalent

### DIFF
--- a/console/program/src/data_types/finalize_type/size_in_bits.rs
+++ b/console/program/src/data_types/finalize_type/size_in_bits.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{DynamicFuture, Identifier, StructType};
+use crate::{DynamicFuture, Identifier, PlaintextType, StructType};
 
 use super::*;
 
@@ -50,16 +50,62 @@ impl<N: Network> FinalizeType<N> {
         F1: Fn(&Locator<N>) -> Result<StructType<N>>,
         F2: Fn(&Locator<N>) -> Result<Vec<FinalizeType<N>>>,
     {
+        // Track the `(size, height)` of the futures and struct types that have already been sized, so that one
+        // shared by many arguments is expanded at most once. Futures nest — a finalize input may be a future of an
+        // imported function, whose own finalize inputs may again be futures — so, exactly as for structs, this
+        // graph is acyclic with exponentially many paths and the walk below would not otherwise terminate.
+        let mut memoized_futures = HashMap::new();
+        let mut memoized_structs = HashMap::new();
+        Ok(self
+            .size_in_bits_inner(
+                get_struct,
+                get_external_struct,
+                get_future,
+                depth,
+                &mut memoized_futures,
+                &mut memoized_structs,
+            )?
+            .0)
+    }
+
+    /// The memoized inner traversal for [`Self::size_in_bits_internal`], returning `(size, height)`.
+    ///
+    /// `height` is the number of levels below this type at which its deepest node sits, and lets a memoized hit at
+    /// a deeper position re-apply the depth check the skipped subtree would have performed.
+    #[allow(clippy::too_many_arguments)]
+    fn size_in_bits_inner<F0, F1, F2>(
+        &self,
+        get_struct: &F0,
+        get_external_struct: &F1,
+        get_future: &F2,
+        depth: usize,
+        memoized_futures: &mut HashMap<Locator<N>, (usize, usize)>,
+        memoized_structs: &mut HashMap<PlaintextType<N>, (usize, usize)>,
+    ) -> Result<(usize, usize)>
+    where
+        F0: Fn(&Identifier<N>) -> Result<StructType<N>>,
+        F1: Fn(&Locator<N>) -> Result<StructType<N>>,
+        F2: Fn(&Locator<N>) -> Result<Vec<FinalizeType<N>>>,
+    {
         // Ensure that the depth is within the maximum limit.
         ensure!(depth <= N::MAX_DATA_DEPTH, "Finalize type depth exceeds maximum limit: {}", N::MAX_DATA_DEPTH);
 
         match self {
             Self::Plaintext(plaintext_type) => {
-                // Memoize within this argument only; see `PlaintextType::size_in_bits` for why the walk needs it.
-                let mut memoized = HashMap::new();
-                Ok(plaintext_type.size_in_bits_internal(get_struct, get_external_struct, depth, &mut memoized)?.0)
+                plaintext_type.size_in_bits_internal(get_struct, get_external_struct, depth, memoized_structs)
             }
             Self::Future(locator) => {
+                // If this future has already been sized in the current traversal, reuse that result, re-checking
+                // the depth limit against its height as the skipped recursion would have on its deepest node.
+                if let Some(&(size, height)) = memoized_futures.get(locator) {
+                    ensure!(
+                        depth.saturating_add(height) <= N::MAX_DATA_DEPTH,
+                        "Finalize type depth exceeds maximum limit: {}",
+                        N::MAX_DATA_DEPTH
+                    );
+                    return Ok((size, height));
+                }
+
                 // Initialize the size in bits.
                 let mut size = 0usize;
 
@@ -88,14 +134,24 @@ impl<N: Network> FinalizeType<N> {
                 // Account for the number of arguments.
                 size = size.checked_add(8).ok_or(anyhow!("`size_in_bits` overflowed"))?;
 
+                // Track the maximum height of any argument's subtree.
+                let mut argument_height = 0usize;
+
                 // Account for each of the arguments.
                 for argument in &arguments {
                     // Account for the argument variant bit.
                     size = size.checked_add(1).ok_or(anyhow!("`size_in_bits` overflowed"))?;
 
                     // Calculate argument bits size.
-                    let argument_size_in_bits =
-                        argument.size_in_bits_internal(get_struct, get_external_struct, get_future, depth + 1)?;
+                    let (argument_size_in_bits, subtree_height) = argument.size_in_bits_inner(
+                        get_struct,
+                        get_external_struct,
+                        get_future,
+                        depth + 1,
+                        memoized_futures,
+                        memoized_structs,
+                    )?;
+                    argument_height = argument_height.max(subtree_height);
 
                     // Account for the size of the argument bits
                     match argument_size_in_bits <= u16::MAX as usize {
@@ -113,9 +169,15 @@ impl<N: Network> FinalizeType<N> {
                     size = size.checked_add(argument_size_in_bits).ok_or(anyhow!("`size_in_bits` overflowed"))?;
                 }
 
-                Ok(size)
+                // The future sits one level above its deepest argument; an argumentless future recurses nowhere.
+                let height = match arguments.is_empty() {
+                    true => 0,
+                    false => argument_height + 1,
+                };
+                memoized_futures.insert(*locator, (size, height));
+                Ok((size, height))
             }
-            Self::DynamicFuture => DynamicFuture::<N>::size_in_bits(),
+            Self::DynamicFuture => Ok((DynamicFuture::<N>::size_in_bits()?, 0)),
         }
     }
 
@@ -132,5 +194,66 @@ impl<N: Network> FinalizeType<N> {
         F2: Fn(&Locator<N>) -> Result<Vec<FinalizeType<N>>>,
     {
         Self::future_size_in_bits(locator, get_struct, get_external_struct, get_future)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LiteralType, PlaintextType};
+    use snarkvm_console_network::MainnetV0;
+
+    use std::{sync::mpsc, thread, time::Duration};
+
+    type CurrentNetwork = MainnetV0;
+
+    /// Builds a chain of `depth` finalize scopes in which every scope takes `MAX_INPUTS` futures of the scope
+    /// below it, and the bottom scope takes a single `field`. Sizing the top future therefore walks an acyclic
+    /// graph with `MAX_INPUTS ^ (depth - 1)` distinct root-to-leaf paths, even though only `depth` distinct
+    /// futures exist — the same shape as the shared-struct DoS, one level up.
+    ///
+    /// Returns the top locator and the `get_future` lookup table.
+    #[allow(clippy::type_complexity)]
+    fn sample_future_chain(
+        depth: usize,
+    ) -> (Locator<CurrentNetwork>, HashMap<Locator<CurrentNetwork>, Vec<FinalizeType<CurrentNetwork>>>) {
+        assert!(depth >= 1);
+        let locator = |level: usize| Locator::<CurrentNetwork>::from_str(&format!("f{level}.aleo/g")).unwrap();
+
+        let mut futures = HashMap::new();
+        futures.insert(locator(0), vec![FinalizeType::Plaintext(PlaintextType::Literal(LiteralType::Field))]);
+        for level in 1..depth {
+            futures.insert(locator(level), vec![FinalizeType::Future(locator(level - 1)); CurrentNetwork::MAX_INPUTS]);
+        }
+
+        (locator(depth - 1), futures)
+    }
+
+    #[test]
+    fn test_future_size_in_bits_shared_future_dag_terminates() {
+        // Without caching, sizing this future expands 16^11 argument nodes and never returns; with caching each
+        // of the 12 distinct futures is expanded once.
+        let (top, futures) = sample_future_chain(12);
+
+        let (sender, receiver) = mpsc::channel();
+        thread::spawn(move || {
+            let get_struct = |_: &Identifier<CurrentNetwork>| bail!("this program declares no structs");
+            let get_external_struct = |_: &Locator<CurrentNetwork>| bail!("this program declares no external structs");
+            let get_future = |locator: &Locator<CurrentNetwork>| {
+                futures.get(locator).cloned().ok_or_else(|| anyhow!("Failed to find future '{locator}'"))
+            };
+            let _ =
+                sender.send(FinalizeType::future_size_in_bits(&top, &get_struct, &get_external_struct, &get_future));
+        });
+
+        // 5 minutes is generous even if the CI machine is heavily loaded.
+        match receiver.recv_timeout(Duration::from_secs(300)) {
+            Ok(Ok(size)) => assert!(size > 0),
+            Ok(Err(error)) => panic!("Failed to size a chain of shared futures: {error}"),
+            Err(_) => panic!(
+                "future_size_in_bits did not terminate within 300s: the future argument tree is being expanded \
+                 exponentially (memoization is missing)"
+            ),
+        }
     }
 }

--- a/console/program/src/data_types/finalize_type/size_in_bits.rs
+++ b/console/program/src/data_types/finalize_type/size_in_bits.rs
@@ -17,6 +17,8 @@ use crate::{DynamicFuture, Identifier, StructType};
 
 use super::*;
 
+use std::collections::HashMap;
+
 impl<N: Network> FinalizeType<N> {
     /// Returns the number of bits of a finalize type.
     /// Note. The plaintext variant is assumed to be an argument of a `Future` and this does not have a "raw" serialization.
@@ -53,7 +55,9 @@ impl<N: Network> FinalizeType<N> {
 
         match self {
             Self::Plaintext(plaintext_type) => {
-                plaintext_type.size_in_bits_internal(get_struct, get_external_struct, depth)
+                // Memoize within this argument only; see `PlaintextType::size_in_bits` for why the walk needs it.
+                let mut memoized = HashMap::new();
+                Ok(plaintext_type.size_in_bits_internal(get_struct, get_external_struct, depth, &mut memoized)?.0)
             }
             Self::Future(locator) => {
                 // Initialize the size in bits.

--- a/console/program/src/data_types/plaintext_type/size_in_bits.rs
+++ b/console/program/src/data_types/plaintext_type/size_in_bits.rs
@@ -15,6 +15,20 @@
 
 use super::*;
 
+use std::collections::HashMap;
+
+/// Returns a memoized `(size, height)` for a struct reached at `depth`, after re-checking the depth limit against
+/// its height. This is the check the skipped recursion would have performed on the subtree's deepest node, so a
+/// memoized hit rejects exactly the deeply-nested cases the full recursion would.
+fn memoized_size<N: Network>(depth: usize, (size, height): (usize, usize)) -> Result<(usize, usize)> {
+    ensure!(
+        depth.saturating_add(height) <= N::MAX_DATA_DEPTH,
+        "Plaintext depth exceeds maximum limit: {}",
+        N::MAX_DATA_DEPTH
+    );
+    Ok((size, height))
+}
+
 impl<N: Network> PlaintextType<N> {
     /// Returns the number of bits of a plaintext type.
     pub fn size_in_bits<F0, F1>(&self, get_struct: &F0, get_external_struct: &F1) -> Result<usize>
@@ -22,16 +36,27 @@ impl<N: Network> PlaintextType<N> {
         F0: Fn(&Identifier<N>) -> Result<StructType<N>>,
         F1: Fn(&Locator<N>) -> Result<StructType<N>>,
     {
-        self.size_in_bits_internal(get_struct, get_external_struct, 0)
+        // Track the `(size, height)` of the struct types that have already been sized, so that a struct shared by
+        // many members is expanded at most once. Without this, a program in which every member of each struct
+        // refers to the same earlier struct forms an acyclic graph with exponentially many paths, and the walk
+        // below would make up to `MAX_STRUCT_ENTRIES ^ MAX_STRUCTS` recursive calls.
+        let mut memoized = HashMap::new();
+        Ok(self.size_in_bits_internal(get_struct, get_external_struct, 0, &mut memoized)?.0)
     }
 
-    /// A helper function to determine the number of bits of a plaintext type, while tracking the depth of the data.
+    /// A helper function to determine the `(size, height)` of a plaintext type, while tracking the depth of the data.
+    ///
+    /// `memoized` is keyed on the struct type itself rather than its name, since an external struct resolves
+    /// through a different lookup whose struct names may collide with the current program's. It holds
+    /// `(size, height)`, where `height` is the number of levels below a type at which its deepest node sits (a
+    /// literal is `0`); see [`memoized_size`] for why the height is tracked.
     pub(crate) fn size_in_bits_internal<F0, F1>(
         &self,
         get_struct: &F0,
         get_external_struct: &F1,
         depth: usize,
-    ) -> Result<usize>
+        memoized: &mut HashMap<PlaintextType<N>, (usize, usize)>,
+    ) -> Result<(usize, usize)>
     where
         F0: Fn(&Identifier<N>) -> Result<StructType<N>>,
         F1: Fn(&Locator<N>) -> Result<StructType<N>>,
@@ -39,12 +64,16 @@ impl<N: Network> PlaintextType<N> {
         // Ensure that the depth is within the maximum limit.
         ensure!(depth <= N::MAX_DATA_DEPTH, "Plaintext depth exceeds maximum limit: {}", N::MAX_DATA_DEPTH);
 
-        // Computes the size in bits of a resolved struct definition.
-        let compute_struct_size = |struct_: &StructType<N>| -> Result<usize> {
+        // Computes the `(size, height)` in bits of a resolved struct definition.
+        let compute_struct_size = |struct_: &StructType<N>,
+                                   memoized: &mut HashMap<PlaintextType<N>, (usize, usize)>|
+         -> Result<(usize, usize)> {
             // Account for the plaintext variant bits.
             let mut total = PlaintextType::<N>::STRUCT_PREFIX_BITS.len();
             // Account for the number of members in the struct.
             total = total.checked_add(8).ok_or(anyhow!("`size_in_bits` overflowed"))?;
+            // Track the maximum height of any member's subtree.
+            let mut member_height = 0usize;
             // Add up the sizes of each member.
             for (identifier, member_type) in struct_.members() {
                 // Account for the size of the identifier.
@@ -56,11 +85,18 @@ impl<N: Network> PlaintextType<N> {
                 // Account for the size of the member.
                 total = total.checked_add(16).ok_or(anyhow!("`size_in_bits` overflowed"))?;
                 // Account for the member itself.
-                let member_size = member_type.size_in_bits_internal(get_struct, get_external_struct, depth + 1)?;
+                let (member_size, subtree_height) =
+                    member_type.size_in_bits_internal(get_struct, get_external_struct, depth + 1, memoized)?;
                 total = total.checked_add(member_size).ok_or(anyhow!("`size_in_bits` overflowed"))?;
+                member_height = member_height.max(subtree_height);
             }
 
-            Ok(total)
+            // The struct sits one level above its deepest member; a memberless struct recurses nowhere.
+            let height = match struct_.members().is_empty() {
+                true => 0,
+                false => member_height + 1,
+            };
+            Ok((total, height))
         };
 
         match &self {
@@ -77,17 +113,29 @@ impl<N: Network> PlaintextType<N> {
                     .checked_add(literal.size_in_bits::<N>() as usize)
                     .ok_or(anyhow!("`size_in_bits` overflowed"))?;
 
-                Ok(total)
+                Ok((total, 0))
             }
             PlaintextType::Struct(identifier) => {
+                // If this struct has already been sized in the current traversal, reuse that result.
+                if let Some(&result) = memoized.get(self) {
+                    return memoized_size::<N>(depth, result);
+                }
                 // Look up the struct.
                 let struct_ = get_struct(identifier)?;
-                compute_struct_size(&struct_)
+                let result = compute_struct_size(&struct_, memoized)?;
+                memoized.insert(self.clone(), result);
+                Ok(result)
             }
             PlaintextType::ExternalStruct(locator) => {
+                // If this struct has already been sized in the current traversal, reuse that result.
+                if let Some(&result) = memoized.get(self) {
+                    return memoized_size::<N>(depth, result);
+                }
                 // Look up the struct
                 let struct_ = get_external_struct(locator)?;
-                compute_struct_size(&struct_)
+                let result = compute_struct_size(&struct_, memoized)?;
+                memoized.insert(self.clone(), result);
+                Ok(result)
             }
             PlaintextType::Array(array_type) => {
                 // Account for the plaintext variant bits.
@@ -95,8 +143,12 @@ impl<N: Network> PlaintextType<N> {
                 // Account for the size of the array length.
                 total = total.checked_add(32).ok_or(anyhow!("`size_in_bits` overflowed"))?;
                 // Get the size of the element type.
-                let element_size =
-                    array_type.next_element_type().size_in_bits_internal(get_struct, get_external_struct, depth + 1)?;
+                let (element_size, element_height) = array_type.next_element_type().size_in_bits_internal(
+                    get_struct,
+                    get_external_struct,
+                    depth + 1,
+                    memoized,
+                )?;
                 // Get the total size of an element.
                 let element_total = 16usize.checked_add(element_size).ok_or(anyhow!("`size_in_bits` overflowed"))?;
                 // Multiply by the length of the array, ensuring no overflow occurs.
@@ -108,7 +160,8 @@ impl<N: Network> PlaintextType<N> {
                     )
                     .ok_or(anyhow!("`size_in_bits` overflowed"))?;
 
-                Ok(total)
+                // The array sits one level above its element.
+                Ok((total, element_height + 1))
             }
         }
     }
@@ -119,16 +172,21 @@ impl<N: Network> PlaintextType<N> {
         F0: Fn(&Identifier<N>) -> Result<StructType<N>>,
         F1: Fn(&Locator<N>) -> Result<StructType<N>>,
     {
-        self.size_in_bits_raw_internal(get_struct, get_external_struct, 0)
+        // See `size_in_bits` for why the traversal is memoized; the two size definitions differ, so they must not
+        // share a map.
+        let mut memoized = HashMap::new();
+        Ok(self.size_in_bits_raw_internal(get_struct, get_external_struct, 0, &mut memoized)?.0)
     }
 
-    // A helper function to determine the number of raw bits of a plaintext type, while tracking the depth of the data.
+    // A helper function to determine the `(size, height)` of raw bits of a plaintext type, while tracking the depth.
+    // See `size_in_bits_internal` for how `memoized` is keyed.
     fn size_in_bits_raw_internal<F0, F1>(
         &self,
         get_struct: &F0,
         get_external_struct: &F1,
         depth: usize,
-    ) -> Result<usize>
+        memoized: &mut HashMap<PlaintextType<N>, (usize, usize)>,
+    ) -> Result<(usize, usize)>
     where
         F0: Fn(&Identifier<N>) -> Result<StructType<N>>,
         F1: Fn(&Locator<N>) -> Result<StructType<N>>,
@@ -136,47 +194,72 @@ impl<N: Network> PlaintextType<N> {
         // Ensure that the depth is within the maximum limit.
         ensure!(depth <= N::MAX_DATA_DEPTH, "Plaintext depth exceeds maximum limit: {}", N::MAX_DATA_DEPTH);
 
-        // Computes the raw size in bits of a resolved struct definition.
-        let compute_struct_size_raw = |struct_: &StructType<N>| -> Result<usize> {
+        // Computes the raw `(size, height)` in bits of a resolved struct definition.
+        let compute_struct_size_raw = |struct_: &StructType<N>,
+                                       memoized: &mut HashMap<PlaintextType<N>, (usize, usize)>|
+         -> Result<(usize, usize)> {
             // Add up the sizes of each member.
             let mut total = 0usize;
+            // Track the maximum height of any member's subtree.
+            let mut member_height = 0usize;
 
             for member_type in struct_.members().values() {
                 // Get the size of the member.
-                let member_size = member_type.size_in_bits_raw_internal(get_struct, get_external_struct, depth + 1)?;
+                let (member_size, subtree_height) =
+                    member_type.size_in_bits_raw_internal(get_struct, get_external_struct, depth + 1, memoized)?;
 
                 // Add to the total size, ensuring no overflow occurs.
                 total = total.checked_add(member_size).ok_or(anyhow!("`size_in_bits_raw` overflowed"))?;
+                member_height = member_height.max(subtree_height);
             }
 
-            Ok(total)
+            // The struct sits one level above its deepest member; a memberless struct recurses nowhere.
+            let height = match struct_.members().is_empty() {
+                true => 0,
+                false => member_height + 1,
+            };
+            Ok((total, height))
         };
 
         match &self {
-            PlaintextType::Literal(literal) => Ok(literal.size_in_bits::<N>() as usize),
+            PlaintextType::Literal(literal) => Ok((literal.size_in_bits::<N>() as usize, 0)),
             PlaintextType::Struct(identifier) => {
+                // If this struct has already been sized in the current traversal, reuse that result.
+                if let Some(&result) = memoized.get(self) {
+                    return memoized_size::<N>(depth, result);
+                }
                 // Look up the struct.
                 let struct_ = get_struct(identifier)?;
-                compute_struct_size_raw(&struct_)
+                let result = compute_struct_size_raw(&struct_, memoized)?;
+                memoized.insert(self.clone(), result);
+                Ok(result)
             }
             PlaintextType::ExternalStruct(locator) => {
+                // If this struct has already been sized in the current traversal, reuse that result.
+                if let Some(&result) = memoized.get(self) {
+                    return memoized_size::<N>(depth, result);
+                }
                 // Look up the struct.
                 let struct_ = get_external_struct(locator)?;
-                compute_struct_size_raw(&struct_)
+                let result = compute_struct_size_raw(&struct_, memoized)?;
+                memoized.insert(self.clone(), result);
+                Ok(result)
             }
             PlaintextType::Array(array_type) => {
                 // Get the size of the element type.
-                let element_size = array_type.next_element_type().size_in_bits_raw_internal(
+                let (element_size, element_height) = array_type.next_element_type().size_in_bits_raw_internal(
                     get_struct,
                     get_external_struct,
                     depth + 1,
+                    memoized,
                 )?;
                 // Multiply by the length of the array, ensuring no overflow occurs.
                 let total = element_size
                     .checked_mul(**array_type.length() as usize)
                     .ok_or(anyhow!("`size_in_bits_raw` overflowed"))?;
 
-                Ok(total)
+                // The array sits one level above its element.
+                Ok((total, element_height + 1))
             }
         }
     }

--- a/synthesizer/process/src/stack/register_types/initialize.rs
+++ b/synthesizer/process/src/stack/register_types/initialize.rs
@@ -1086,13 +1086,20 @@ mod tests {
 
     type CurrentNetwork = MainnetV0;
 
-    /// Builds a program whose `depth` structs each have `MAX_STRUCT_ENTRIES` members, where every member of
-    /// `s{k}` refers to `s{k-1}` (and every member of `s0` is a `field`). A single function input of type
+    /// Builds a program named `name` whose `depth` structs each have `MAX_STRUCT_ENTRIES` members, where every
+    /// member of `s{k}` refers to `s{k-1}` (and every member of `s0` is a `field`). A function input of type
     /// `s{depth - 1}` therefore references an acyclic struct graph with `MAX_STRUCT_ENTRIES ^ (depth - 1)`
     /// distinct root-to-leaf paths — the shape exploited by the type-validation DoS.
-    fn sample_shared_struct_program(depth: usize) -> Program<CurrentNetwork> {
+    ///
+    /// `function` is passed `depth - 1` and returns the body of the `compute` function, so that each test can
+    /// drive a different type-checking walker over that graph.
+    fn sample_shared_struct_program(
+        name: &str,
+        depth: usize,
+        function: impl FnOnce(usize) -> String,
+    ) -> Program<CurrentNetwork> {
         assert!(depth >= 1);
-        let mut source = String::from("program testing_dag.aleo;\n\n");
+        let mut source = format!("program {name}.aleo;\n\n");
         for level in 0..depth {
             writeln!(source, "struct s{level}:").unwrap();
             let member_type = if level == 0 { "field".to_string() } else { format!("s{}", level - 1) };
@@ -1101,7 +1108,7 @@ mod tests {
             }
             source.push('\n');
         }
-        writeln!(source, "function compute:\n    input r0 as s{}.private;", depth - 1).unwrap();
+        writeln!(source, "function compute:\n{}", function(depth - 1)).unwrap();
         source.push_str("\nconstructor:\n    assert.eq true true;\n");
         Program::from_str(&source).unwrap()
     }
@@ -1114,7 +1121,7 @@ mod tests {
         //
         // The traversal is run on a detached thread so that the missing-memoization regression surfaces as a
         // bounded timeout failure rather than hanging the test suite indefinitely.
-        let program = sample_shared_struct_program(12);
+        let program = sample_shared_struct_program("testing_dag", 12, |top| format!("    input r0 as s{top}.private;"));
 
         let (sender, receiver) = mpsc::channel();
         thread::spawn(move || {
@@ -1124,12 +1131,72 @@ mod tests {
             let _ = sender.send(is_ok);
         });
 
-        // 5 minutes is generous even if the CI machine is heavily loaded
+        // 5 minutes is generous even if the CI machine is heavily loaded.
         match receiver.recv_timeout(Duration::from_secs(300)) {
             Ok(true) => {}
             Ok(false) => panic!("Stack::new rejected a well-formed shared-struct program"),
             Err(_) => panic!(
-                "check_plaintext_type did not terminate within 30s: the shared-struct graph is being re-expanded \
+                "check_plaintext_type did not terminate within 300s: the shared-struct graph is being re-expanded \
+                 exponentially (memoization is missing)"
+            ),
+        }
+    }
+
+    #[test]
+    fn test_size_in_bits_shared_struct_dag_terminates() {
+        // `hash.bhp256` computes `size_in_bits` of its operand type during `Stack::new` type-checking. Without
+        // memoization this recurses over the shared-struct DAG exponentially and never returns. With memoization
+        // the walk is linear and `Stack::new` returns promptly. (The deployment is then rejected for an unrelated
+        // reason - the struct's bit size overflows `usize` - so only termination is asserted here.)
+        let program = sample_shared_struct_program("testing_dag_hash", 12, |top| {
+            format!(
+                "    input r0 as s{top}.private;\n    hash.bhp256 r0 into r1 as field;\n    output r1 as field.private;"
+            )
+        });
+
+        let (sender, receiver) = mpsc::channel();
+        thread::spawn(move || {
+            let process = Process::<CurrentNetwork>::load().expect("Failed to load process");
+            // We only assert that type-checking terminates; the deployment itself may still be rejected.
+            let _ = Stack::new(&process, &program);
+            let _ = sender.send(());
+        });
+
+        // 5 minutes is generous even if the CI machine is heavily loaded.
+        match receiver.recv_timeout(Duration::from_secs(300)) {
+            Ok(()) => {}
+            Err(_) => panic!(
+                "size_in_bits did not terminate within 300s: the shared-struct type is being sized \
+                 exponentially (memoization is missing)"
+            ),
+        }
+    }
+
+    #[test]
+    fn test_types_equivalent_shared_struct_dag_terminates() {
+        // `is.eq` on two shared-struct-DAG operands runs `register_types_equivalent` -> `types_equivalent`
+        // during `Stack::new` type-checking. Without memoization this compares hundreds of trillions of member
+        // pairs and never returns; with memoization each `(program, program, struct)` triple is compared once.
+        let program = sample_shared_struct_program("testing_dag_eq", 12, |top| {
+            format!(
+                "    input r0 as s{top}.private;\n    input r1 as s{top}.private;\n    is.eq r0 r1 into r2;\n    \
+                 output r2 as boolean.private;"
+            )
+        });
+
+        let (sender, receiver) = mpsc::channel();
+        thread::spawn(move || {
+            let process = Process::<CurrentNetwork>::load().expect("Failed to load process");
+            let is_ok = Stack::new(&process, &program).is_ok();
+            let _ = sender.send(is_ok);
+        });
+
+        // 5 minutes is generous even if the CI machine is heavily loaded.
+        match receiver.recv_timeout(Duration::from_secs(300)) {
+            Ok(true) => {}
+            Ok(false) => panic!("Stack::new rejected a well-formed program using is.eq on shared structs"),
+            Err(_) => panic!(
+                "types_equivalent did not terminate within 300s: shared-struct comparison is being expanded \
                  exponentially (memoization is missing)"
             ),
         }

--- a/synthesizer/program/src/traits/stack_and_registers.rs
+++ b/synthesizer/program/src/traits/stack_and_registers.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use crate::{FinalizeGlobalState, FinalizeStoreTrait, Function, Operand, Program};
 use console::{
@@ -32,7 +32,6 @@ use console::{
         Register,
         RegisterType,
         Request,
-        StructType,
         Value,
         ValueType,
     },
@@ -243,64 +242,94 @@ pub fn types_equivalent<N: Network>(
     stack1: &impl StackTrait<N>,
     type1: &PlaintextType<N>,
 ) -> Result<bool> {
+    // Track the `(program0, program1, struct)` triples that have already been confirmed equivalent, so that a
+    // struct shared by many members is compared at most once. Without this, a program in which every member of
+    // each struct refers to the same earlier struct forms an acyclic graph with exponentially many paths, and the
+    // walk below would make up to `MAX_STRUCT_ENTRIES ^ MAX_STRUCTS` recursive calls.
+    let mut confirmed = HashSet::new();
+    types_equivalent_inner(stack0, type0, stack1, type1, &mut confirmed)
+}
+
+/// The memoized inner traversal for [`types_equivalent`].
+fn types_equivalent_inner<N: Network>(
+    stack0: &impl StackTrait<N>,
+    type0: &PlaintextType<N>,
+    stack1: &impl StackTrait<N>,
+    type1: &PlaintextType<N>,
+    confirmed: &mut HashSet<(ProgramID<N>, ProgramID<N>, Identifier<N>)>,
+) -> Result<bool> {
     use PlaintextType::*;
 
-    let struct_compare = |stack0, st0: &StructType<N>, stack1, st1: &StructType<N>| -> Result<bool> {
-        if st0.members().len() != st1.members().len() {
-            return Ok(false);
-        }
-
-        for ((name0, type0), (name1, type1)) in st0.members().iter().zip(st1.members()) {
-            if name0 != name1 || !types_equivalent(stack0, type0, stack1, type1)? {
-                return Ok(false);
-            }
-        }
-
-        Ok(true)
-    };
-
+    // Equivalence requires equal struct names, so each arm below compares one name across the two stacks.
     match (type0, type1) {
         (Array(array0), Array(array1)) => Ok(array0.length() == array1.length()
-            && types_equivalent(stack0, array0.next_element_type(), stack1, array1.next_element_type())?),
+            && types_equivalent_inner(
+                stack0,
+                array0.next_element_type(),
+                stack1,
+                array1.next_element_type(),
+                confirmed,
+            )?),
         (Literal(lit0), Literal(lit1)) => Ok(lit0 == lit1),
-        (Struct(id0), Struct(id1)) => {
-            if id0 != id1 {
-                return Ok(false);
-            }
-            let struct_type0 = stack0.program().get_struct(id0)?;
-            let struct_type1 = stack1.program().get_struct(id1)?;
-            struct_compare(stack0, struct_type0, stack1, struct_type1)
-        }
-        (ExternalStruct(loc0), ExternalStruct(loc1)) => {
-            if loc0.resource() != loc1.resource() {
-                return Ok(false);
-            }
-            let external_stack0 = stack0.get_external_stack(loc0.program_id())?;
-            let struct_type0 = external_stack0.program().get_struct(loc0.resource())?;
-            let external_stack1 = stack1.get_external_stack(loc1.program_id())?;
-            let struct_type1 = external_stack1.program().get_struct(loc1.resource())?;
-            struct_compare(&*external_stack0, struct_type0, &*external_stack1, struct_type1)
-        }
-        (ExternalStruct(loc), Struct(id)) => {
-            if loc.resource() != id {
-                return Ok(false);
-            }
-            let external_stack = stack0.get_external_stack(loc.program_id())?;
-            let struct_type0 = external_stack.program().get_struct(loc.resource())?;
-            let struct_type1 = stack1.program().get_struct(id)?;
-            struct_compare(&*external_stack, struct_type0, stack1, struct_type1)
-        }
-        (Struct(id), ExternalStruct(loc)) => {
-            if id != loc.resource() {
-                return Ok(false);
-            }
-            let struct_type0 = stack0.program().get_struct(id)?;
-            let external_stack = stack1.get_external_stack(loc.program_id())?;
-            let struct_type1 = external_stack.program().get_struct(loc.resource())?;
-            struct_compare(stack0, struct_type0, &*external_stack, struct_type1)
-        }
+        (Struct(id0), Struct(id1)) => match id0 == id1 {
+            true => structs_equivalent_inner(stack0, stack1, id0, confirmed),
+            false => Ok(false),
+        },
+        (ExternalStruct(loc0), ExternalStruct(loc1)) => match loc0.resource() == loc1.resource() {
+            true => structs_equivalent_inner(
+                &*stack0.get_external_stack(loc0.program_id())?,
+                &*stack1.get_external_stack(loc1.program_id())?,
+                loc0.resource(),
+                confirmed,
+            ),
+            false => Ok(false),
+        },
+        (ExternalStruct(loc), Struct(id)) => match loc.resource() == id {
+            true => structs_equivalent_inner(&*stack0.get_external_stack(loc.program_id())?, stack1, id, confirmed),
+            false => Ok(false),
+        },
+        (Struct(id), ExternalStruct(loc)) => match id == loc.resource() {
+            true => structs_equivalent_inner(stack0, &*stack1.get_external_stack(loc.program_id())?, id, confirmed),
+            false => Ok(false),
+        },
         _ => Ok(false),
     }
+}
+
+/// Compares the struct named `name` in `stack0` against the one of that name in `stack1`, threading the
+/// memoization set from [`types_equivalent_inner`].
+///
+/// The key is `(program0, program1, name)`, which uniquely identifies the pair being compared, since a name
+/// resolves to one struct per program.
+fn structs_equivalent_inner<N: Network>(
+    stack0: &impl StackTrait<N>,
+    stack1: &impl StackTrait<N>,
+    name: &Identifier<N>,
+    confirmed: &mut HashSet<(ProgramID<N>, ProgramID<N>, Identifier<N>)>,
+) -> Result<bool> {
+    // If this pair of structs has already been confirmed equivalent, there is nothing left to compare.
+    let key = (*stack0.program_id(), *stack1.program_id(), *name);
+    if confirmed.contains(&key) {
+        return Ok(true);
+    }
+
+    let st0 = stack0.program().get_struct(name)?;
+    let st1 = stack1.program().get_struct(name)?;
+
+    if st0.members().len() != st1.members().len() {
+        return Ok(false);
+    }
+
+    for ((name0, type0), (name1, type1)) in st0.members().iter().zip(st1.members()) {
+        if name0 != name1 || !types_equivalent_inner(stack0, type0, stack1, type1, confirmed)? {
+            return Ok(false);
+        }
+    }
+
+    // Record only confirmed equivalences: a mismatch short-circuits the whole comparison to `false`, so a hit
+    // above always denotes a genuine equivalence, and the memoization changes only the running time.
+    confirmed.insert(key);
+    Ok(true)
 }
 
 pub trait FinalizeRegistersState<N: Network>: RegistersTrait<N> {

--- a/synthesizer/src/vm/helpers/program.rs
+++ b/synthesizer/src/vm/helpers/program.rs
@@ -16,11 +16,13 @@
 use crate::Stack;
 use console::{
     prelude::{Network, cfg_iter},
-    program::{EntryType, FinalizeType, Identifier, Locator, PlaintextType, RegisterType, ValueType},
+    program::{EntryType, FinalizeType, Identifier, Locator, PlaintextType, ProgramID, RegisterType, ValueType},
 };
 use snarkvm_synthesizer_program::{Program, StackTrait};
 
 use anyhow::{Result, anyhow, bail, ensure};
+
+use std::collections::HashMap;
 
 #[cfg(not(feature = "serial"))]
 use rayon::prelude::*;
@@ -109,9 +111,13 @@ pub fn check_program_plaintext_sizes<N: Network>(
     stack: &Stack<N>,
     max_bits: usize,
 ) -> Result<()> {
+    // Track the `(size, height)` of the `(program, struct)` pairs that have already been sized. This is shared by
+    // every `check` below, since the declarations walked here overlap heavily; see `plaintext_size_in_bits_raw`.
+    let mut memoized = HashMap::new();
+
     // Check a single plaintext type against the budget.
-    let check = |pt: &PlaintextType<N>| -> Result<()> {
-        let bits = plaintext_size_in_bits_raw(stack, pt, 0)?;
+    let mut check = |pt: &PlaintextType<N>| -> Result<()> {
+        let bits = plaintext_size_in_bits_raw(stack, pt, 0, &mut memoized)?.0;
         ensure!(
             bits <= max_bits,
             "Plaintext type '{pt}' exceeds the maximum allowed size in bits ({bits} > {max_bits})"
@@ -193,39 +199,78 @@ pub fn check_program_plaintext_sizes<N: Network>(
     Ok(())
 }
 
-/// Returns the size in bits of the given plaintext type, excluding any type metadata.
+/// Returns the `(size, height)` in bits of the given plaintext type, excluding any type metadata.
 ///
 /// Each struct reference is resolved against the program that declares it, since a struct declared
 /// in an external program may refer to structs local to that program, or to structs in programs
 /// that the current program does not import.
+///
+/// `memoized` records the result for each `(program, struct)` pair already sized, so that a struct shared by many
+/// members is expanded at most once. Without this, a program in which every member of each struct refers to the
+/// same earlier struct forms an acyclic graph with exponentially many paths, and this walk would make up to
+/// `MAX_STRUCT_ENTRIES ^ MAX_STRUCTS` recursive calls.
+///
+/// `height` is the number of levels below a type at which its deepest node sits (a literal is `0`). It lets a
+/// memoized hit at a deeper position re-apply the depth check the skipped recursion would have performed on that
+/// node, so the memoization changes only the running time and never the result.
 fn plaintext_size_in_bits_raw<N: Network>(
     stack: &Stack<N>,
     plaintext_type: &PlaintextType<N>,
     depth: usize,
-) -> Result<usize> {
+    memoized: &mut HashMap<(ProgramID<N>, Identifier<N>), (usize, usize)>,
+) -> Result<(usize, usize)> {
     // Ensure that the depth is within the maximum limit.
     ensure!(depth <= N::MAX_DATA_DEPTH, "Plaintext depth exceeds maximum limit: {}", N::MAX_DATA_DEPTH);
 
     match plaintext_type {
-        PlaintextType::Literal(literal_type) => Ok(literal_type.size_in_bits::<N>() as usize),
+        PlaintextType::Literal(literal_type) => Ok((literal_type.size_in_bits::<N>() as usize, 0)),
         PlaintextType::Struct(struct_name) => {
+            // If this struct has already been sized in the current traversal, reuse that result.
+            let key = (*stack.program_id(), *struct_name);
+            if let Some(&(size, height)) = memoized.get(&key) {
+                ensure!(
+                    depth.saturating_add(height) <= N::MAX_DATA_DEPTH,
+                    "Plaintext depth exceeds maximum limit: {}",
+                    N::MAX_DATA_DEPTH
+                );
+                return Ok((size, height));
+            }
+
             // Add up the sizes of the members, which are declared in the same program.
-            stack.program().get_struct(struct_name)?.members().values().try_fold(0usize, |total, member_type| {
-                total
-                    .checked_add(plaintext_size_in_bits_raw(stack, member_type, depth + 1)?)
-                    .ok_or_else(|| anyhow!("`plaintext_size_in_bits_raw` overflowed"))
-            })
+            let members = stack.program().get_struct(struct_name)?.members();
+            let mut total = 0usize;
+            // Track the maximum height of any member's subtree.
+            let mut member_height = 0usize;
+            for member_type in members.values() {
+                let (member_size, subtree_height) =
+                    plaintext_size_in_bits_raw(stack, member_type, depth + 1, memoized)?;
+                total =
+                    total.checked_add(member_size).ok_or_else(|| anyhow!("`plaintext_size_in_bits_raw` overflowed"))?;
+                member_height = member_height.max(subtree_height);
+            }
+
+            // The struct sits one level above its deepest member; a memberless struct recurses nowhere.
+            let height = match members.is_empty() {
+                true => 0,
+                false => member_height + 1,
+            };
+            memoized.insert(key, (total, height));
+            Ok((total, height))
         }
         PlaintextType::ExternalStruct(locator) => {
             // Resolve the struct, and therefore its members, against the external program.
             let external_stack = stack.get_external_stack(locator.program_id())?;
-            plaintext_size_in_bits_raw(&external_stack, &PlaintextType::Struct(*locator.resource()), depth)
+            plaintext_size_in_bits_raw(&external_stack, &PlaintextType::Struct(*locator.resource()), depth, memoized)
         }
         PlaintextType::Array(array_type) => {
             // Multiply the size of an element by the length of the array.
-            plaintext_size_in_bits_raw(stack, array_type.next_element_type(), depth + 1)?
+            let (element_size, element_height) =
+                plaintext_size_in_bits_raw(stack, array_type.next_element_type(), depth + 1, memoized)?;
+            let total = element_size
                 .checked_mul(**array_type.length() as usize)
-                .ok_or_else(|| anyhow!("`plaintext_size_in_bits_raw` overflowed"))
+                .ok_or_else(|| anyhow!("`plaintext_size_in_bits_raw` overflowed"))?;
+            // The array sits one level above its element.
+            Ok((total, element_height + 1))
         }
     }
 }

--- a/synthesizer/src/vm/tests/test_v20/plaintext_size.rs
+++ b/synthesizer/src/vm/tests/test_v20/plaintext_size.rs
@@ -325,3 +325,53 @@ constructor:
     )
     .expect("under-cap transitive external struct must pass");
 }
+
+/// A shared-struct graph: `MAX_STRUCT_ENTRIES` members per struct, every member of `s{k}` referring to `s{k-1}`.
+/// A single input of type `s{depth - 1}` therefore spans `MAX_STRUCT_ENTRIES ^ (depth - 1)` distinct root-to-leaf
+/// paths — the shape exploited by the type-validation DoS. Without memoization `check_program_plaintext_sizes`
+/// re-expands every path and never returns; with it, each `(program, struct)` pair is sized once.
+///
+/// The check is run on a detached thread so that the regression surfaces as a bounded timeout failure rather
+/// than hanging the test suite indefinitely.
+#[test]
+fn test_shared_struct_dag_terminates() {
+    use std::{
+        fmt::Write as _,
+        sync::{mpsc, mpsc::RecvTimeoutError},
+        thread,
+        time::Duration,
+    };
+
+    const DEPTH: usize = 12;
+
+    let mut source = String::from("program testing_dag.aleo;\n\n");
+    for level in 0..DEPTH {
+        writeln!(source, "struct s{level}:").unwrap();
+        let member_type = if level == 0 { "field".to_string() } else { format!("s{}", level - 1) };
+        for member in 0..CurrentNetwork::MAX_STRUCT_ENTRIES {
+            writeln!(source, "    m{member} as {member_type};").unwrap();
+        }
+        source.push('\n');
+    }
+    writeln!(source, "function f:\n    input r0 as s{}.private;", DEPTH - 1).unwrap();
+    source.push_str("\nconstructor:\n    assert.eq true true;\n");
+
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = sender.send(run_check_at_v20(&source));
+    });
+
+    // 5 minutes is generous even if the CI machine is heavily loaded.
+    match receiver.recv_timeout(Duration::from_secs(300)) {
+        // The graph is astronomically over the cap, so it must be rejected — either for exceeding the cap or,
+        // as here, because its bit size overflows `usize` first. The point is only that it is rejected promptly.
+        Ok(result) => {
+            result.expect_err("over-cap shared-struct graph must be rejected");
+        }
+        Err(RecvTimeoutError::Timeout) => panic!(
+            "check_program_plaintext_sizes did not terminate within 300s: the shared-struct graph is being \
+             re-expanded exponentially (memoization is missing)"
+        ),
+        Err(RecvTimeoutError::Disconnected) => panic!("the checking thread panicked; see its output above"),
+    }
+}


### PR DESCRIPTION
## Motivation

Prevent exponential recursion in `size_in_bits` and `types_equivalent`.

This is essentially the same issue https://github.com/ProvableHQ/snarkVM/pull/3357 but appearing in different functions.

This was also found by an AI scanner.

The fix is very similar, to use memoization to remember subcalls that we already evaluated so that we don't redo them.

However, the data that is memoized is a little more complex because we need to remember the total "height" we have seen so far; if we don't do that, then it is a subtle change in behavior from what the code does currently.

## Test Plan

We add regression tests that test that pathological cases evaluate correctly in a short amount of time.

## Backwards compatibility

This should be backwards compatible for the same reason that 3357 was -- we aren't changing behavior, we are just more efficiently determining the same answer.