### PR TITLE
Apply a conservative spend_limit to beacon blocks similar to production environments

### DIFF
--- a/console/network/src/canary_v0.rs
+++ b/console/network/src/canary_v0.rs
@@ -169,21 +169,23 @@ impl Network for CanaryV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::canary::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 100),
         (ConsensusVersion::V5, 100),
         (ConsensusVersion::V6, 100),
         (ConsensusVersion::V9, 100),
+        (ConsensusVersion::V20, 100),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 25),
         (ConsensusVersion::V3, 25),
         (ConsensusVersion::V5, 25),
         (ConsensusVersion::V6, 25),
         (ConsensusVersion::V9, 25),
+        (ConsensusVersion::V20, 25),
     ];
     /// The (long) network name.
     const NAME: &'static str = "Aleo Canary (v0)";

--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -73,8 +73,8 @@ pub enum ConsensusVersion {
     ///      deployment variable and constraint limits. The first V19 block still
     ///      uses the block-wide synthesis limit.
     V19 = 19,
-    /// V20: Adds more accurate type checking for the root call, and bounds the size of every
-    /// `PlaintextType` declared in a deployed program.
+    /// V20: Adds more accurate type checking for the root call, bounds the size of every
+    /// `PlaintextType` declared in a deployed program, and updates the number of validators.
     V20 = 20,
     /// V21: TBD
     V21 = 21,
@@ -499,10 +499,13 @@ mod tests {
 
     /// Ensure that `MAX_CERTIFICATES` increases and is correctly defined.
     /// See the constant declaration for an explanation why.
-    fn max_certificates_increasing<N: Network>() {
+    /// The versions in `exempt_versions` are permitted to decrease the value.
+    fn max_certificates_increasing<N: Network>(exempt_versions: &[ConsensusVersion]) {
         let mut previous_value = N::MAX_CERTIFICATES.first().unwrap().1;
-        for (_, value) in N::MAX_CERTIFICATES.iter().skip(1) {
-            assert!(*value >= previous_value);
+        for (version, value) in N::MAX_CERTIFICATES.iter().skip(1) {
+            if !exempt_versions.contains(version) {
+                assert!(*value >= previous_value, "MAX_CERTIFICATES must not decrease at {version:?}");
+            }
             previous_value = *value;
         }
     }
@@ -618,9 +621,10 @@ mod tests {
         consensus_config_returns_some::<TestnetV0>();
         consensus_config_returns_some::<CanaryV0>();
 
-        max_certificates_increasing::<MainnetV0>();
-        max_certificates_increasing::<TestnetV0>();
-        max_certificates_increasing::<CanaryV0>();
+        max_certificates_increasing::<MainnetV0>(&[]);
+        // Testnet lowers the maximum committee size at `V20`.
+        max_certificates_increasing::<TestnetV0>(&[ConsensusVersion::V20]);
+        max_certificates_increasing::<CanaryV0>(&[]);
 
         max_array_elements_increasing::<MainnetV0>();
         max_array_elements_increasing::<TestnetV0>();

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -319,7 +319,7 @@ pub trait Network:
     //  Decreasing this value will break backwards compatibility of serialization without explicit
     //  declaration of migration based on round number rather than block height.
     //  Increasing this value will require a migration to prevent forking during network upgrades.
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5];
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6];
 
     /// Returns the list of consensus versions.
     #[allow(non_snake_case)]

--- a/console/network/src/mainnet_v0.rs
+++ b/console/network/src/mainnet_v0.rs
@@ -174,21 +174,23 @@ impl Network for MainnetV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::mainnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 16),
         (ConsensusVersion::V3, 25),
         (ConsensusVersion::V5, 30),
         (ConsensusVersion::V6, 35),
         (ConsensusVersion::V9, 40),
+        (ConsensusVersion::V20, 40),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 101),
         (ConsensusVersion::V5, 102),
         (ConsensusVersion::V6, 103),
         (ConsensusVersion::V9, 104),
+        (ConsensusVersion::V20, 105),
     ];
     /// The (long) network name.
     const NAME: &'static str = "Aleo Mainnet (v0)";

--- a/console/network/src/testnet_v0.rs
+++ b/console/network/src/testnet_v0.rs
@@ -169,21 +169,23 @@ impl Network for TestnetV0 {
     const INCLUSION_FUNCTION_NAME: &'static str = snarkvm_parameters::testnet::NETWORK_INCLUSION_FUNCTION_NAME;
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(not(any(test, feature = "test")))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 100),
         (ConsensusVersion::V3, 100),
         (ConsensusVersion::V5, 100),
         (ConsensusVersion::V6, 100),
         (ConsensusVersion::V9, 100),
