### PR TITLE
Fix/bound varuna proof lengths

### DIFF
--- a/algorithms/src/polycommit/sonic_pc/data_structures.rs
+++ b/algorithms/src/polycommit/sonic_pc/data_structures.rs
@@ -396,9 +396,58 @@ impl<'a, E: PairingEngine> CommitterUnionKey<'a, E> {
     }
 }
 
+/// The maximum number of evaluation proofs in a `BatchProof`.
+///
+/// `SonicKZG10::batch_open` emits exactly one proof per distinct query point
+/// name. The Varuna AHP queries at three names ("alpha", "beta", "gamma") and
+/// the verifying key certificate at one ("challenge"), so no `BatchProof` this
+/// crate can produce holds more than three. `batch_check` already rejects any
+/// other count; bounding it here refuses the length before it is used.
+pub const MAX_BATCH_PROOF_LEN: u64 = 3;
+
 /// Evaluation proof at a query set.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, CanonicalSerialize, CanonicalDeserialize)]
+///
+/// `CanonicalDeserialize` and `Valid` are written out rather than derived, so
+/// that the length prefix can be bounded by `MAX_BATCH_PROOF_LEN` before any
+/// element is read. Both are needed because deriving `CanonicalDeserialize`
+/// is also what derives `Valid`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, CanonicalSerialize)]
 pub struct BatchProof<E: PairingEngine>(pub(crate) Vec<kzg10::KZGProof<E>>);
