### PR TITLE
docs: stop rustdoc compiling the Restrictions how-to snippets

### DIFF
--- a/synthesizer/src/restrictions/mod.rs
+++ b/synthesizer/src/restrictions/mod.rs
@@ -58,7 +58,7 @@ use indexmap::IndexMap;
 /// # Example: Restricting a program
 ///
 /// ## In the `test_restrictions_list_comparison` function of `synthesizer/src/restrictions/mod.rs`:
-/// ```rust
+/// ```ignore
 /// // Set the network.
 /// type Network = console::network::MainnetV0;
 /// // Initialize the restrictions.
@@ -94,7 +94,7 @@ use indexmap::IndexMap;
 /// Make sure to import `console::types::Address`, e.g., by replacing `use console::types::I8;` with `use console::types::{Address, I8};`.
 ///
 /// ## In the `test_restrictions_list_comparison function` of `synthesizer/src/restrictions/mod.rs`:
-/// ```rust
+/// ```ignore
 /// // Set the network.
 /// type Network = console::network::MainnetV0;
 /// // Initialize the restrictions.


### PR DESCRIPTION
`cargo test -p snarkvm-synthesizer --doc` fails on two blocks in the `Restrictions` doc comment. They are not examples: they are snippets to paste into the body of `test_restrictions_list_comparison`, where `check_restrictions!` is a local `macro_rules!` and the types are already in scope. Standalone they cannot compile — the macro does not exist outside that function and the snippets carry no imports.

Fence them as `ignore` so rustdoc renders them with Rust highlighting but does not build them.