+        (ConsensusVersion::V20, 40),
     ];
     /// A list of (consensus_version, size) pairs indicating the maximum number of certificates in a batch.
     #[cfg(any(test, feature = "test"))]
-    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 5] = [
+    const MAX_CERTIFICATES: [(ConsensusVersion, u16); 6] = [
         (ConsensusVersion::V1, 25),
         (ConsensusVersion::V3, 25),
         (ConsensusVersion::V5, 25),
         (ConsensusVersion::V6, 25),
         (ConsensusVersion::V9, 25),
+        (ConsensusVersion::V20, 25),
     ];
     /// The (long) network name.
     const NAME: &'static str = "Aleo Testnet (v0)";

--- a/ledger/authority/src/lib.rs
+++ b/ledger/authority/src/lib.rs
@@ -115,6 +115,11 @@ impl<N: Network> Authority<N> {
             Self::Quorum(subdag) => subdag.leader_address(),
         }
     }
+
+    /// Returns spend and synthesis limits for a beacon block at `block_height`.
+    pub fn beacon_limits(block_height: u32) -> (Option<u64>, Option<u64>) {
+        (Subdag::<N>::min_spend_limit(block_height), Subdag::<N>::min_synthesis_limit(block_height))
+    }
 }
 
 #[cfg(any(test, feature = "test-helpers"))]

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -258,15 +258,14 @@ impl<N: Network> Subdag<N> {
         }
     }
 
-    /// Returns a lower-bound certificate count for a subdag at `block_height`.
+    /// Returns a lower-bound certificate count for a subdag with `max_certificates` per round.
     ///
-    /// For `N = MAX_CERTIFICATES(block_height)` written as `N = 3f + 1`, this is the integer
-    /// `2 * (f + 1)`. In general (including `N = 3f + 1 + k` with `0 <= k < 3`), this is two
-    /// rounds of the availability threshold: `2 * ((N + 2) / 3)`.
+    /// For `N = max_certificates` written as `N = 3f + 1`, this is the integer `2 * (f + 1)`.
+    /// In general (including `N = 3f + 1 + k` with `0 <= k < 3`), this is two rounds of the
+    /// availability threshold: `2 * ((N + 2) / 3)`.
     #[inline]