+
+impl<E: PairingEngine> Valid for BatchProof<E> {
+    fn check(&self) -> Result<(), SerializationError> {
+        Valid::check(&self.0)
+    }
+
+    fn batch_check<'a>(batch: impl Iterator<Item = &'a Self> + Send) -> Result<(), SerializationError>
+    where
+        Self: 'a,
+    {
+        let batch: Vec<_> = batch.collect();
+        Valid::batch_check(batch.iter().map(|v| &v.0))
+    }
+}
+
+impl<E: PairingEngine> CanonicalDeserialize for BatchProof<E> {
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        compress: Compress,
+        validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let len = u64::deserialize_with_mode(&mut reader, compress, validate)?;
+        if len > MAX_BATCH_PROOF_LEN {
+            return Err(SerializationError::InvalidData);
+        }
+        let mut proofs = Vec::with_capacity(len as usize);
+        for _ in 0..len {
+            proofs.push(kzg10::KZGProof::deserialize_with_mode(&mut reader, compress, Validate::No)?);
+        }
+        if let Validate::Yes = validate {
+            kzg10::KZGProof::<E>::batch_check(proofs.iter())?;
+        }
+        Ok(BatchProof(proofs))
+    }
+}
 
 impl<E: PairingEngine> BatchProof<E> {
     pub fn is_hiding(&self) -> bool {

--- a/algorithms/src/polycommit/sonic_pc/data_structures.rs
+++ b/algorithms/src/polycommit/sonic_pc/data_structures.rs
@@ -440,8 +440,7 @@ impl<E: PairingEngine> Valid for BatchProof<E> {
     where
         Self: 'a,
     {
-        let batch: Vec<_> = batch.collect();
-        Valid::batch_check(batch.iter().map(|v| &v.0))
+        Valid::batch_check(batch.map(|v| &v.0))
     }
 }
 

--- a/algorithms/src/polycommit/sonic_pc/data_structures.rs
+++ b/algorithms/src/polycommit/sonic_pc/data_structures.rs
@@ -396,23 +396,40 @@ impl<'a, E: PairingEngine> CommitterUnionKey<'a, E> {
     }
 }
 
-/// The maximum number of evaluation proofs in a `BatchProof`.
+/// The maximum number of evaluation proofs a `BatchProof` will serialize.
 ///
-/// `SonicKZG10::batch_open` emits exactly one proof per distinct query point
-/// name. The Varuna AHP queries at three names ("alpha", "beta", "gamma") and
-/// the verifying key certificate at one ("challenge"), so no `BatchProof` this
-/// crate can produce holds more than three. `batch_check` already rejects any
-/// other count; bounding it here refuses the length before it is used.
+/// `SonicKZG10::batch_open` emits one proof per distinct query point name, so
+/// the count follows from the caller's query set rather than from the scheme.
+/// Both callers in this crate sit at or below three: the Varuna AHP queries at
+/// "alpha", "beta" and "gamma", and the verifying key certificate at
+/// "challenge". `batch_check` already rejects any other count.
+///
+/// This is enforced on serialization as well as deserialization, so that the
+/// round trip stays total -- whatever writes will read back. A caller with a
+/// larger query set would have to raise it.
 pub const MAX_BATCH_PROOF_LEN: u64 = 3;
 
 /// Evaluation proof at a query set.
 ///
-/// `CanonicalDeserialize` and `Valid` are written out rather than derived, so
-/// that the length prefix can be bounded by `MAX_BATCH_PROOF_LEN` before any
-/// element is read. Both are needed because deriving `CanonicalDeserialize`
-/// is also what derives `Valid`.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, CanonicalSerialize)]
+/// `CanonicalSerialize`, `CanonicalDeserialize` and `Valid` are written out
+/// rather than derived, so that the length can be bounded by
+/// `MAX_BATCH_PROOF_LEN` on both sides. All three are needed because deriving
+/// `CanonicalDeserialize` is also what derives `Valid`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct BatchProof<E: PairingEngine>(pub(crate) Vec<kzg10::KZGProof<E>>);
+
+impl<E: PairingEngine> CanonicalSerialize for BatchProof<E> {
+    fn serialize_with_mode<W: Write>(&self, mut writer: W, compress: Compress) -> Result<(), SerializationError> {
+        if self.0.len() as u64 > MAX_BATCH_PROOF_LEN {
+            return Err(SerializationError::InvalidData);
+        }
+        CanonicalSerialize::serialize_with_mode(&self.0, &mut writer, compress)
+    }
+
+    fn serialized_size(&self, compress: Compress) -> usize {
+        CanonicalSerialize::serialized_size(&self.0, compress)
+    }
+}
 
 impl<E: PairingEngine> Valid for BatchProof<E> {
     fn check(&self) -> Result<(), SerializationError> {

--- a/algorithms/src/snark/varuna/ahp/verifier/messages.rs
+++ b/algorithms/src/snark/varuna/ahp/verifier/messages.rs
@@ -193,3 +193,70 @@ pub fn select_third_round_challenges<F: PrimeField>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        fft::EvaluationDomain,
+        polycommit::sonic_pc::MAX_BATCH_PROOF_LEN,
+        snark::varuna::{
+            VarunaHidingMode,
+            ahp::verifier::{CircuitSpecificState, State},
+        },
+    };
+    use snarkvm_curves::bls12_377::Fr;
+
+    use core::marker::PhantomData;
+    use std::collections::BTreeSet;
+
+    /// Builds a verifier state holding a single circuit, with arbitrary field
+    /// values.
+    ///
+    /// `QuerySet::new` reads only `alpha`, `beta`, `gamma` and the circuit ids,
+    /// and the query point names it assigns do not depend on any of them,
+    /// so nothing here has to come from a real proof.
+    fn dummy_state() -> State<Fr, VarunaHidingMode> {
+        // Any domain will do; `QuerySet::new` never looks at them.
+        let domain = EvaluationDomain::new(4).unwrap();
+        let circuit_specific_state = CircuitSpecificState {
+            input_domain: domain,
+            variable_domain: domain,
+            constraint_domain: domain,
+            non_zero_a_domain: domain,
+            non_zero_b_domain: domain,
+            non_zero_c_domain: domain,
+            batch_size: 1,
+        };
+        State {
+            circuit_specific_states: BTreeMap::from([(CircuitId([0u8; 32]), circuit_specific_state)]),
+            max_constraint_domain: domain,
+            max_variable_domain: domain,
+            max_non_zero_domain: domain,
+            first_round_message: None,
+            second_round_message: Some(SecondMessage { alpha: Fr::from(1u64), eta_b: None, eta_c: None }),
+            prepare_third_round_message: None,
+            third_round_message: Some(ThirdMessage { beta: Fr::from(2u64) }),
+            fourth_round_message: None,
+            gamma: Some(Fr::from(3u64)),
+            mode: PhantomData,
+        }
+    }
+
+    #[test]
+    fn test_query_point_names_fit_in_a_batch_proof() {
+        // `SonicKZG10::batch_open` groups the query set by query point name and emits
+        // one evaluation proof per group, so the number of distinct names here
+        // is exactly what a `BatchProof` has to hold. The seven queries below
+        // collapse onto three names, which is why `MAX_BATCH_PROOF_LEN` is what
+        // it is; adding an eighth query under a new name, or renaming one of
+        // the seven, would need that constant raised to match.
+        let query_set = QuerySet::new(&dummy_state());
+        let names: BTreeSet<String> = query_set.to_set().into_iter().map(|(_label, (name, _point))| name).collect();
+        assert_eq!(
+            names.len() as u64,
+            MAX_BATCH_PROOF_LEN,
+            "the verifier queries at {names:?}, which no longer matches MAX_BATCH_PROOF_LEN"
+        );
+    }
+}

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -34,21 +34,31 @@ use std::mem::size_of;
 
 /// The maximum number of circuits in a batch proof.
 ///
-/// Every circuit in a batch contributes at least one instance, so the number of
-/// circuits is bounded by the consensus limit on the total number of instances
-/// in a batch proof, `Network::MAX_BATCH_PROOF_INSTANCES`. That limit lives in
-/// `snarkvm-console-network`, which this crate cannot depend on, so the value
-/// is repeated here: if it is ever raised, this constant has to be raised
-/// first, or newly produced proofs stop being deserializable.
+/// Two different arguments bound this, because the consensus limit on the total
+/// number of instances in a batch proof, `Network::MAX_BATCH_PROOF_INSTANCES`
+/// (128), is only applied from `ConsensusVersion::V14` and so says nothing
+/// about older proofs:
+///
+/// - From V14, every circuit holds at least one instance, so the number of
+///   circuits cannot exceed that limit of 128.
+/// - Before V14, a batch held one circuit per distinct function in the
+///   execution plus one for inclusion, and an execution carries fewer than
+///   `Transaction::MAX_TRANSITIONS` (32) transitions, giving at most 32.
+///
+/// 128 therefore covers both eras. It repeats a value from
+/// `snarkvm-console-network`, which this crate cannot depend on; a compile-time
+/// assertion beside that limit keeps the two from drifting apart.
 pub const MAX_CIRCUITS_PER_BATCH_PROOF: u64 = 128;
 
 /// The maximum number of instances of any single circuit in a batch proof.
 ///
 /// The largest legitimate batch is the inclusion circuit, which holds one
-/// instance per input record, so at most `Network::MAX_INPUTS` (16) times
-/// `Transaction::MAX_TRANSITIONS` (32). Proofs predating the consensus limit
-/// on total instances can reach that, so this is deliberately looser than the
-/// 128 above; tightening it would reject historical blocks.
+/// instance per input record. An execution carries at most
+/// `Transaction::MAX_TRANSITIONS - 1` transitions, one slot being held back
+/// for the fee (see `Transaction::check_execution_size`), so at most
+/// 31 * `Network::MAX_INPUTS` (16) = 496 records. Proofs predating the
+/// consensus limit on total instances can reach that, so this is deliberately
+/// looser than the 128 above; tightening it would reject historical blocks.
 pub const MAX_INSTANCES_PER_CIRCUIT: u64 = 512;
 
 /// The maximum number of instances across all circuits in a batch proof.
@@ -699,5 +709,11 @@ mod test {
             BatchProof::<Bls12_377>::deserialize_compressed(&bytes[..]),
             Err(SerializationError::InvalidData)
         ));
