### PR TITLE
CC additional maintainers on benchmark regression alerts

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -139,7 +139,7 @@ jobs:
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true
-          alert-comment-cc-users: '@vicsn'
+          alert-comment-cc-users: '@vicsn,@snarkworld,@cbeck88'
           auto-push: true
           # Enable Job Summary for PRs
           summary-always: true


### PR DESCRIPTION
## Summary
- Add `@snarkworld` and `@cbeck88` to `alert-comment-cc-users` in the snarkVM benchmark workflow so they are notified on regression alerts, alongside `@vicsn`.