-    pub fn min_certificates(block_height: u32) -> u64 {
-        // unwrap: `MAX_CERTIFICATES` is defined for every consensus height.
-        let n = consensus_config_value!(N, MAX_CERTIFICATES, block_height).unwrap() as u64;
+    pub fn min_certificates(max_certificates: u16) -> u64 {
+        let n = max_certificates as u64;
         // `(N + 2) / 3 = f + 1` when `N = 3f + 1 + k` with `0 <= k < 3`.
         n.saturating_add(2).saturating_div(3).saturating_mul(2)
     }
@@ -278,7 +277,9 @@ impl<N: Network> Subdag<N> {
     pub fn min_spend_limit(block_height: u32) -> Option<u64> {
         // unwrap: `CONSENSUS_HEIGHT` is defined for every `ConsensusVersion`.
         if block_height >= N::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap() {
-            Some(Self::min_certificates(block_height).saturating_mul(BatchHeader::<N>::batch_spend_limit(block_height)))
+            // unwrap: `MAX_CERTIFICATES` is defined for every consensus height.
+            let max_certs = consensus_config_value!(N, MAX_CERTIFICATES, block_height).unwrap();
+            Some(Self::min_certificates(max_certs).saturating_mul(BatchHeader::<N>::batch_spend_limit(block_height)))
         } else {
             None
         }
@@ -296,9 +297,9 @@ impl<N: Network> Subdag<N> {
         {
             let synthesis_per_second_runtime = 5_f64 * N::SYNTHESIS_PER_SECOND_OF_RUNTIME as f64;
             // unwrap: `MAX_CERTIFICATES` is defined for every consensus height.
-            let synthesis_per_certificate = synthesis_per_second_runtime
-                / consensus_config_value!(N, MAX_CERTIFICATES, block_height).unwrap() as f64;
-            Some((synthesis_per_certificate * Self::min_certificates(block_height) as f64) as u64)
+            let max_certificates = consensus_config_value!(N, MAX_CERTIFICATES, block_height).unwrap();
+            let synthesis_per_certificate = synthesis_per_second_runtime / max_certificates as f64;
+            Some((synthesis_per_certificate * Self::min_certificates(max_certificates) as f64) as u64)
         } else {
             None
         }
@@ -704,27 +705,15 @@ mod tests {
         }
     }
 
-    /// Beacon min limits match a subdag with `min_certificates` certificates.
+    /// Minimum certificates must be equal to 2*(f+1) for N=3f+1+k with 0<=k<3.
     #[test]
-    fn test_min_limits_use_min_certificates() {
-        let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap();
-        let v18_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V18).unwrap();
-
-        for height in [v16_height, v18_height, u32::MAX] {
-            let n = consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, height).unwrap() as u64;
-            let min_certs = n.saturating_add(2).saturating_div(3).saturating_mul(2);
-            assert_eq!(Subdag::<CurrentNetwork>::min_certificates(height), min_certs);
-            if n % 3 == 1 {
-                let f = n.saturating_sub(1) / 3;
-                assert_eq!(min_certs, 2 * (f + 1));
-            }
-
-            if height >= v16_height {
-                assert_eq!(
-                    Subdag::<CurrentNetwork>::min_spend_limit(height),
-                    Some(min_certs.saturating_mul(BatchHeader::<CurrentNetwork>::batch_spend_limit(height)))
-                );
-            }
+    fn test_min_certificates() {
+        for n in 1u16..=200 {
+            let n_u64 = n as u64;
+            let min_certs = n_u64.saturating_add(2).saturating_div(3).saturating_mul(2);
+            let f = n_u64.saturating_sub(1) / 3;
+            assert_eq!(min_certs, 2 * (f + 1), "min_certificates must equal 2*(f+1) for N={n}");
+            assert_eq!(Subdag::<CurrentNetwork>::min_certificates(n), min_certs);
         }
     }
 }

--- a/ledger/narwhal/subdag/src/lib.rs
+++ b/ledger/narwhal/subdag/src/lib.rs
@@ -258,6 +258,52 @@ impl<N: Network> Subdag<N> {
         }
     }
 
+    /// Returns a lower-bound certificate count for a subdag at `block_height`.
+    ///
+    /// For `N = MAX_CERTIFICATES(block_height)` written as `N = 3f + 1`, this is the integer
+    /// `2 * (f + 1)`. In general (including `N = 3f + 1 + k` with `0 <= k < 3`), this is two
+    /// rounds of the availability threshold: `2 * ((N + 2) / 3)`.
+    #[inline]
+    pub fn min_certificates(block_height: u32) -> u64 {
+        // unwrap: `MAX_CERTIFICATES` is defined for every consensus height.
+        let n = consensus_config_value!(N, MAX_CERTIFICATES, block_height).unwrap() as u64;
+        // `(N + 2) / 3 = f + 1` when `N = 3f + 1 + k` with `0 <= k < 3`.
+        n.saturating_add(2).saturating_div(3).saturating_mul(2)
+    }
+
+    /// Returns the block spend limit for a subdag with `min_certificates` at `block_height`.
+    ///
+    /// Used for beacon blocks, which have no subdag but must still enforce block-wide limits.
+    #[inline]
+    pub fn min_spend_limit(block_height: u32) -> Option<u64> {
+        // unwrap: `CONSENSUS_HEIGHT` is defined for every `ConsensusVersion`.
+        if block_height >= N::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap() {
+            Some(Self::min_certificates(block_height).saturating_mul(BatchHeader::<N>::batch_spend_limit(block_height)))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the synthesis limit for a subdag with `min_certificates` at `block_height`.
+    ///
+    /// Used for beacon blocks, which have no subdag but must still enforce block-wide limits.
+    #[inline]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn min_synthesis_limit(block_height: u32) -> Option<u64> {
+        // unwrap: `CONSENSUS_HEIGHT` is defined for every `ConsensusVersion`.
+        if block_height >= N::CONSENSUS_HEIGHT(ConsensusVersion::V18).unwrap()
+            && block_height <= N::CONSENSUS_HEIGHT(ConsensusVersion::V19).unwrap()
+        {
+            let synthesis_per_second_runtime = 5_f64 * N::SYNTHESIS_PER_SECOND_OF_RUNTIME as f64;
+            // unwrap: `MAX_CERTIFICATES` is defined for every consensus height.
+            let synthesis_per_certificate = synthesis_per_second_runtime
+                / consensus_config_value!(N, MAX_CERTIFICATES, block_height).unwrap() as f64;
+            Some((synthesis_per_certificate * Self::min_certificates(block_height) as f64) as u64)
+        } else {
+            None
+        }
+    }
+
     /// Returns the leader certificate.
     pub fn leader_certificate(&self) -> &BatchCertificate<N> {
         // Retrieve entry for the anchor round.
@@ -655,6 +701,30 @@ mod tests {
             let limit = subdag_with_cert_count(n, &mut rng).spend_limit(v16_height).unwrap();
             assert!(limit >= previous, "spend_limit must not decrease: n={n}, limit={limit}, previous={previous}");
             previous = limit;
+        }
+    }
+
+    /// Beacon min limits match a subdag with `min_certificates` certificates.
+    #[test]
+    fn test_min_limits_use_min_certificates() {
+        let v16_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V16).unwrap();
+        let v18_height = CurrentNetwork::CONSENSUS_HEIGHT(ConsensusVersion::V18).unwrap();
+
+        for height in [v16_height, v18_height, u32::MAX] {
+            let n = consensus_config_value!(CurrentNetwork, MAX_CERTIFICATES, height).unwrap() as u64;
+            let min_certs = n.saturating_add(2).saturating_div(3).saturating_mul(2);
+            assert_eq!(Subdag::<CurrentNetwork>::min_certificates(height), min_certs);
+            if n % 3 == 1 {
+                let f = n.saturating_sub(1) / 3;
+                assert_eq!(min_certs, 2 * (f + 1));
+            }
+
+            if height >= v16_height {
+                assert_eq!(
+                    Subdag::<CurrentNetwork>::min_spend_limit(height),
+                    Some(min_certs.saturating_mul(BatchHeader::<CurrentNetwork>::batch_spend_limit(height)))
+                );
+            }
         }
     }
 }