+
+        // The same bound applies on the way out, so nothing serializes that would then
+        // fail to deserialize.
+        let over = BatchProof::<Bls12_377>(over);
+        let mut bytes = Vec::new();
+        assert!(matches!(over.serialize_compressed(&mut bytes), Err(SerializationError::InvalidData)));
     }
 }

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -52,16 +52,23 @@ pub const MAX_CIRCUITS_PER_BATCH_PROOF: u64 = 128;
 
 /// The maximum number of instances across all circuits in a batch proof.
 ///
-/// The largest legitimate batch is the inclusion circuit, which holds one
-/// instance per input record. An execution carries at most
-/// `Transaction::MAX_TRANSITIONS - 1` transitions, one slot being held back
-/// for the fee (see `Transaction::check_execution_size`), so at most
-/// 31 * `Network::MAX_INPUTS` (16) = 496 records; each function circuit adds
-/// one instance per transition, so a batch holds fewer than 528. Proofs
-/// predating `Network::MAX_BATCH_PROOF_INSTANCES` can reach that, so this is
-/// deliberately looser than the 128 above; tightening it would reject
-/// historical blocks. A compile-time assertion in `snarkvm-console-network`
-/// pins it above that sum.
+/// As for the circuit count above, the two consensus eras are bounded by
+/// separate arguments:
+///
+/// - From V14, `Network::MAX_BATCH_PROOF_INSTANCES` (128) caps the total
+///   directly, counting transition, record-translation and inclusion instances
+///   alike.
+/// - Before V14 that limit did not apply, but neither did record translation:
+///   the `dynamic` syntax it requires cannot be deployed before V14, so a batch
+///   holds only function and inclusion instances. An execution carries at most
+///   `Transaction::MAX_TRANSITIONS - 1` transitions, one slot being held back
+///   for the fee (see `Transaction::check_execution_size`), giving at most 31 *
+///   `Network::MAX_INPUTS` (16) = 496 inclusion instances, plus one per
+///   transition for the function circuits: fewer than 528.
+///
+/// 1024 covers both eras. It is deliberately looser than the 128, which binds
+/// only from V14; tightening it would reject historical blocks. Compile-time
+/// assertions in `snarkvm-console-network` pin it above both bounds.
 pub const MAX_INSTANCES_PER_BATCH_PROOF: u64 = 1024;
 
 #[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -406,6 +406,8 @@ impl<E: PairingEngine> CanonicalDeserialize for Proof<E> {
             if total_instances > MAX_INSTANCES_PER_BATCH_PROOF {
                 return Err(SerializationError::InvalidData);
             }
