### PR TITLE
Fixed synthesis limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1324,7 +1324,7 @@ workflows:
       or pipeline.git.branch == "canary"
       or pipeline.git.branch == "testnet"
       or pipeline.git.branch == "mainnet"
-      or pipeline.git.branch == "fix_ci_integration"
+      or pipeline.git.branch == "fixed_synthesis_limit"
     jobs:
       - check-unused-dependencies # This can be cleaned up before releases
       - check-cargo-semver-checks # This can be cleaned up before releases

--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -70,7 +70,8 @@ pub enum ConsensusVersion {
     ///      and enforces canonical subDAG certificate ordering.
     V18 = 18,
     /// V19: Adds more accurate type checking for the root call, and bounds the size of every
-    /// `PlaintextType` declared in a deployed program.
+    ///      `PlaintextType` declared in a deployed program. It introduces a fixed block-wide
+    ///      synthesis limit.
     V19 = 19,
     /// V20: TBD
     V20 = 20,

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -163,6 +163,9 @@ pub trait Network:
     /// when checking a deployment. From it, a per-proposal synthesis limit is enforced starting at consensus
     /// version V17 which overrides the two per-transaction limits above.
     const SYNTHESIS_PER_SECOND_OF_RUNTIME: u64 = 1_500_000;
+    /// Starting with consensus version V19, the synthesis limit is fixed at 15_000_000, roughly 10 seconds of
+    /// synthesis work.
+    const STATIC_SYNTHESIS_LIMIT: u64 = 10 * Self::SYNTHESIS_PER_SECOND_OF_RUNTIME;
     const MAX_BATCH_PROOF_INSTANCES: usize = 128;
     /// The maximum number of microcredits that can be spent as a fee.
     const MAX_FEE: u64 = 1_000_000_000_000_000;

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -236,7 +236,11 @@ impl<N: Network> Subdag<N> {
     #[inline]
     #[allow(clippy::cast_possible_truncation)]
     pub fn synthesis_limit(&self, block_height: u32) -> Option<u64> {
-        if block_height >= N::CONSENSUS_HEIGHT(ConsensusVersion::V18).unwrap() {
+        if block_height >= N::CONSENSUS_HEIGHT(ConsensusVersion::V19).unwrap() {
+            // At V19+ the synthesis limit is fixed and independent of the number of certificates in
+            // the subdag.
+            Some(N::STATIC_SYNTHESIS_LIMIT)
+        } else if block_height >= N::CONSENSUS_HEIGHT(ConsensusVersion::V18).unwrap() {
             // One full round of consensus has a synthesis budget of 5 seconds.
             let synthesis_per_second_runtime = 5_f64 * N::SYNTHESIS_PER_SECOND_OF_RUNTIME as f64;
             // A certificate therefore has a synthesis budget of 5 seconds / MAX_CERTIFICATES.

--- a/synthesizer/src/vm/tests/test_v18/blockwide_synthesis_limit.rs
+++ b/synthesizer/src/vm/tests/test_v18/blockwide_synthesis_limit.rs
@@ -128,7 +128,7 @@ fn test_blockwide_synthesis_limit() {
     let rng = &mut TestRng::default();
 
     let v18_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V18).unwrap();
-    let vm = sample_vm_at_height(v18_height, rng);
+    let mut vm = sample_vm_with_genesis_block(rng);
     let genesis_private_key = sample_genesis_private_key(rng);
 
     // Set to true to print the combined density of each individual deployment.
@@ -185,6 +185,10 @@ fn test_blockwide_synthesis_limit() {
     let num_deployer_keys = cases.iter().map(|(_, ds, _)| ds.len()).sum::<usize>();
 
     let mut deployer_keys = fund_deployer_keys(&vm, &genesis_private_key, num_deployer_keys, rng);
+
+    // Advance the tip to one block below V18 so that the block under test (tip + 1) lands exactly on
+    // V18, exercising the per-certificate synthesis limit rather than the static V19+ limit.
+    advance_vm_to_height(&mut vm, genesis_private_key, v18_height - 1, rng);
 
     let block_hash = vm.block_store().get_block_hash(vm.block_store().max_height().unwrap()).unwrap().unwrap();
     let previous_block = vm.block_store().get_block(&block_hash).unwrap().unwrap();


### PR DESCRIPTION
Switches the block-wide synthesis limit introduced in V18 from the value computed there (which depended on the number of certificates in the consensus rounds) to a hardcoded value of 15_000_000 (roughly equivalent to 10 seconds of deployment-verification time).