--- a/ledger/src/advance.rs
+++ b/ledger/src/advance.rs
@@ -416,7 +416,7 @@ impl<N: Network, C: ConsensusStorage<N>> Ledger<N, C> {
         let (block_spend_limit, block_synthesis_limit) = if let Some(subdag) = subdag {
             (subdag.spend_limit(next_height), subdag.synthesis_limit(next_height))
         } else {
-            (None, None)
+            (Subdag::<N>::min_spend_limit(next_height), Subdag::<N>::min_synthesis_limit(next_height))
         };
         // Construct the finalize state.
         let state = FinalizeGlobalState::new::<N>(

--- a/synthesizer/src/vm/finalize.rs
+++ b/synthesizer/src/vm/finalize.rs
@@ -311,7 +311,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let (block_spend_limit, block_synthesis_limit) = if let Authority::Quorum(subdag) = block.authority() {
             (subdag.spend_limit(block.height()), subdag.synthesis_limit(block.height()))
         } else {
-            (None, None)
+            Authority::<N>::beacon_limits(block.height())
         };
         let state = FinalizeGlobalState::new::<N>(
             block.round(),

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -328,7 +328,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let (block_spend_limit, block_synthesis_limit) = if let Authority::Quorum(subdag) = block.authority() {
             (subdag.spend_limit(block.height()), subdag.synthesis_limit(block.height()))
         } else {
-            (None, None)
+            Authority::<N>::beacon_limits(block.height())
         };
         FinalizeGlobalState::new::<N>(
             block.round(),
@@ -616,7 +616,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let (block_spend_limit, block_synthesis_limit) = if let Authority::Quorum(subdag) = block.authority() {
             (subdag.spend_limit(block.height()), subdag.synthesis_limit(block.height()))
         } else {
-            (None, None)
+            Authority::<N>::beacon_limits(block.height())
         };
         // Construct the finalize state.
         let state = FinalizeGlobalState::new::<N>(


### PR DESCRIPTION
## Summary

1. Apply `spend_limit` to beacon blocks. Use a conservative `min_certificates` = `2 * ((MAX_CERTIFICATES + 2) / 3)`.
2. Set testnet `MAX_CERTIFICATES` to 40 from consensus V20. This will make the `spend_limit` in testnet beacon blocks reflect reality more closely.

Quorum `spend_limit` does not change.

## Test plan

- [x] `cargo test -p snarkvm-ledger-narwhal-subdag --lib --features test-helpers -- test_spend_limit test_min_limits`
- [x] `cargo test -p snarkvm-console-network --lib consensus_constants --features test`

## Backwards compatibility

The code contains a comment:
```
    //  Note: This value must **not** decrease without considering the impact on serialization.
    //  Decreasing this value will break backwards compatibility of serialization without explicit
    //  declaration of migration based on round number rather than block height.
```
Based on manual and AI review we don't see any issues because we only have 26 validators active on testnet. https://github.com/ProvableHQ/snarkVM/pull/3366#issuecomment-5250733492