### PR TITLE
Stabilize Puzzle::prove benchmark CI reporting

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -115,7 +115,11 @@ jobs:
       - name: Benchmark ledger/puzzle
         run: |
           set -o pipefail
-          cargo bench --package=snarkvm-ledger-puzzle --bench puzzle --features=setup -- --output-format bencher | tee -a output.txt
+          # Puzzle::prove is high-variance at the crate's 10-sample default; the
+          # bencher median then trips the 200% alert. Collect it separately with
+          # more samples and longer windows. Filter so check_solutions stays cheap.
+          cargo bench --package=snarkvm-ledger-puzzle --bench puzzle --features=setup -- Puzzle::prove --output-format bencher --sample-size 100 --warm-up-time 3 --measurement-time 10 | tee -a output.txt
+          cargo bench --package=snarkvm-ledger-puzzle --bench puzzle --features=setup -- Puzzle::check_solutions --output-format bencher | tee -a output.txt
 
       # Clean benchmark output to remove unnecessary lines
       - name: Clean benchmark output

--- a/ledger/puzzle/README.md
+++ b/ledger/puzzle/README.md
@@ -3,3 +3,12 @@
 [![Crates.io](https://img.shields.io/crates/v/snarkvm-ledger-puzzle.svg?color=neon)](https://crates.io/crates/snarkvm-ledger-puzzle)
 [![Authors](https://img.shields.io/badge/authors-Aleo-orange.svg)](https://aleo.org)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE.md)
+
+## Benchmarks
+
+`Puzzle::prove` is noisy at Criterion's 10-sample default (the bencher format reports a median, and CI fails at 200%). CI therefore runs it alone with 100 samples, 3s warmup, and 10s measurement. `Puzzle::check_solutions` keeps the cheap default.
+
+```bash
+cargo bench --package=snarkvm-ledger-puzzle --bench puzzle --features=setup -- Puzzle::prove \
+  --sample-size 100 --warm-up-time 3 --measurement-time 10
+```

--- a/ledger/puzzle/benches/puzzle.rs
+++ b/ledger/puzzle/benches/puzzle.rs
@@ -27,6 +27,7 @@ use snarkvm_ledger_puzzle_epoch::MerklePuzzle;
 
 use criterion::Criterion;
 use rand::{self, CryptoRng, RngExt};
+use std::time::Duration;
 
 fn sample_address_and_counter(rng: &mut impl CryptoRng) -> (Address<MainnetV0>, u64) {
     let private_key = PrivateKey::new(rng).unwrap();
@@ -75,9 +76,18 @@ fn puzzle_verify(c: &mut Criterion) {
 }
 
 criterion_group! {
-    name = puzzle;
-    config = Criterion::default().sample_size(10);
-    targets = puzzle_prove, puzzle_verify,
+    name = puzzle_prove_group;
+    config = Criterion::default()
+        .sample_size(100)
+        .warm_up_time(Duration::from_secs(3))
+        .measurement_time(Duration::from_secs(10));
+    targets = puzzle_prove,
 }
 
-criterion_main!(puzzle);
+criterion_group! {
+    name = puzzle_verify_group;
+    config = Criterion::default().sample_size(10);
+    targets = puzzle_verify,
+}
+
+criterion_main!(puzzle_prove_group, puzzle_verify_group);


### PR DESCRIPTION
## Summary
- Run `Puzzle::prove` in CI with 100 samples, 3s warmup, and 10s measurement so the bencher median is not dominated by the old 10-sample default.
- Keep `Puzzle::check_solutions` on the cheap path; document the local command in `ledger/puzzle/README.md`.

A 940% `Puzzle::prove` alert between `c04138c` and `f1f867b` did not reproduce locally (later SHA was faster). The 200% github-action-benchmark gate was firing on n=10 noise.

## Test plan
- [x] Confirm the `Benchmark ledger/puzzle` step still emits one `Puzzle::prove` bencher line and the `Puzzle::check_solutions` line(s).
- [x] After merge, treat the first post-change comparison as a new baseline for `Puzzle::prove` (sample size changed).