### PR TITLE
ci: pin the nightly that check-fmt formats with

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,22 @@ parameters:
   twoxlarge:
     type: string
     default: 2xlarge
+  # The toolchain `check-fmt` formats with.
+  #
+  # `.rustfmt.toml` uses options that only exist on nightly -- imports_layout,
+  # imports_granularity, overflow_delimited_expr, reorder_impl_items and
+  # style_edition -- so the formatter cannot be the 1.88.0 this project builds
+  # with, and `cargo fmt` without a toolchain silently drops all five rather
+  # than refusing. The formatter is therefore a second toolchain, and pinning
+  # it is the same act as pinning the first.
+  #
+  # Resolves to rustfmt 1.9.0-nightly (7e46c5f6fb 2026-04-01); rustup's dated
+  # nightlies are built from the previous day's commit. Bumping it may reformat
+  # the tree, so it should be a deliberate change with the reformatting in the
+  # same commit.
+  fmt_nightly:
+    type: string
+    default: nightly-2026-04-02
 
 orbs:
   windows: circleci/windows@5.0
@@ -473,9 +489,9 @@ commands:
                 cache_key: v4.7.3-rust-1.88.0-<< parameters.workspace_member >><< parameters.cache_key_suffix >>-cache
 
   install_rust_nightly:
-    description: "Install Rust nightly toolchain"
+    description: "Install the pinned Rust nightly toolchain used for formatting"
     steps:
-      - run: rustup toolchain install nightly-x86_64-unknown-linux-gnu
+      - run: rustup toolchain install << pipeline.parameters.fmt_nightly >>-x86_64-unknown-linux-gnu --profile minimal --component rustfmt
 
 jobs:
   snarkvm:
@@ -1127,7 +1143,7 @@ jobs:
       - run:
           name: Check style
           no_output_timeout: 35m
-          command: cargo +nightly fmt --all -- --check
+          command: cargo +<< pipeline.parameters.fmt_nightly >> fmt --all -- --check
       - clear_environment:
           cache_key: v4.7.3-rust-1.88.0-snarkvm-fmt-cache
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,18 +63,20 @@ Run in order:
 ```bash
 cargo check -p <crate>
 cargo clippy -p <crate> -- -D warnings
-cargo +nightly fmt --check
+cargo +nightly-2026-04-02 fmt --check
 cargo test -p <crate>
 ```
 
-Clippy warnings are errors. Formatting requires nightly (`cargo +nightly fmt --all` to fix).
+Clippy warnings are errors. Formatting requires the nightly `.circleci/config.yml` pins as
+`fmt_nightly` (`cargo +nightly-2026-04-02 fmt --all` to fix) -- `.rustfmt.toml` uses
+nightly-only options, and plain `cargo fmt` drops them silently rather than refusing.
 
-Pre-commit hook runs workspace-wide: `cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo +nightly fmt --all -- --check`
+Pre-commit hook runs workspace-wide: `cargo clippy --workspace --all-targets --all-features -- -D warnings && cargo +nightly-2026-04-02 fmt --all -- --check`
 
 ## Git
 - Never commit unless explicitly asked.
 - Stage with `git add` only if requested.
-- Run `cargo +nightly fmt --all` before staging.
+- Run `cargo +nightly-2026-04-02 fmt --all` before staging.
 
 ## Style
 - One blank line between functions.


### PR DESCRIPTION
`install_rust_nightly` runs `rustup toolchain install nightly-...`, which resolves to whatever nightly exists on the day the job runs. `check-fmt` then formats with it. So the definition of "correctly formatted" is a moving target, and a pull request that changes nothing about formatting can go red because rustfmt's output moved that morning. It also means a contributor whose local nightly differs from the one CI happened to resolve gets a green check locally and a red one on the branch, with no way to tell why.

The formatter has to be a separate toolchain: `.rustfmt.toml` uses imports_layout, imports_granularity, overflow_delimited_expr, reorder_impl_items and style_edition, none of which exist on stable, while rust-toolchain.toml pins 1.88. Since it is a second toolchain, it wants pinning for the same reasons the first one does.

`fmt_nightly` sits with the other constants this file already keeps as pipeline parameters, so the version lives in one place and bumping it is one edit. `--profile minimal --component rustfmt` is added because the job needs the formatter and nothing else.

This is insurance rather than a repair. The tree reports zero diffs under all three formatters it was checked against --

    rustfmt 1.8.0-nightly  (74509131e8 2025-04-29)
    rustfmt 1.9.0-nightly  (7e46c5f6fb 2026-04-01)   <- the pin
    rustfmt 1.10.0-nightly (e7769602ac 2026-08-24)

so rustfmt's output for this codebase has not moved in sixteen months. The point is that nothing currently stops it from moving, and when it does the failure lands on whichever pull request happens to be open.

AGENTS.md names the pinned toolchain everywhere it previously said `cargo +nightly`, so that the documented commands and CI agree. CONTRIBUTING.md still says plain `cargo fmt`, which was already inaccurate for the reason above; it is left for a separate change rather than edited in passing here.