+            // Cannot fail: `batch_size` is at most 512 by the check above, and `usize` is
+            // at least 16 bits wide on every target.
             batch_sizes.push(usize::try_from(batch_size)?);
         }
         let commitments = Commitments::deserialize_with_mode(&batch_sizes, &mut reader, compress, validate)?;

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -32,6 +32,28 @@ use std::{
 
 use std::mem::size_of;
 
+/// The maximum number of circuits in a batch proof.
+///
+/// Every circuit in a batch contributes at least one instance, so the number of
+/// circuits is bounded by the consensus limit on the total number of instances
+/// in a batch proof, `Network::MAX_BATCH_PROOF_INSTANCES`. That limit lives in
+/// `snarkvm-console-network`, which this crate cannot depend on, so the value
+/// is repeated here: if it is ever raised, this constant has to be raised
+/// first, or newly produced proofs stop being deserializable.
+pub const MAX_CIRCUITS_PER_BATCH_PROOF: u64 = 128;
+
+/// The maximum number of instances of any single circuit in a batch proof.
+///
+/// The largest legitimate batch is the inclusion circuit, which holds one
+/// instance per input record, so at most `Network::MAX_INPUTS` (16) times
+/// `Transaction::MAX_TRANSITIONS` (32). Proofs predating the consensus limit
+/// on total instances can reach that, so this is deliberately looser than the
+/// 128 above; tightening it would reject historical blocks.
+pub const MAX_INSTANCES_PER_CIRCUIT: u64 = 512;
+
+/// The maximum number of instances across all circuits in a batch proof.
+pub const MAX_INSTANCES_PER_BATCH_PROOF: u64 = 1024;
+
 #[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Commitments<E: PairingEngine> {
     pub witness_commitments: Vec<WitnessCommitments<E>>,
@@ -347,8 +369,29 @@ impl<E: PairingEngine> CanonicalDeserialize for Proof<E> {
         compress: Compress,
         validate: Validate,
     ) -> Result<Self, SerializationError> {
-        let batch_sizes: Vec<u64> = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
-        let batch_sizes: Vec<usize> = batch_sizes.into_iter().map(|x| x as usize).collect();
+        // Read the batch sizes one value at a time rather than as a `Vec<u64>`,
+        // so that each count can be bounded as it arrives. These come off the
+        // wire and are used below as loop counts and expected lengths, so
+        // nothing downstream should see a count no honest prover could have
+        // produced. Zero is rejected too: the verifier computes `size - 1`.
+        let num_circuits = u64::deserialize_with_mode(&mut reader, compress, validate)?;
+        if num_circuits == 0 || num_circuits > MAX_CIRCUITS_PER_BATCH_PROOF {
+            return Err(SerializationError::InvalidData);
+        }
+        let mut batch_sizes = Vec::with_capacity(num_circuits as usize);
+        let mut total_instances = 0u64;
+        for _ in 0..num_circuits {
+            let batch_size = u64::deserialize_with_mode(&mut reader, compress, validate)?;
+            if batch_size == 0 || batch_size > MAX_INSTANCES_PER_CIRCUIT {
+                return Err(SerializationError::InvalidData);
+            }
+            // Cannot overflow, being at most 128 * 512.
+            total_instances += batch_size;
+            if total_instances > MAX_INSTANCES_PER_BATCH_PROOF {
+                return Err(SerializationError::InvalidData);
+            }
+            batch_sizes.push(usize::try_from(batch_size)?);
+        }
         let commitments = Commitments::deserialize_with_mode(&batch_sizes, &mut reader, compress, validate)?;
         let evaluations = Evaluations::deserialize_with_mode(&batch_sizes, &mut reader, compress, validate)?;
         let third_msg_sums = batch_sizes
@@ -471,7 +514,7 @@ mod test {
     use crate::{
         polycommit::{
             kzg10::{KZGCommitment, KZGProof},
-            sonic_pc::BatchProof,
+            sonic_pc::{BatchProof, MAX_BATCH_PROOF_LEN},
         },
         snark::varuna::prover::MatrixSums,
     };
@@ -584,8 +627,12 @@ mod test {
                 let evaluations: Evaluations<Fr> = rand_evaluations(rng, i);
                 let third_msg = ThirdMessage::<Fr> { sums: vec![vec![rand_sums(rng); j]; i] };
                 let fourth_msg = FourthMessage::<Fr> { sums: vec![rand_sums(rng); i] };
-                let pc_proof =
-                    sonic_pc::BatchLCProof { proof: BatchProof(vec![rand_kzg_proof(rng, test_with_none); j]) };
+                // A `BatchProof` holds one evaluation proof per distinct query
+                // point name, so it never exceeds `MAX_BATCH_PROOF_LEN`.
+                let num_kzg_proofs = j.min(MAX_BATCH_PROOF_LEN as usize);
+                let pc_proof = sonic_pc::BatchLCProof {
+                    proof: BatchProof(vec![rand_kzg_proof(rng, test_with_none); num_kzg_proofs]),
+                };
                 let proof = Proof { batch_sizes, commitments, evaluations, third_msg, fourth_msg, pc_proof };
                 let combinations = modes();
                 for (compress, validate) in combinations {
@@ -597,5 +644,60 @@ mod test {
                 }
             }
         }
+    }
+
+    /// Serializes `sizes` exactly as a `Proof` writes its batch sizes, giving a
+    /// `Proof` blob that is truncated immediately after them.
+    fn batch_sizes_blob(sizes: &[u64]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        sizes.to_vec().serialize_compressed(&mut bytes).unwrap();
+        bytes
+    }
+
+    #[test]
+    fn test_proof_batch_sizes_are_bounded() {
+        let rejected = [
+            (vec![], "no circuits"),
+            (vec![0u64], "a circuit with no instances"),
+            (vec![1u64; MAX_CIRCUITS_PER_BATCH_PROOF as usize + 1], "too many circuits"),
+            (vec![MAX_INSTANCES_PER_CIRCUIT + 1], "too many instances in one circuit"),
+            (vec![MAX_INSTANCES_PER_CIRCUIT; 4], "too many instances in total"),
+        ];
+        for (sizes, why) in rejected {
+            let bytes = batch_sizes_blob(&sizes);
+            assert!(
+                matches!(Proof::<Bls12_377>::deserialize_compressed(&bytes[..]), Err(SerializationError::InvalidData)),
+                "expected these batch sizes to be rejected: {why}"
+            );
+        }
+
+        // Batch sizes within the bounds get past these checks and fail on the truncated
+        // body instead, so the assertions above are rejecting the counts and
+        // not the short buffer.
+        let bytes = batch_sizes_blob(&[MAX_INSTANCES_PER_CIRCUIT]);
+        assert!(matches!(Proof::<Bls12_377>::deserialize_compressed(&bytes[..]), Err(SerializationError::IoError(_))));
+    }
+
+    #[test]
+    fn test_batch_proof_length_is_bounded() {
+        let rng = &mut TestRng::default();
+
+        // Every length the protocol can produce round-trips: one for a certificate,
+        // three for a proof.
+        for len in 0..=MAX_BATCH_PROOF_LEN as usize {
+            let expected = BatchProof::<Bls12_377>(vec![rand_kzg_proof(rng, false); len]);
+            let mut bytes = Vec::new();
+            expected.serialize_compressed(&mut bytes).unwrap();
+            assert_eq!(expected, BatchProof::deserialize_compressed(&bytes[..]).unwrap());
+        }
+
+        // One more than that is refused on the length prefix, before any proof is read.
+        let over = vec![rand_kzg_proof(rng, false); MAX_BATCH_PROOF_LEN as usize + 1];
+        let mut bytes = Vec::new();
+        over.serialize_compressed(&mut bytes).unwrap();
+        assert!(matches!(
+            BatchProof::<Bls12_377>::deserialize_compressed(&bytes[..]),
+            Err(SerializationError::InvalidData)
+        ));
     }
 }

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -50,24 +50,18 @@ use std::mem::size_of;
 /// assertion beside that limit keeps the two from drifting apart.
 pub const MAX_CIRCUITS_PER_BATCH_PROOF: u64 = 128;
 
-/// The maximum number of instances of any single circuit in a batch proof.
+/// The maximum number of instances across all circuits in a batch proof.
 ///
 /// The largest legitimate batch is the inclusion circuit, which holds one
 /// instance per input record. An execution carries at most
 /// `Transaction::MAX_TRANSITIONS - 1` transitions, one slot being held back
 /// for the fee (see `Transaction::check_execution_size`), so at most
-/// 31 * `Network::MAX_INPUTS` (16) = 496 records. Proofs predating the
-/// consensus limit on total instances can reach that, so this is deliberately
-/// looser than the 128 above; tightening it would reject historical blocks. A
-/// compile-time assertion in `snarkvm-console-network` pins it above the 496.
-pub const MAX_INSTANCES_PER_CIRCUIT: u64 = 512;
-
-/// The maximum number of instances across all circuits in a batch proof.
-///
-/// The inclusion circuit contributes the 496 above, and each function circuit
-/// one instance per transition, so a batch holds fewer than 528. As with the
-/// per-circuit bound this keeps room to spare, and a compile-time assertion in
-/// `snarkvm-console-network` pins it above that sum.
+/// 31 * `Network::MAX_INPUTS` (16) = 496 records; each function circuit adds
+/// one instance per transition, so a batch holds fewer than 528. Proofs
+/// predating `Network::MAX_BATCH_PROOF_INSTANCES` can reach that, so this is
+/// deliberately looser than the 128 above; tightening it would reject
+/// historical blocks. A compile-time assertion in `snarkvm-console-network`
+/// pins it above that sum.
 pub const MAX_INSTANCES_PER_BATCH_PROOF: u64 = 1024;
 
 #[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
@@ -398,15 +392,16 @@ impl<E: PairingEngine> CanonicalDeserialize for Proof<E> {
         let mut total_instances = 0u64;
         for _ in 0..num_circuits {
             let batch_size = u64::deserialize_with_mode(&mut reader, compress, validate)?;
-            if batch_size == 0 || batch_size > MAX_INSTANCES_PER_CIRCUIT {
+            if batch_size == 0 {
                 return Err(SerializationError::InvalidData);
             }
-            // Cannot overflow, being at most 128 * 512.
-            total_instances += batch_size;
+            // Saturating, because `batch_size` is not itself bounded yet: the running
+            // total is what bounds it, one circuit at a time.
+            total_instances = total_instances.saturating_add(batch_size);
             if total_instances > MAX_INSTANCES_PER_BATCH_PROOF {
                 return Err(SerializationError::InvalidData);
             }
-            // Cannot fail: `batch_size` is at most 512 by the check above, and `usize` is
+            // Cannot fail: `batch_size` is at most 1024 by the check above, and `usize` is
             // at least 16 bits wide on every target.
             batch_sizes.push(usize::try_from(batch_size)?);
         }
@@ -678,8 +673,9 @@ mod test {
             (vec![], "no circuits"),
             (vec![0u64], "a circuit with no instances"),
             (vec![1u64; MAX_CIRCUITS_PER_BATCH_PROOF as usize + 1], "too many circuits"),
-            (vec![MAX_INSTANCES_PER_CIRCUIT + 1], "too many instances in one circuit"),
-            (vec![MAX_INSTANCES_PER_CIRCUIT; 4], "too many instances in total"),
+            (vec![MAX_INSTANCES_PER_BATCH_PROOF + 1], "one circuit holding more than the whole batch allows"),
+            (vec![1, u64::MAX], "an instance count that would wrap the running total past zero"),
+            (vec![MAX_INSTANCES_PER_BATCH_PROOF / 2 + 1; 2], "too many instances in total"),
         ];
         for (sizes, why) in rejected {
             let bytes = batch_sizes_blob(&sizes);
@@ -692,7 +688,7 @@ mod test {
         // Batch sizes within the bounds get past these checks and fail on the truncated
         // body instead, so the assertions above are rejecting the counts and
         // not the short buffer.
-        let bytes = batch_sizes_blob(&[MAX_INSTANCES_PER_CIRCUIT]);
+        let bytes = batch_sizes_blob(&[MAX_INSTANCES_PER_BATCH_PROOF]);
         assert!(matches!(Proof::<Bls12_377>::deserialize_compressed(&bytes[..]), Err(SerializationError::IoError(_))));
     }
 

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -58,10 +58,16 @@ pub const MAX_CIRCUITS_PER_BATCH_PROOF: u64 = 128;
 /// for the fee (see `Transaction::check_execution_size`), so at most
 /// 31 * `Network::MAX_INPUTS` (16) = 496 records. Proofs predating the
 /// consensus limit on total instances can reach that, so this is deliberately
-/// looser than the 128 above; tightening it would reject historical blocks.
+/// looser than the 128 above; tightening it would reject historical blocks. A
+/// compile-time assertion in `snarkvm-console-network` pins it above the 496.
 pub const MAX_INSTANCES_PER_CIRCUIT: u64 = 512;
 
 /// The maximum number of instances across all circuits in a batch proof.
+///
+/// The inclusion circuit contributes the 496 above, and each function circuit
+/// one instance per transition, so a batch holds fewer than 528. As with the
+/// per-circuit bound this keeps room to spare, and a compile-time assertion in
+/// `snarkvm-console-network` pins it above that sum.
 pub const MAX_INSTANCES_PER_BATCH_PROOF: u64 = 1024;
 
 #[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -651,14 +651,10 @@ const _: () = {
         // Every instance needs a circuit to live in, so the number of circuits in a batch cannot
         // exceed the limit on the number of instances.
         assert!(N::MAX_BATCH_PROOF_INSTANCES as u64 <= snarkvm_algorithms::snark::varuna::MAX_CIRCUITS_PER_BATCH_PROOF);
-        // The largest single circuit is inclusion, which holds one instance per input record over
-        // every transition but the fee. `Transaction::MAX_TRANSITIONS` is `MAX_FUNCTIONS + 1`
-        // (see `test_transaction_depth_is_correct`), so that is `MAX_FUNCTIONS` transitions.
-        assert!(
-            (N::MAX_FUNCTIONS * N::MAX_INPUTS) as u64 <= snarkvm_algorithms::snark::varuna::MAX_INSTANCES_PER_CIRCUIT
-        );
-        // Across the whole batch: the inclusion circuit's instances, plus one instance per
-        // transition for the function circuits.
+        // Across the whole batch: the inclusion circuit holds one instance per input record over
+        // every transition but the fee -- `Transaction::MAX_TRANSITIONS` is `MAX_FUNCTIONS + 1`
+        // (see `test_transaction_depth_is_correct`), so that is `MAX_FUNCTIONS` transitions --
+        // plus one instance per transition for the function circuits.
         assert!(
             (N::MAX_FUNCTIONS * N::MAX_INPUTS + N::MAX_FUNCTIONS + 1) as u64
                 <= snarkvm_algorithms::snark::varuna::MAX_INSTANCES_PER_BATCH_PROOF

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -651,10 +651,16 @@ const _: () = {
         // Every instance needs a circuit to live in, so the number of circuits in a batch cannot
         // exceed the limit on the number of instances.
         assert!(N::MAX_BATCH_PROOF_INSTANCES as u64 <= snarkvm_algorithms::snark::varuna::MAX_CIRCUITS_PER_BATCH_PROOF);
-        // Across the whole batch: the inclusion circuit holds one instance per input record over
-        // every transition but the fee -- `Transaction::MAX_TRANSITIONS` is `MAX_FUNCTIONS + 1`
-        // (see `test_transaction_depth_is_correct`), so that is `MAX_FUNCTIONS` transitions --
-        // plus one instance per transition for the function circuits.
+        // From `ConsensusVersion::V14` this limit caps an execution's batch directly, counting
+        // transition, record-translation and inclusion instances alike.
+        assert!(
+            N::MAX_BATCH_PROOF_INSTANCES as u64 <= snarkvm_algorithms::snark::varuna::MAX_INSTANCES_PER_BATCH_PROOF
+        );
+        // Before V14 that limit did not apply, and record translation did not yet exist, so the
+        // batch holds one inclusion instance per input record over every transition but the fee --
+        // `Transaction::MAX_TRANSITIONS` is `MAX_FUNCTIONS + 1` (see
+        // `test_transaction_depth_is_correct`), so that is `MAX_FUNCTIONS` transitions -- plus one
+        // instance per transition for the function circuits.
         assert!(
             (N::MAX_FUNCTIONS * N::MAX_INPUTS + N::MAX_FUNCTIONS + 1) as u64
                 <= snarkvm_algorithms::snark::varuna::MAX_INSTANCES_PER_BATCH_PROOF

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -641,24 +641,32 @@ pub trait Network:
     fn dynamic_record_path_hasher() -> &'static Poseidon2<Self>;
 }
 
-/// Every instance permitted by `MAX_BATCH_PROOF_INSTANCES` needs a circuit to live in, and the
-/// Varuna proof deserializer caps the number of circuits it will read. `snarkvm-algorithms` cannot
-/// depend on this crate, so its cap is a hand-written constant; raising the limit here past it
-/// would leave newly produced proofs undeserializable. Pin the relationship at the definition, so
-/// that raising the limit without raising the cap is a build failure rather than a runtime one.
+/// The Varuna proof deserializer caps the batch shapes it will read. `snarkvm-algorithms` cannot
+/// depend on this crate, so those caps are hand-written constants there. Pin each one against the
+/// consensus limit it has to stay above, so that raising a limit here without raising the
+/// corresponding cap is a build failure rather than proofs that stop deserializing.
 const _: () = {
-    assert!(
-        <MainnetV0 as Network>::MAX_BATCH_PROOF_INSTANCES as u64
-            <= snarkvm_algorithms::snark::varuna::MAX_CIRCUITS_PER_BATCH_PROOF
-    );
-    assert!(
-        <TestnetV0 as Network>::MAX_BATCH_PROOF_INSTANCES as u64
-            <= snarkvm_algorithms::snark::varuna::MAX_CIRCUITS_PER_BATCH_PROOF
-    );
-    assert!(
-        <CanaryV0 as Network>::MAX_BATCH_PROOF_INSTANCES as u64
-            <= snarkvm_algorithms::snark::varuna::MAX_CIRCUITS_PER_BATCH_PROOF
-    );
+    /// Asserts the deserializer's caps against one network's limits.
+    const fn assert_batch_proof_caps<N: Network>() {
+        // Every instance needs a circuit to live in, so the number of circuits in a batch cannot
+        // exceed the limit on the number of instances.
+        assert!(N::MAX_BATCH_PROOF_INSTANCES as u64 <= snarkvm_algorithms::snark::varuna::MAX_CIRCUITS_PER_BATCH_PROOF);
+        // The largest single circuit is inclusion, which holds one instance per input record over
+        // every transition but the fee. `Transaction::MAX_TRANSITIONS` is `MAX_FUNCTIONS + 1`
+        // (see `test_transaction_depth_is_correct`), so that is `MAX_FUNCTIONS` transitions.
+        assert!(
+            (N::MAX_FUNCTIONS * N::MAX_INPUTS) as u64 <= snarkvm_algorithms::snark::varuna::MAX_INSTANCES_PER_CIRCUIT
+        );
+        // Across the whole batch: the inclusion circuit's instances, plus one instance per
+        // transition for the function circuits.
+        assert!(
+            (N::MAX_FUNCTIONS * N::MAX_INPUTS + N::MAX_FUNCTIONS + 1) as u64
+                <= snarkvm_algorithms::snark::varuna::MAX_INSTANCES_PER_BATCH_PROOF
+        );
+    }
+    assert_batch_proof_caps::<MainnetV0>();
+    assert_batch_proof_caps::<TestnetV0>();
+    assert_batch_proof_caps::<CanaryV0>();
 };
 
 /// Returns the consensus version heights, initializing them if necessary.

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -641,6 +641,26 @@ pub trait Network:
     fn dynamic_record_path_hasher() -> &'static Poseidon2<Self>;
 }
 
+/// Every instance permitted by `MAX_BATCH_PROOF_INSTANCES` needs a circuit to live in, and the
+/// Varuna proof deserializer caps the number of circuits it will read. `snarkvm-algorithms` cannot
+/// depend on this crate, so its cap is a hand-written constant; raising the limit here past it
+/// would leave newly produced proofs undeserializable. Pin the relationship at the definition, so
+/// that raising the limit without raising the cap is a build failure rather than a runtime one.
+const _: () = {
+    assert!(
+        <MainnetV0 as Network>::MAX_BATCH_PROOF_INSTANCES as u64
+            <= snarkvm_algorithms::snark::varuna::MAX_CIRCUITS_PER_BATCH_PROOF
+    );
+    assert!(
+        <TestnetV0 as Network>::MAX_BATCH_PROOF_INSTANCES as u64
+            <= snarkvm_algorithms::snark::varuna::MAX_CIRCUITS_PER_BATCH_PROOF
+    );
+    assert!(
+        <CanaryV0 as Network>::MAX_BATCH_PROOF_INSTANCES as u64
+            <= snarkvm_algorithms::snark::varuna::MAX_CIRCUITS_PER_BATCH_PROOF
+    );
+};
+
 /// Returns the consensus version heights, initializing them if necessary.
 ///
 /// If a `heights` string is provided, it must be a comma-separated list of ascending block heights


### PR DESCRIPTION
## Motivation

We read serialized `varuna::Proof` and `sonic_pc::BatchProof` from the wire, and so bounding the maximum sizes of these that will be accommodated by the deserializer helps to harden the node against abuse.

`varuna::Proof` and `sonic_pc::BatchProof` both begin with a length taken straight from the reader, and neither bounds it.

`Proof::deserialize_with_mode` reads `batch_sizes` as a length-prefixed `Vec<u64>`. Those values are not inert — they become loop counts and expected lengths for everything that follows (`Commitments`, `Evaluations`, the third and fourth prover messages), and they are carried on the deserialized `Proof` for the verifier. `BatchProof` reads its evaluation proofs the same way, and is reached twice over: once as `Proof.pc_proof`, and once as `Certificate.pc_proof` via `BatchLCProof`.

Both are reachable from ordinary deserialized objects — a proof through any execution or fee transaction, a certificate through any deployment — so the counts driving that work are whatever the sender wrote.

These are protocol constants, and other code already depends on their values: `SonicKZG10::batch_check` requires exactly one evaluation proof per distinct query point name, and the verifier computes `batch_size - 1`. This PR checks them at the point where the length is read, so that a malformed proof is rejected on its first few bytes rather than surviving into code that assumes the check already happened. `CircuitVerifyingKey` already does exactly this for its commitments (`MAX_CIRCUIT_COMMITMENTS = 12`); these are the two remaining length-prefixed reads on the same path.

To be precise: This is **not** a fix for a live memory-exhaustion bug. The generic `Vec<T>` deserializer now caps its `try_reserve` at 1024 elements (#3391, since merged to staging), and `deserialize_vec_without_len` collects into a `Result<Vec<_>, _>`, whose size hint reserves nothing — so an implausible length dies on the first short read. The value here is validation, failing fast, and not leaving the property resting on those two incidental details, and consistency with the circuit verifying key.

Complements #3391, which approached the same class from the other end by bounding the generic `Vec<T>` reserve. The two are independent: this PR bounds the specific reachable sites with their semantic limits, #3391 is a backstop for sites nobody has audited.

## Test Plan

New tests in `algorithms/src/snark/varuna/data_structures/proof.rs`:

- `test_proof_batch_sizes_are_bounded` — covers all six rejection paths (zero circuits, a zero-instance circuit, too many circuits, one circuit holding more than the whole batch allows, an instance count that would wrap the running total past zero, and too many instances in total). It also asserts that an in-bounds blob fails with `IoError` rather than `InvalidData`, so the test distinguishes "the counts were rejected" from "the buffer was short."
- `test_batch_proof_length_is_bounded` — round-trips every length the protocol can produce (0–3), rejects 4 on read, and rejects 4 on write.
    -  `test_serializing_proof` previously built a 10-element `BatchProof`; it now builds at most `MAX_BATCH_PROOF_LEN`. That was the only place in the tree constructing an out-of-spec one.

Verified on an idle machine, built from the pushed commit:

- `cargo test -p snarkvm-algorithms -p snarkvm-console-network --lib` — 87/87
  and 7/7, including every varuna end-to-end `prove_and_verify_*` test and the
  hiding variants, so real proofs still round-trip through the new bounds.
- `cargo +nightly-2026-04-02 fmt --all -- --check` clean.
- The compile-time assertions were checked to actually fire, not merely
  compile: lowering either `MAX_CIRCUITS_PER_BATCH_PROOF` or
  `MAX_INSTANCES_PER_BATCH_PROOF` below the consensus limit it pins produces
  `error[E0080]: evaluation of constant value failed`.

## Documentation

N/A

## Backwards compatibility

No consensus version guard needed.

The wire format is unchanged — this only changes which byte strings are accepted, and every bound sits above anything either consensus era can produce:

- Circuits ≤ 128. From V14 this follows from `MAX_BATCH_PROOF_INSTANCES = 128`, since every circuit holds at least one instance. Before V14 that limit did not apply, so the bound comes from the transitions instead: an execution carries fewer than `Transaction::MAX_TRANSITIONS` (32) transitions, one circuit each, plus one for inclusion — at most 32.
- Instances across the whole batch ≤ 1024, by the same two-era split as the circuit bound:
  - From V14, `Network::MAX_BATCH_PROOF_INSTANCES` (128) caps the total directly. It counts every instance an execution proves — transition, record-translation and inclusion alike (`verify_execution/mod.rs:321-331`).
  - Before V14 that limit did not apply, but neither did record translation: it requires `dynamic` syntax, which `contains_v14_syntax` refuses to deploy before V14 (`vm/verify.rs:341-344`), and pre-V14 deployments may not carry record verifying keys (`vm/verify.rs:347-352`). So a batch holds only function and inclusion instances: at most 31 transitions × `MAX_INPUTS` (16) = 496 inclusion instances, plus one per transition for the function circuits — fewer than 528.

  Deliberately not tightened to 128 — pre-V14 proofs can legitimately exceed that, and tightening would reject historical blocks. There is no separate per-circuit cap: a single oversized circuit is caught by this same total.
- Evaluation proofs ≤ 3, one per distinct query point name. The Varuna AHP queries at three ("alpha", "beta", "gamma"), the certificate at one ("challenge"). Unchanged since before mainnet launch, and independent of circuit count, hiding mode and `VarunaVersion`.

BatchProof now also refuses to serialize more than three, so the round trip stays total. Nothing in the repository constructs one that large; test_templates.rs holds a BatchProof in TestComponents but never serializes it.

