### PR TITLE
Emit DynamicRecord encoding version 2

### DIFF
--- a/console/program/src/data/dynamic/record/bytes.rs
+++ b/console/program/src/data/dynamic/record/bytes.rs
@@ -94,9 +94,12 @@ impl<N: Network> DynamicRecord<N> {
 
 impl<N: Network> ToBytes for DynamicRecord<N> {
     /// Writes the record to a buffer.
+    ///
+    /// Always writes encoding version 2, which includes the plaintext entry map when it is present.
+    /// Merge this change only after delegated provers decode version 2.
     fn write_le<W: Write>(&self, mut writer: W) -> IoResult<()> {
         // Write the serialization format version.
-        1u8.write_le(&mut writer)?;
+        2u8.write_le(&mut writer)?;
 
         // Write the owner.
         self.owner.write_le(&mut writer)?;
@@ -108,7 +111,41 @@ impl<N: Network> ToBytes for DynamicRecord<N> {
         self.nonce.write_le(&mut writer)?;
 
         // Write the record version field.
-        self.version.write_le(&mut writer)
+        self.version.write_le(&mut writer)?;
+
+        // Write the optional entry map (empty when `data` is `None`).
+        Self::write_data_le(&mut writer, self.data.as_ref())
+    }
+}
+
+impl<N: Network> DynamicRecord<N> {
+    /// Writes a version-2 plaintext entry map.
+    fn write_data_le<W: Write>(mut writer: W, data: Option<&RecordData<N>>) -> IoResult<()> {
+        let data = match data {
+            Some(data) => data,
+            None => {
+                0u8.write_le(&mut writer)?;
+                return Ok(());
+            }
+        };
+
+        // Write the number of entries.
+        u8::try_from(data.len()).or_halt_with::<N>("Dynamic record length exceeds u8::MAX").write_le(&mut writer)?;
+        // Write each entry.
+        for (entry_name, entry_value) in data {
+            // Write the entry name.
+            entry_name.write_le(&mut writer)?;
+            // Write the entry value (performed in 2 steps to prevent infinite recursion).
+            let bytes = entry_value.to_bytes_le().map_err(|e| error(e.to_string()))?;
+            // Write the number of bytes.
+            u16::try_from(bytes.len())
+                .or_halt_with::<N>("Dynamic record entry exceeds u16::MAX bytes")
+                .write_le(&mut writer)?;
+            // Write the bytes.
+            bytes.write_le(&mut writer)?;
+        }
+
+        Ok(())
     }
 }
 
@@ -133,6 +170,7 @@ mod tests {
         assert_eq!(expected.root(), candidate.root());
         assert_eq!(expected.nonce(), candidate.nonce());
         assert_eq!(expected.version(), candidate.version());
+        assert_eq!(expected.data(), candidate.data());
     }
 
     #[test]
@@ -181,23 +219,14 @@ mod tests {
         check_bytes(&record);
     }
 
-    /// Encodes a dynamic record using the version-2 layout (header plus entry map).
-    fn write_v2(record: &DynamicRecord<CurrentNetwork>) -> Vec<u8> {
+    /// Encodes a dynamic record using the version-1 layout (header only).
+    fn write_v1(record: &DynamicRecord<CurrentNetwork>) -> Vec<u8> {
         let mut writer = Vec::new();
-        2u8.write_le(&mut writer).unwrap();
+        1u8.write_le(&mut writer).unwrap();
         record.owner().write_le(&mut writer).unwrap();
         record.root().write_le(&mut writer).unwrap();
         record.nonce().write_le(&mut writer).unwrap();
         record.version().write_le(&mut writer).unwrap();
-
-        let data = record.data().as_ref().expect("expected populated dynamic record data");
-        u8::try_from(data.len()).unwrap().write_le(&mut writer).unwrap();
-        for (entry_name, entry_value) in data {
-            entry_name.write_le(&mut writer).unwrap();
-            let bytes = entry_value.to_bytes_le().unwrap();
-            u16::try_from(bytes.len()).unwrap().write_le(&mut writer).unwrap();
-            bytes.write_le(&mut writer).unwrap();
-        }
         writer
     }
 
@@ -218,7 +247,7 @@ mod tests {
         .unwrap();
         let expected = DynamicRecord::from_record(&record).unwrap();
 
-        let candidate = DynamicRecord::<CurrentNetwork>::read_le(&write_v2(&expected)[..]).unwrap();
+        let candidate = DynamicRecord::<CurrentNetwork>::read_le(&expected.to_bytes_le().unwrap()[..]).unwrap();
         assert_eq!(expected.owner(), candidate.owner());
         assert_eq!(expected.root(), candidate.root());
         assert_eq!(expected.nonce(), candidate.nonce());
@@ -244,7 +273,7 @@ mod tests {
         let expected = DynamicRecord::from_record(&record).unwrap();
         assert!(expected.data().is_some());
 
-        let candidate = DynamicRecord::<CurrentNetwork>::read_le(&expected.to_bytes_le().unwrap()[..]).unwrap();
+        let candidate = DynamicRecord::<CurrentNetwork>::read_le(&write_v1(&expected)[..]).unwrap();
         assert!(candidate.data().is_none());
     }
 
@@ -263,7 +292,7 @@ mod tests {
         )
         .unwrap();
         let expected = DynamicRecord::from_record(&record).unwrap();
-        let mut bytes = write_v2(&expected);
+        let mut bytes = expected.to_bytes_le().unwrap();
         // Overwrite the root (bytes after the encoding version and owner).
         let root_offset = 1 + expected.owner().to_bytes_le().unwrap().len();
         let root_bytes = Field::<CurrentNetwork>::from_u64(12345).to_bytes_le().unwrap();

--- a/console/program/src/data/dynamic/record/bytes.rs
+++ b/console/program/src/data/dynamic/record/bytes.rs
@@ -19,10 +19,10 @@ impl<N: Network> FromBytes for DynamicRecord<N> {
     /// Reads the dynamic record from a buffer.
     fn read_le<R: Read>(mut reader: R) -> IoResult<Self> {
         // Read the serialization format version.
-        let version = u8::read_le(&mut reader)?;
+        let encoding_version = u8::read_le(&mut reader)?;
         // Ensure the version is valid.
-        if version != 1 {
-            return Err(error("Invalid dynamic record version"));
+        if encoding_version != 1 && encoding_version != 2 {
+            return Err(error(format!("Invalid dynamic record version: {encoding_version}")));
         }
 
         // Read the owner.
@@ -37,7 +37,58 @@ impl<N: Network> FromBytes for DynamicRecord<N> {
         // Read the record version field.
         let version = U8::read_le(&mut reader)?;
 
-        Ok(Self::new_unchecked(owner, root, nonce, version, None))
+        // Version 1 omits entry data. Version 2 includes it.
+        let data = match encoding_version {
+            1 => None,
+            2 => Some(Self::read_data_le(&mut reader, &root)?),
+            // Note that the version is validated above to be 1 or 2.
+            _ => unreachable!(),
+        };
+
+        Ok(Self::new_unchecked(owner, root, nonce, version, data))
+    }
+}
+
+impl<N: Network> DynamicRecord<N> {
+    /// Reads a version-2 plaintext entry map and checks it against the Merkle root.
+    fn read_data_le<R: Read>(mut reader: R, root: &Field<N>) -> IoResult<RecordData<N>> {
+        // Read the number of entries.
+        let num_entries = u8::read_le(&mut reader)?;
+        // Ensure the number of entries is within the maximum limit.
+        if num_entries as usize > N::MAX_DATA_ENTRIES {
+            return Err(error("Failed to parse dynamic record - too many entries"));
+        }
+
+        // Read the record data.
+        let mut data = IndexMap::with_capacity(num_entries as usize);
+        for _ in 0..num_entries {
+            // Read the identifier.
+            let identifier = Identifier::<N>::read_le(&mut reader)?;
+            // Read the entry value (in 2 steps to prevent infinite recursion).
+            let num_bytes = u16::read_le(&mut reader)?;
+            // Read the entry bytes.
+            let mut bytes = Vec::new();
+            (&mut reader).take(num_bytes as u64).read_to_end(&mut bytes)?;
+            // Recover the entry value.
+            let entry = Entry::read_le(&mut bytes.as_slice())?;
+            // Add the entry.
+            data.insert(identifier, entry);
+        }
+
+        // Prepare the reserved entry names.
+        let reserved = [Identifier::from_str("owner").map_err(|e| error(e.to_string()))?];
+        // Ensure the entries have no duplicate names.
+        if has_duplicates(data.keys().chain(reserved.iter())) {
+            return Err(error("Duplicate entry type found in dynamic record"));
+        }
+
+        // Check that the Merkle root matches the recovered data.
+        let tree = Self::merkleize_data(&data).map_err(|e| error(e.to_string()))?;
+        if tree.root() != root {
+            return Err(error("The root in the dynamic record does not match the one computed from its data"));
+        }
+
+        Ok(data)
     }
 }
 
@@ -128,5 +179,97 @@ mod tests {
         )
         .unwrap();
         check_bytes(&record);
+    }
+
+    /// Encodes a dynamic record using the version-2 layout (header plus entry map).
+    fn write_v2(record: &DynamicRecord<CurrentNetwork>) -> Vec<u8> {
+        let mut writer = Vec::new();
+        2u8.write_le(&mut writer).unwrap();
+        record.owner().write_le(&mut writer).unwrap();
+        record.root().write_le(&mut writer).unwrap();
+        record.nonce().write_le(&mut writer).unwrap();
+        record.version().write_le(&mut writer).unwrap();
+
+        let data = record.data().as_ref().expect("expected populated dynamic record data");
+        u8::try_from(data.len()).unwrap().write_le(&mut writer).unwrap();
+        for (entry_name, entry_value) in data {
+            entry_name.write_le(&mut writer).unwrap();
+            let bytes = entry_value.to_bytes_le().unwrap();
+            u16::try_from(bytes.len()).unwrap().write_le(&mut writer).unwrap();
+            bytes.write_le(&mut writer).unwrap();
+        }
+        writer
+    }
+
+    #[test]
+    fn test_read_le_version_2_recovers_data() {
+        let rng = &mut TestRng::default();
+        let data = indexmap::indexmap! {
+            Identifier::from_str("amount").unwrap() => Entry::Private(Plaintext::from(Literal::U64(U64::rand(rng)))),
+            Identifier::from_str("memo").unwrap() => Entry::Public(Plaintext::from(Literal::U64(U64::rand(rng)))),
+        };
+        let owner = Owner::Public(Address::rand(rng));
+        let record = Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::from_plaintext(
+            owner,
+            data.clone(),
+            Group::rand(rng),
+            U8::new(0),
+        )
+        .unwrap();
+        let expected = DynamicRecord::from_record(&record).unwrap();
+
+        let candidate = DynamicRecord::<CurrentNetwork>::read_le(&write_v2(&expected)[..]).unwrap();
+        assert_eq!(expected.owner(), candidate.owner());
+        assert_eq!(expected.root(), candidate.root());
+        assert_eq!(expected.nonce(), candidate.nonce());
+        assert_eq!(expected.version(), candidate.version());
+        assert_eq!(expected.data(), candidate.data());
+        assert_eq!(candidate.data().as_ref(), Some(&data));
+    }
+
+    #[test]
+    fn test_read_le_version_1_omits_data() {
+        let rng = &mut TestRng::default();
+        let data = indexmap::indexmap! {
+            Identifier::from_str("amount").unwrap() => Entry::Private(Plaintext::from(Literal::U64(U64::rand(rng)))),
+        };
+        let owner = Owner::Public(Address::rand(rng));
+        let record = Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::from_plaintext(
+            owner,
+            data,
+            Group::rand(rng),
+            U8::new(0),
+        )
+        .unwrap();
+        let expected = DynamicRecord::from_record(&record).unwrap();
+        assert!(expected.data().is_some());
+
+        let candidate = DynamicRecord::<CurrentNetwork>::read_le(&expected.to_bytes_le().unwrap()[..]).unwrap();
+        assert!(candidate.data().is_none());
+    }
+
+    #[test]
+    fn test_read_le_version_2_rejects_mismatched_root() {
+        let rng = &mut TestRng::default();
+        let data = indexmap::indexmap! {
+            Identifier::from_str("amount").unwrap() => Entry::Private(Plaintext::from(Literal::U64(U64::new(1)))),
+        };
+        let owner = Owner::Public(Address::rand(rng));
+        let record = Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::from_plaintext(
+            owner,
+            data,
+            Group::rand(rng),
+            U8::new(0),
+        )
+        .unwrap();
+        let expected = DynamicRecord::from_record(&record).unwrap();
+        let mut bytes = write_v2(&expected);
+        // Overwrite the root (bytes after the encoding version and owner).
+        let root_offset = 1 + expected.owner().to_bytes_le().unwrap().len();
+        let root_bytes = Field::<CurrentNetwork>::from_u64(12345).to_bytes_le().unwrap();
+        bytes[root_offset..root_offset + root_bytes.len()].copy_from_slice(&root_bytes);
+
+        let error = DynamicRecord::<CurrentNetwork>::read_le(&bytes[..]).unwrap_err();
+        assert!(error.to_string().contains("does not match"));
     }
 }

--- a/console/program/src/data/record/bytes.rs
+++ b/console/program/src/data/record/bytes.rs
@@ -37,6 +37,12 @@ impl<N: Network, Private: Visibility> FromBytes for Record<N, Private> {
 
         // Read the number of entries in the record data.
         let num_entries = u8::read_le(&mut reader)?;
+
+        // Ensure the number of entries is within the maximum limit.
+        if num_entries as usize > N::MAX_DATA_ENTRIES {
+            return Err(error("Failed to parse record - too many entries"));
+        }
+
         // Read the record data.
         let mut data = IndexMap::with_capacity(num_entries as usize);
         for _ in 0..num_entries {
@@ -61,10 +67,6 @@ impl<N: Network, Private: Visibility> FromBytes for Record<N, Private> {
         // Ensure the entries has no duplicate names.
         if has_duplicates(data.keys().chain(reserved.iter())) {
             return Err(error("Duplicate entry type found in record"));
-        }
-        // Ensure the number of entries is within the maximum limit.
-        if data.len() > N::MAX_DATA_ENTRIES {
-            return Err(error("Failed to parse record - too many entries"));
         }
 
         Ok(Self { owner, data, nonce, version })


### PR DESCRIPTION
## Summary
- `DynamicRecord::write_le` now writes encoding version 2. The payload includes the plaintext entry map.
- A version-2 round-trip keeps the record entries. `get.record.dynamic` can then run after a client sends an `Authorization` to a prover.
- Version 1 payloads still decode. Do not merge this PR until delegated provers run #3382.

Depends on https://github.com/ProvableHQ/snarkVM/pull/3382.

CC @iamalwaysuncomfortable @Roee-87 @niklaslong

## Test plan
- [ ] Merge or rebase onto #3382 first
- [ ] `cargo test -p snarkvm-console-program -- data::dynamic::record::bytes`
- [ ] Confirm `from_record` then `to_bytes_le` then `read_le` recovers `data`
- [ ] Confirm a version-1 fixture still decodes with `data: None`


Made with [Cursor](https://cursor.com)