### PR TITLE
Perf/cpu proving algos

### DIFF
--- a/algorithms/src/fft/domain.rs
+++ b/algorithms/src/fft/domain.rs
@@ -272,16 +272,33 @@ impl<F: FftField> EvaluationDomain<F> {
             }
             u
         } else {
-            let mut l = (t_size - one) * self.size_inv;
-            let mut r = one;
+            let l0 = (t_size - one) * self.size_inv;
             let mut u = vec![F::zero(); size];
             let mut ls = vec![F::zero(); size];
-            for i in 0..size {
-                u[i] = tau - r;
-                ls[i] = l;
-                l *= &self.group_gen;
-                r *= &self.group_gen;
-            }
+
+            // Both sequences are powers of `group_gen`, so a block can seed itself with
+            // `group_gen^start` rather than walking there from zero. Written serially this
+            // is one dependency chain the length of the domain, which neither
+            // more cores nor wider registers can shorten.
+            //
+            // Same shape as `distribute_powers_and_mul_by_const` above.
+            #[cfg(not(feature = "serial"))]
+            let chunk = core::cmp::max(size / max_available_threads(), 1024);
+            #[cfg(feature = "serial")]
+            let chunk = core::cmp::max(size, 1);
+
+            cfg_chunks_mut!(u, chunk).zip(cfg_chunks_mut!(ls, chunk)).enumerate().for_each(
+                |(i, (u_chunk, ls_chunk))| {
+                    let mut r = self.group_gen.pow([(i * chunk) as u64]);
+                    let mut l = l0 * r;
+                    u_chunk.iter_mut().zip(ls_chunk.iter_mut()).for_each(|(tau_minus_r, l_i)| {
+                        *tau_minus_r = tau - r;
+                        *l_i = l;
+                        r *= &self.group_gen;
+                        l *= &self.group_gen;
+                    });
+                },
+            );
 
             batch_inversion(u.as_mut_slice());
             cfg_iter_mut!(u, 1_000).zip_eq(ls).for_each(|(tau_minus_r, l)| {

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -102,6 +102,37 @@ impl<F: Field> DensePolynomial<F> {
         } else if point.is_zero() {
             return self.coeffs[0];
         }
+
+        // Horner's rule: `degree` multiplications and no allocation, where
+        // materialising the powers of the point needs two multiplications per
+        // coefficient -- once to build the power, once to weight the
+        // coefficient -- and a vector the size of the polynomial to hold them.
+        //
+        // It is fully serial, where the powers form parallelised the weighting.
+        // That is the trade, and it is worth taking: the deleted half of the
+        // arithmetic outweighs the parallelism given up, and the allocation it
+        // also deletes is proportional to the polynomial.
+        //
+        // Unlike the powers form this tolerates trailing zero coefficients,
+        // which reach it because `coeffs` is public and callers do build such
+        // polynomials. The powers form called `degree()` and panicked on that
+        // input; `evaluate_tolerates_trailing_zeros` pins the new behaviour.
+        let mut acc = F::zero();
+        for coeff in self.coeffs.iter().rev() {
+            acc = acc * point + *coeff;
+        }
+        acc
+    }
+
+    /// The powers form that `evaluate` replaced, kept so the equivalence test
+    /// has something to compare against.
+    #[cfg(test)]
+    fn evaluate_by_powers(&self, point: F) -> F {
+        if self.is_zero() {
+            return F::zero();
+        } else if point.is_zero() {
+            return self.coeffs[0];
+        }
         let mut powers_of_point = Vec::with_capacity(1 + self.degree());
         powers_of_point.push(F::one());
         let mut cur = point;
@@ -983,5 +1014,47 @@ mod monic_linear_divide_tests {
         let (q, r) = DensePolynomial::from_coefficients_vec(vec![c]).divide_by_monic_linear(z);
         assert!(q.is_zero());
         assert_eq!(r, c);
+    }
+}
+
+#[cfg(test)]
+mod evaluate_tests {
+    use super::vanishing_divide_tests::rand_poly;
+    use snarkvm_curves::bls12_377::Fr;
+    use snarkvm_fields::{One, Zero};
+    use snarkvm_utilities::rand::{TestRng, Uniform};
+
+    /// Horner agrees with the powers form it replaced, on well-formed input.
+    ///
+    /// Field addition is associative, so the tree reduction the powers form
+    /// used and Horner's serial accumulation agree exactly rather than
+    /// approximately -- `assert_eq!` is the right strength here, not an
+    /// epsilon.
+    #[test]
+    fn evaluate_agrees_with_the_powers_form() {
+        let rng = &mut TestRng::default();
+        for len in [0usize, 1, 2, 5, 16, 17, 33, 70] {
+            let p = rand_poly(len, rng);
+            for point in [Fr::zero(), Fr::one(), Fr::rand(rng), Fr::rand(rng)] {
+                assert_eq!(p.evaluate(point), p.evaluate_by_powers(point), "len={len}");
+            }
+        }
+    }
+
+    /// `evaluate` tolerates trailing zero coefficients. The powers form it
+    /// replaced panicked in `degree()` on exactly this input, so the tolerance
+    /// is a deliberate widening rather than an accident.
+    #[test]
+    fn evaluate_tolerates_trailing_zeros() {
+        let rng = &mut TestRng::default();
+        for len in [1usize, 5, 17] {
+            for pad in [1usize, 4, 20] {
+                let mut p = rand_poly(len, rng);
+                let point = Fr::rand(rng);
+                let expected = p.evaluate(point);
+                p.coeffs.resize(p.coeffs.len() + pad, Fr::zero());
+                assert_eq!(p.evaluate(point), expected, "len={len} pad={pad}");
+            }
+        }
     }
 }

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -367,9 +367,15 @@ impl<'a, F: Field> AddAssign<(F, &'a DensePolynomial<F>)> for DensePolynomial<F>
     #[allow(clippy::suspicious_op_assign_impl)]
     fn add_assign(&mut self, (f, other): (F, &'a DensePolynomial<F>)) {
         if self.is_zero() {
+            // One pass, not two. The scale has to happen either way; the copy
+            // does not have to be a separate walk over the coefficients.
+            //
+            // `clear()` rather than assigning a fresh vector, because `self`
+            // being zero does not mean it is empty -- a polynomial whose
+            // coefficients are all zero reaches here too, and its allocation is
+            // worth keeping.
             self.coeffs.clear();
-            self.coeffs.extend_from_slice(&other.coeffs);
-            self.coeffs.iter_mut().for_each(|c| *c *= &f);
+            self.coeffs.extend(other.coeffs.iter().map(|c| *c * f));
         } else if other.is_zero() {
             // return
         } else if self.degree() >= other.degree() {
@@ -646,6 +652,41 @@ mod tests {
                 assert_eq!(res1, res2);
             }
         }
+    }
+
+    #[test]
+    fn add_scaled_polynomial_to_zero() {
+        // `DensePolynomial::rand` resamples until the leading coefficient is
+        // non-zero, so `add_polynomials_with_mul` never enters `add_assign`'s
+        // `self.is_zero()` branch. These do, both ways it can be reached: an
+        // empty polynomial, and a non-empty one whose coefficients are all zero
+        // -- which is why that branch still has to `clear()`.
+        let rng = &mut TestRng::default();
+        for degree in 0..70 {
+            let q = DensePolynomial::rand(degree, rng);
+            let f = Fr::rand(rng);
+            let expected = DensePolynomial::from_coefficients_vec(q.coeffs.iter().map(|c| f * c).collect());
+
+            let mut empty = DensePolynomial::zero();
+            empty += (f, &q);
+            assert_eq!(empty, expected, "scaled add onto an empty polynomial");
+
+            // Built through the field, not `from_coefficients_vec`, which strips
+            // trailing zeros and would hand back the empty representation --
+            // making this the same case as `empty` above and testing nothing.
+            let mut zeroed = DensePolynomial::zero();
+            zeroed.coeffs = vec![Fr::zero(); degree + 3];
+            assert!(zeroed.is_zero() && !zeroed.coeffs.is_empty());
+            zeroed += (f, &q);
+            assert_eq!(zeroed, expected, "scaled add onto a non-empty all-zero polynomial");
+        }
+
+        // A zero scalar still normalises to the empty representation.
+        let q = DensePolynomial::rand(16, rng);
+        let mut p = DensePolynomial::zero();
+        p += (Fr::zero(), &q);
+        assert!(p.is_zero());
+        assert!(p.coeffs.is_empty());
     }
 
     #[test]

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -158,6 +158,32 @@ impl<F: PrimeField> DensePolynomial<F> {
         DensePolynomial::from_coefficients_vec(shifted)
     }
 
+    /// Divides by the monic linear polynomial `X - z`, returning the quotient
+    /// and the remainder.
+    ///
+    /// Ruffini's rule: one multiply-add per coefficient. Generic long division
+    /// reaches the same answer with two multiplications per coefficient, a
+    /// clone of the dividend, and a trailing-zero trim and degree check on
+    /// every iteration.
+    ///
+    /// The remainder is the scalar `self(z)`, which is what the divisor's
+    /// degree makes it.
+    pub fn divide_by_monic_linear(&self, z: F) -> (Self, F) {
+        match self.coeffs.len() {
+            0 => (Self::zero(), F::zero()),
+            1 => (Self::zero(), self.coeffs[0]),
+            n => {
+                let mut quotient = vec![F::zero(); n - 1];
+                quotient[n - 2] = self.coeffs[n - 1];
+                for i in (1..n - 1).rev() {
+                    quotient[i - 1] = self.coeffs[i] + z * quotient[i];
+                }
+                let remainder = self.coeffs[0] + z * quotient[0];
+                (Self::from_coefficients_vec(quotient), remainder)
+            }
+        }
+    }
+
     /// Divides by the vanishing polynomial `X^n - 1` of `domain`, returning
     /// `(quotient, remainder)`.
     ///
@@ -857,5 +883,105 @@ mod vanishing_divide_tests {
         let (q, r) = DensePolynomial::<Fr>::zero().divide_by_vanishing_poly(domain).unwrap();
         assert!(q.is_zero());
         assert!(r.is_zero());
+    }
+}
+
+#[cfg(test)]
+mod monic_linear_divide_tests {
+    use crate::fft::{DensePolynomial, Polynomial};
+    use snarkvm_curves::bls12_377::Fr;
+    use snarkvm_fields::{One, Zero};
+    use snarkvm_utilities::{TestRng, Uniform};
+
+    /// What generic long division would have produced, for comparison.
+    fn generic(p: &DensePolynomial<Fr>, z: Fr) -> (DensePolynomial<Fr>, DensePolynomial<Fr>) {
+        let divisor = DensePolynomial::from_coefficients_vec(vec![-z, Fr::one()]);
+        Polynomial::from(p.clone()).divide_with_q_and_r(&Polynomial::from(divisor)).unwrap()
+    }
+
+    #[test]
+    fn agrees_with_generic_long_division() {
+        let rng = &mut TestRng::default();
+        for degree in [0usize, 1, 2, 3, 7, 64, 255, 1024] {
+            let p = DensePolynomial::<Fr>::rand(degree, rng);
+            let z = Fr::rand(rng);
+            let (q, r) = p.divide_by_monic_linear(z);
+            let (gq, gr) = generic(&p, z);
+            assert_eq!(q, gq, "quotient differs at degree {degree}");
+            assert_eq!(DensePolynomial::from_coefficients_vec(vec![r]), gr, "remainder differs at degree {degree}");
+        }
+    }
+
+    /// p = (X - z) q + r, over enough random inputs to catch an off-by-one that
+    /// hand-picked shapes would step over.
+    #[test]
+    fn satisfies_the_defining_identity() {
+        let rng = &mut TestRng::default();
+        for _ in 0..200 {
+            let degree = (u64::rand(rng) % 128) as usize;
+            let p = DensePolynomial::<Fr>::rand(degree, rng);
+            let z = Fr::rand(rng);
+            let (q, r) = p.divide_by_monic_linear(z);
+            let divisor = DensePolynomial::from_coefficients_vec(vec![-z, Fr::one()]);
+            let reconstructed = &(&divisor * &q) + &DensePolynomial::from_coefficients_vec(vec![r]);
+            assert_eq!(reconstructed, p);
+        }
+    }
+
+    /// The remainder of dividing by `X - z` is the evaluation at `z`.
+    #[test]
+    fn the_remainder_is_the_evaluation() {
+        let rng = &mut TestRng::default();
+        for degree in [0usize, 1, 5, 100, 513] {
+            let p = DensePolynomial::<Fr>::rand(degree, rng);
+            let z = Fr::rand(rng);
+            let (_, r) = p.divide_by_monic_linear(z);
+            assert_eq!(r, p.evaluate(z), "at degree {degree}");
+        }
+    }
+
+    /// A root divides exactly, and the quotient must come back canonical --
+    /// this is the shape that carried a real defect in the vanishing-poly case.
+    #[test]
+    fn a_root_divides_exactly() {
+        let rng = &mut TestRng::default();
+        for degree in [1usize, 2, 9, 200] {
+            let q = DensePolynomial::<Fr>::rand(degree, rng);
+            let z = Fr::rand(rng);
+            let divisor = DensePolynomial::from_coefficients_vec(vec![-z, Fr::one()]);
+            let p = &divisor * &q;
+            let (quotient, r) = p.divide_by_monic_linear(z);
+            assert!(r.is_zero(), "remainder at degree {degree}");
+            assert_eq!(quotient, q);
+            assert!(quotient.coeffs.last().is_none_or(|c| !c.is_zero()), "non-canonical quotient");
+        }
+    }
+
+    /// Trailing zeros in the coefficient vector must not change the answer.
+    #[test]
+    fn tolerates_non_canonical_input() {
+        let rng = &mut TestRng::default();
+        let p = DensePolynomial::<Fr>::rand(30, rng);
+        let z = Fr::rand(rng);
+        let mut padded = p.clone();
+        padded.coeffs.extend(std::iter::repeat_n(Fr::zero(), 5));
+        let (q1, r1) = p.divide_by_monic_linear(z);
+        let (q2, r2) = padded.divide_by_monic_linear(z);
+        assert_eq!(q1, q2);
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn zero_and_constant_polynomials() {
+        let rng = &mut TestRng::default();
+        let z = Fr::rand(rng);
+
+        let (q, r) = DensePolynomial::<Fr>::zero().divide_by_monic_linear(z);
+        assert!(q.is_zero() && r.is_zero());
+
+        let c = Fr::rand(rng);
+        let (q, r) = DensePolynomial::from_coefficients_vec(vec![c]).divide_by_monic_linear(z);
+        assert!(q.is_zero());
+        assert_eq!(r, c);
     }
 }

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -158,15 +158,51 @@ impl<F: PrimeField> DensePolynomial<F> {
         DensePolynomial::from_coefficients_vec(shifted)
     }
 
-    /// Divide `self` by the vanishing polynomial for the domain `domain`.
-    /// Returns the quotient and remainder of the division.
+    /// Divides by the vanishing polynomial `X^n - 1` of `domain`, returning
+    /// `(quotient, remainder)`.
+    ///
+    /// Matching coefficients on `p = q(X^n - 1) + r`, with `deg(r) < n`:
+    ///
+    /// ```text
+    ///     q[j] = p[j+n] + q[j+n]      (q[k] = 0 for k >= len(q))
+    ///     r[i] = p[i]   + q[i]
+    /// ```
+    ///
+    /// The recurrence is `n` independent chains, one per residue class mod `n`.
+    /// For `deg(p) < 2n` each chain is a single step and the quotient is
+    /// `p[n..]`.
     pub fn divide_by_vanishing_poly(
         &self,
         domain: EvaluationDomain<F>,
     ) -> Result<(DensePolynomial<F>, DensePolynomial<F>)> {
-        let self_poly = Polynomial::from(self);
-        let vanishing_poly = Polynomial::from(domain.vanishing_polynomial());
-        self_poly.divide_with_q_and_r(&vanishing_poly)
+        let n = domain.size();
+        anyhow::ensure!(n > 0, "Dividing by the vanishing polynomial of an empty domain");
+
+        let p = &self.coeffs;
+        // deg(p) < n: the quotient is zero and the remainder is `p`.
+        if p.len() <= n {
+            return Ok((DensePolynomial::zero(), Self::from_coefficients_slice(p)));
+        }
+
+        let q_len = p.len() - n;
+        let q = if q_len <= n {
+            // Single-step chains.
+            p[n..].to_vec()
+        } else {
+            // Chains span several steps, so each carries into the next.
+            let mut q = vec![F::zero(); q_len];
+            for j in (0..q_len).rev() {
+                let carry = if j + n < q_len { q[j + n] } else { F::zero() };
+                q[j] = p[j + n] + carry;
+            }
+            q
+        };
+
+        let mut r = p[..n].to_vec();
+        let overlap = q_len.min(n);
+        cfg_iter_mut!(r[..overlap]).enumerate().for_each(|(i, r_i)| *r_i += q[i]);
+
+        Ok((DensePolynomial::from_coefficients_vec(q), DensePolynomial::from_coefficients_vec(r)))
     }
 
     /// Evaluate `self` over `domain`.
@@ -717,5 +753,109 @@ mod tests {
                 assert_eq!(ans1, ans2);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod vanishing_divide_tests {
+    use crate::fft::{DensePolynomial, EvaluationDomain, Polynomial};
+    use snarkvm_curves::bls12_377::Fr;
+    use snarkvm_fields::Zero;
+    use snarkvm_utilities::rand::{TestRng, Uniform};
+
+    pub(super) fn rand_poly(len: usize, rng: &mut TestRng) -> DensePolynomial<Fr> {
+        DensePolynomial::from_coefficients_vec((0..len).map(|_| Fr::rand(rng)).collect())
+    }
+
+    /// `q * (X^n - 1) + r == p`, and `deg(r) < n`.
+    ///
+    /// Compared against the canonical form of `p`: results are trimmed on
+    /// construction, so an input carrying trailing zeros would otherwise differ
+    /// from an equal output by representation alone.
+    fn check_identity(p: &DensePolynomial<Fr>, domain: EvaluationDomain<Fr>, label: &str) {
+        let n = domain.size();
+        let (q, r) = p.divide_by_vanishing_poly(domain).unwrap();
+        let v = DensePolynomial::from(domain.vanishing_polynomial());
+        let canonical = DensePolynomial::from_coefficients_vec(p.coeffs.clone());
+        assert_eq!(&(&q * &v) + &r, canonical, "q*v + r != p [{label}]");
+        assert!(r.is_zero() || r.degree() < n, "deg(r) >= n [{label}]");
+    }
+
+    /// Agrees with generic long division across inputs shorter than the
+    /// divisor, on the `deg(p) < 2n` path, and long enough for a chain to
+    /// carry.
+    #[test]
+    fn agrees_with_generic_long_division() {
+        let rng = &mut TestRng::default();
+        for log_n in [3usize, 5, 8] {
+            let domain = EvaluationDomain::<Fr>::new(1 << log_n).unwrap();
+            let n = domain.size();
+            for len in [0, 1, n / 2, n, n + 1, 2 * n - 1, 2 * n, 2 * n + 3, 4 * n + 5] {
+                let p = rand_poly(len, rng);
+                let (q, r) = p.divide_by_vanishing_poly(domain).unwrap();
+
+                let expect =
+                    Polynomial::from(&p).divide_with_q_and_r(&Polynomial::from(domain.vanishing_polynomial())).unwrap();
+                assert_eq!(q, expect.0, "quotient differs at n={n} len={len}");
+                assert_eq!(r, expect.1, "remainder differs at n={n} len={len}");
+                check_identity(&p, domain, &format!("n={n} len={len}"));
+            }
+        }
+    }
+
+    /// Random lengths spanning every branch, including chains long enough to
+    /// carry several times.
+    #[test]
+    fn identity_holds_for_random_inputs() {
+        let rng = &mut TestRng::default();
+        for _ in 0..200 {
+            let log_n = 2 + (u64::rand(rng) % 7) as usize;
+            let domain = EvaluationDomain::<Fr>::new(1 << log_n).unwrap();
+            let len = (u64::rand(rng) % (6 * domain.size() as u64 + 2)) as usize;
+            let p = rand_poly(len, rng);
+            check_identity(&p, domain, &format!("n={} len={len}", domain.size()));
+        }
+    }
+
+    /// `coeffs` is public, so a caller can hand over a polynomial carrying
+    /// trailing zeros. The quotient's own leading zeros are trimmed on
+    /// construction, so the identity still holds.
+    #[test]
+    fn tolerates_trailing_zeros() {
+        let rng = &mut TestRng::default();
+        let domain = EvaluationDomain::<Fr>::new(16).unwrap();
+        for len in [0usize, 5, 16, 17, 33, 70] {
+            for pad in [1usize, 4, 20] {
+                let mut p = rand_poly(len, rng);
+                p.coeffs.resize(p.coeffs.len() + pad, Fr::zero());
+                check_identity(&p, domain, &format!("len={len} pad={pad}"));
+            }
+        }
+    }
+
+    /// A polynomial that is exactly a multiple of the vanishing polynomial
+    /// divides with no remainder, which is what the selector paths assert.
+    #[test]
+    fn exact_multiples_leave_no_remainder() {
+        let rng = &mut TestRng::default();
+        for log_n in [3usize, 6] {
+            let domain = EvaluationDomain::<Fr>::new(1 << log_n).unwrap();
+            let v = DensePolynomial::from(domain.vanishing_polynomial());
+            for len in [1usize, 5, domain.size(), 3 * domain.size()] {
+                let p = &rand_poly(len, rng) * &v;
+                let (q, r) = p.divide_by_vanishing_poly(domain).unwrap();
+                assert!(r.is_zero(), "expected no remainder [n={} len={len}]", domain.size());
+                assert_eq!(&q * &v, p, "q*v != p [n={} len={len}]", domain.size());
+            }
+        }
+    }
+
+    /// The zero polynomial divides to zero and zero.
+    #[test]
+    fn zero_divides_to_zero() {
+        let domain = EvaluationDomain::<Fr>::new(8).unwrap();
+        let (q, r) = DensePolynomial::<Fr>::zero().divide_by_vanishing_poly(domain).unwrap();
+        assert!(q.is_zero());
+        assert!(r.is_zero());
     }
 }

--- a/algorithms/src/fft/polynomial/dense.rs
+++ b/algorithms/src/fft/polynomial/dense.rs
@@ -57,6 +57,22 @@ impl<F: Field> fmt::Debug for DensePolynomial<F> {
 }
 
 impl<F: Field> DensePolynomial<F> {
+    /// Drops trailing zero coefficients, so that `degree()` is the real degree.
+    ///
+    /// `degree()` asserts that the last coefficient is non-zero, and
+    /// `apply_randomized_selector` divides by degree, so a polynomial that
+    /// skips this is a live panic rather than an untidy one. The loop was
+    /// written out seven times in this file and once in `second.rs`; naming it
+    /// means the next person changing one changes all of them.
+    ///
+    /// `from_coefficients_vec` still writes the loop out, and has to: it trims
+    /// a bare `Vec<F>` before there is a `Self` to call this on.
+    pub(crate) fn trim_trailing_zeros(&mut self) {
+        while let Some(true) = self.coeffs.last().map(|c| c.is_zero()) {
+            self.coeffs.pop();
+        }
+    }
+
     /// Returns the zero polynomial.
     pub fn zero() -> Self {
         Self { coeffs: Vec::new() }
@@ -304,10 +320,7 @@ impl<'a, F: Field> Add<&'a DensePolynomial<F>> for &'_ DensePolynomial<F> {
             cfg_iter_mut!(result.coeffs).zip(&self.coeffs).for_each(|(a, b)| *a += b);
             result
         };
-        // If the leading coefficient ends up being zero, pop it off.
-        while let Some(true) = result.coeffs.last().map(|c| c.is_zero()) {
-            result.coeffs.pop();
-        }
+        result.trim_trailing_zeros();
         result
     }
 }
@@ -328,10 +341,7 @@ impl<'a, F: Field> AddAssign<&'a DensePolynomial<F>> for DensePolynomial<F> {
             // Zip safety: `self` and `other` have the same length.
             cfg_iter_mut!(self.coeffs, 1_000).zip(&other.coeffs).for_each(|(a, b)| *a += b);
         }
-        // If the leading coefficient ends up being zero, pop it off.
-        while let Some(true) = self.coeffs.last().map(|c| c.is_zero()) {
-            self.coeffs.pop();
-        }
+        self.trim_trailing_zeros();
     }
 }
 
@@ -375,10 +385,7 @@ impl<'a, F: Field> AddAssign<(F, &'a DensePolynomial<F>)> for DensePolynomial<F>
                 *a += f * b;
             });
         }
-        // If the leading coefficient ends up being zero, pop it off.
-        while let Some(true) = self.coeffs.last().map(|c| c.is_zero()) {
-            self.coeffs.pop();
-        }
+        self.trim_trailing_zeros();
     }
 }
 
@@ -421,10 +428,7 @@ impl<'a, F: Field> Sub<&'a DensePolynomial<F>> for &'_ DensePolynomial<F> {
             });
             result
         };
-        // If the leading coefficient ends up being zero, pop it off.
-        while let Some(true) = result.coeffs.last().map(|c| c.is_zero()) {
-            result.coeffs.pop();
-        }
+        result.trim_trailing_zeros();
         result
     }
 }
@@ -448,10 +452,7 @@ impl<'a, F: Field> SubAssign<&'a DensePolynomial<F>> for DensePolynomial<F> {
             // Zip safety: self and other have the same length after the resize.
             cfg_iter_mut!(self.coeffs).zip(&other.coeffs).for_each(|(a, b)| *a -= b);
         }
-        // If the leading coefficient ends up being zero, pop it off.
-        while let Some(true) = self.coeffs.last().map(|c| c.is_zero()) {
-            self.coeffs.pop();
-        }
+        self.trim_trailing_zeros();
     }
 }
 
@@ -464,10 +465,7 @@ impl<'a, F: Field> AddAssign<&'a super::SparsePolynomial<F>> for DensePolynomial
         for (i, b) in other.coeffs() {
             self.coeffs[*i] += b;
         }
-        // If the leading coefficient ends up being zero, pop it off.
-        while let Some(true) = self.coeffs.last().map(|c| c.is_zero()) {
-            self.coeffs.pop();
-        }
+        self.trim_trailing_zeros();
     }
 }
 
@@ -482,10 +480,7 @@ impl<'a, F: Field> Sub<&'a super::SparsePolynomial<F>> for DensePolynomial<F> {
         for (i, b) in other.coeffs() {
             self.coeffs[*i] -= b;
         }
-        // If the leading coefficient ends up being zero, pop it off.
-        while let Some(true) = self.coeffs.last().map(|c| c.is_zero()) {
-            self.coeffs.pop();
-        }
+        self.trim_trailing_zeros();
         self
     }
 }

--- a/algorithms/src/polycommit/kzg10/mod.rs
+++ b/algorithms/src/polycommit/kzg10/mod.rs
@@ -217,17 +217,15 @@ impl<E: PairingEngine> KZG10<E> {
         point: E::Fr,
         randomness: &KZGRandomness<E>,
     ) -> Result<(DensePolynomial<E::Fr>, Option<DensePolynomial<E::Fr>>), PCError> {
-        let divisor = DensePolynomial::from_coefficients_vec(vec![-point, E::Fr::one()]);
-
         let witness_time = start_timer!(|| "Computing witness polynomial");
-        let witness_polynomial = polynomial / &divisor;
+        let (witness_polynomial, _) = polynomial.divide_by_monic_linear(point);
         end_timer!(witness_time);
 
         let random_witness_polynomial = if randomness.is_hiding() {
             let random_p = &randomness.blinding_polynomial;
 
             let witness_time = start_timer!(|| "Computing random witness polynomial");
-            let random_witness_polynomial = random_p / &divisor;
+            let (random_witness_polynomial, _) = random_p.divide_by_monic_linear(point);
             end_timer!(witness_time);
             Some(random_witness_polynomial)
         } else {

--- a/algorithms/src/polycommit/sonic_pc/mod.rs
+++ b/algorithms/src/polycommit/sonic_pc/mod.rs
@@ -439,6 +439,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         let mut lc_randomness = Vec::new();
         let mut lc_info = Vec::new();
 
+        let accumulate_time = start_timer!(|| "Accumulating linear combinations");
         for lc in linear_combinations {
             let lc_label = lc.label().to_string();
             let mut poly = DensePolynomial::zero();
@@ -475,6 +476,7 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
             lc_randomness.push(randomness);
             lc_info.push((lc_label, degree_bound));
         }
+        end_timer!(accumulate_time);
 
         let proof =
             Self::batch_open(universal_prover, ck, lc_polynomials.iter(), query_set, lc_randomness.iter(), fs_rng)?;

--- a/algorithms/src/polycommit/sonic_pc/mod.rs
+++ b/algorithms/src/polycommit/sonic_pc/mod.rs
@@ -41,6 +41,27 @@ pub use data_structures::*;
 mod polynomial;
 pub use polynomial::*;
 
+/// A linear combination whose polynomial has not been formed.
+///
+/// `open_combinations` resolves each combination to the polynomials it names
+/// and the scalar in front of each, and leaves the coefficient arithmetic to
+/// `open_lazy_combinations`, which folds in the Fiat-Shamir challenge and
+/// accumulates once. Holding the polynomial by reference is the
+/// point: `LabeledPolynomial` owns a `Cow<'static, _>`, so putting one into a
+/// combination is a clone of every coefficient.
+struct LazyCombination<'a, E: PairingEngine> {
+    label: String,
+    /// `(coefficient, polynomial)` per term, with the `LCTerm::One` constants
+    /// already filtered out -- the verifier uses those directly and nothing
+    /// is committed to them.
+    terms: Vec<(E::Fr, &'a LabeledPolynomial<E::Fr>)>,
+    /// `Some` only for a single-term combination whose coefficient is one,
+    /// which is what `open_combinations` enforces; `open_lazy_combinations`
+    /// relies on it.
+    degree_bound: Option<usize>,
+    randomness: Randomness<E>,
+}
+
 /// Polynomial commitment based on [\[KZG10\]][kzg], with degree enforcement and
 /// batching taken from [[MBKM19, “Sonic”]][sonic] (more precisely, their
 /// counterparts in [[Gabizon19, “AuroraLight”]][al] that avoid negative G1
@@ -287,6 +308,117 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
     /// On input a list of labeled polynomials and a query set, `open` outputs a
     /// proof of evaluation of the polynomials at the points in the query
     /// set.
+    /// `batch_open` over combinations whose polynomials have not been formed.
+    ///
+    /// Both levels of the opening are linear in the coefficients. A combination
+    /// is `Σ c_i · P_i`, and `combine_for_open` then scales that by a
+    /// Fiat-Shamir challenge `d_j` and sums the results. So
+    ///
+    /// ```text
+    ///     Σ_j d_j · ( Σ_i c_ji · P_i )  =  Σ_i ( Σ_j d_j · c_ji ) · P_i
+    /// ```
+    ///
+    /// and composing the two coefficients accumulates the same polynomial in
+    /// **one** pass over each term instead of two. What made the second
+    /// pass easy to miss is that most of Varuna's combinations have a
+    /// single term, so their first pass is a whole scaled copy of a polynomial
+    /// that the second pass then walks again.
+    ///
+    /// This is safe to compose only because the sponge is **squeezed and never
+    /// absorbed** between here and the KZG open, so every challenge is
+    /// determined before any polynomial arithmetic happens. Squeeze order
+    /// is preserved exactly: groups in query-set order, combinations in
+    /// label order within a group, and the trailing squeeze per group.
+    fn open_lazy_combinations(
+        universal_prover: &UniversalProver<E>,
+        ck: &CommitterUnionKey<E>,
+        combinations: &[LazyCombination<'_, E>],
+        query_set: &QuerySet<E::Fr>,
+        fs_rng: &mut S,
+    ) -> Result<BatchProof<E>> {
+        let open_time = start_timer!(|| format!(
+            "Opening {} combinations at query set of size {}",
+            combinations.len(),
+            query_set.len(),
+        ));
+
+        let by_label: BTreeMap<&str, &LazyCombination<'_, E>> =
+            combinations.iter().map(|c| (c.label.as_str(), c)).collect();
+
+        let mut query_to_labels_map = BTreeMap::new();
+        for (label, (point_name, point)) in query_set.iter() {
+            let labels = query_to_labels_map.entry(point_name).or_insert((point, BTreeSet::new()));
+            labels.1.insert(label);
+        }
+
+        let mut proofs = Vec::new();
+        for (_point_name, (&query, labels)) in query_to_labels_map.into_iter() {
+            let mut group = Vec::with_capacity(labels.len());
+            for label in labels {
+                let c = by_label.get(label as &str).ok_or(PCError::MissingPolynomial { label: label.to_string() })?;
+                group.push(*c);
+            }
+
+            let mut challenges = Vec::with_capacity(group.len());
+            for c in &group {
+                // `check_degrees_and_bounds` returns immediately unless the polynomial carries
+                // a degree bound, and a combination only carries one when it
+                // has a single term with coefficient one -- in which case the
+                // combination's polynomial *is* that term's. So checking the
+                // term is the same check on the same coefficients.
+                if let Some(bound) = c.degree_bound {
+                    // Enforced rather than asserted. The invariant is real -- `open_combinations`
+                    // bails unless `lc.len() == 1` before it can set `degree_bound` -- but it is
+                    // established in another function, and `debug_assert!` is compiled out of the
+                    // builds that ship. If it ever broke, nothing would panic: the bound would be
+                    // checked against the first term while the opening covered the whole sum, the
+                    // proof would still verify, and what would quietly be gone is a soundness
+                    // property of the commitment scheme.
+                    ensure!(
+                        c.terms.len() == 1,
+                        "combination {} carries degree bound {bound} with {} terms; \
+                         a degree-bounded combination must have exactly one",
+                        c.label,
+                        c.terms.len(),
+                    );
+                    let enforced_degree_bounds: Option<&[usize]> = ck.enforced_degree_bounds.as_deref();
+                    kzg10::KZG10::<E>::check_degrees_and_bounds(
+                        universal_prover.max_degree,
+                        enforced_degree_bounds,
+                        c.terms[0].1,
+                    )?;
+                }
+                challenges.push(fs_rng.squeeze_short_nonnative_field_element::<E::Fr>());
+            }
+
+            let combine_time = start_timer!(|| format!("Combining {} combinations for the opening", group.len()));
+            let mut polynomial = DensePolynomial::zero();
+            let mut rand = Randomness::empty();
+            for (c, challenge) in group.iter().zip_eq(challenges.iter()) {
+                rand += (*challenge, &c.randomness);
+                for (coeff, p) in &c.terms {
+                    let scale = *challenge * coeff;
+                    if scale.is_one() {
+                        polynomial += p.polynomial();
+                    } else {
+                        polynomial += (scale, p.polynomial());
+                    }
+                }
+            }
+            end_timer!(combine_time);
+
+            let proof_time = start_timer!(|| "Creating proof");
+            let proof = kzg10::KZG10::open(&ck.powers(), &polynomial, query, &rand)?;
+            end_timer!(proof_time);
+            proofs.push(proof);
+
+            let _ = fs_rng.squeeze_short_nonnative_field_element::<E::Fr>();
+        }
+        end_timer!(open_time);
+
+        Ok(BatchProof(proofs))
+    }
+
     pub fn batch_open<'a>(
         universal_prover: &UniversalProver<E>,
         ck: &CommitterUnionKey<E>,
@@ -435,17 +567,21 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
         let label_map =
             polynomials.into_iter().zip_eq(rands).map(|(p, r)| (p.to_label(), (p, r))).collect::<BTreeMap<_, _>>();
 
-        let mut lc_polynomials = Vec::new();
-        let mut lc_randomness = Vec::new();
-        let mut lc_info = Vec::new();
-
-        let accumulate_time = start_timer!(|| "Accumulating linear combinations");
+        // Resolve each combination to its terms without forming its polynomial.
+        //
+        // The arithmetic below is over scalars: `lc` is symbolic, its terms naming
+        // polynomials rather than holding them. Forming the polynomial here is
+        // exactly what `open_lazy_combinations` avoids.
+        let resolve_time = start_timer!(|| "Resolving combination terms");
+        let mut combinations = Vec::new();
         for lc in linear_combinations {
             let lc_label = lc.label().to_string();
-            let mut poly = DensePolynomial::zero();
+            // `lc.len()` counts terms *before* the `is_one()` filter below, so this
+            // over-reserves by the number of constant terms. Left as is because
+            // that pre-filter reading is what the degree-bound guard relies on.
+            let mut terms = Vec::with_capacity(lc.len());
             let mut randomness = Randomness::empty();
             let mut degree_bound = None;
-            let mut hiding_bound = None;
 
             let num_polys = lc.len();
             // We filter out l.is_one() entries because those constants are not committed to
@@ -465,21 +601,19 @@ impl<E: PairingEngine, S: AlgebraicSponge<E::Fq, 2>> SonicKZG10<E, S> {
                         degree_bound = cur_poly.degree_bound();
                     }
                 }
-                // Some(_) > None, always.
-                hiding_bound = core::cmp::max(hiding_bound, cur_poly.hiding_bound());
-                poly += (*coeff, cur_poly.polynomial());
+                terms.push((*coeff, cur_poly));
                 randomness += (*coeff, *cur_rand);
             }
 
-            let lc_poly = LabeledPolynomial::new(lc_label.clone(), poly, degree_bound, hiding_bound);
-            lc_polynomials.push(lc_poly);
-            lc_randomness.push(randomness);
-            lc_info.push((lc_label, degree_bound));
+            // The hiding bound is not carried. It was only ever handed to the
+            // `LabeledPolynomial` built here, and nothing downstream of the
+            // opening reads it: the hiding bound is enforced when the
+            // polynomial is committed, not when it is opened.
+            combinations.push(LazyCombination { label: lc_label, terms, degree_bound, randomness });
         }
-        end_timer!(accumulate_time);
+        end_timer!(resolve_time);
 
-        let proof =
-            Self::batch_open(universal_prover, ck, lc_polynomials.iter(), query_set, lc_randomness.iter(), fs_rng)?;
+        let proof = Self::open_lazy_combinations(universal_prover, ck, &combinations, query_set, fs_rng)?;
 
         Ok(BatchLCProof { proof })
     }

--- a/algorithms/src/snark/varuna/ahp/ahp.rs
+++ b/algorithms/src/snark/varuna/ahp/ahp.rs
@@ -435,10 +435,13 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
 
         // When running as the prover, who has access to a(X) and b(X), we directly
         // return those
+        // `has_lc_eval`, not `get_lc_eval(..).is_ok()`: the question is whether the
+        // polynomial is present, and the prover's implementation of the latter
+        // answers it by evaluating the polynomial and throwing the value away.
         let a_poly = LinearCombination::new(label_a_poly.clone(), [(F::one(), label_a_poly.clone())]);
-        let a_poly_eval_available = evals.get_lc_eval(&a_poly, gamma).is_ok();
+        let a_poly_eval_available = evals.has_lc_eval(&a_poly, gamma);
         let b_poly = LinearCombination::new(label_b_poly.clone(), [(F::one(), label_b_poly.clone())]);
-        let b_poly_eval_available = evals.get_lc_eval(&b_poly, gamma).is_ok();
+        let b_poly_eval_available = evals.has_lc_eval(&b_poly, gamma);
         ensure!(a_poly_eval_available == b_poly_eval_available);
         if a_poly_eval_available && b_poly_eval_available {
             return Ok((a_poly, b_poly));
@@ -472,6 +475,17 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
 pub trait EvaluationsProvider<F: PrimeField>: core::fmt::Debug {
     /// Get the evaluation of linear combination `lc` at `point`.
     fn get_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> Result<F>;
+
+    /// Whether `get_lc_eval` would succeed, without computing the value.
+    ///
+    /// `construct_matrix_linear_combinations` has to know which side of the
+    /// protocol it is running on, and asks by seeing whether an evaluation is
+    /// available. Answering that with `get_lc_eval(..).is_ok()` costs a full
+    /// evaluation of every named polynomial on the prover's implementation, and
+    /// the value is then discarded.
+    ///
+    /// Implementations must agree with `get_lc_eval(..).is_ok()` exactly.
+    fn has_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> bool;
 }
 
 /// The `EvaluationsProvider` used by the verifier
@@ -479,6 +493,10 @@ impl<F: PrimeField> EvaluationsProvider<F> for crate::polycommit::sonic_pc::Eval
     fn get_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> Result<F> {
         let key = (lc.label.clone(), point);
         self.get(&key).copied().ok_or_else(|| AHPError::MissingEval(lc.label.clone())).map_err(Into::into)
+    }
+
+    fn has_lc_eval(&self, lc: &LinearCombination<F>, point: F) -> bool {
+        self.get(&(lc.label.clone(), point)).is_some()
     }
 }
 
@@ -505,6 +523,17 @@ where
         }
         Ok(eval)
     }
+
+    fn has_lc_eval(&self, lc: &LinearCombination<F>, _point: F) -> bool {
+        // Mirrors the two ways `get_lc_eval` above can fail: a `PolyLabel` term
+        // with no matching polynomial, and a non-`PolyLabel` term that is not
+        // one. The point is irrelevant -- if the polynomial is here, it can be
+        // evaluated anywhere.
+        lc.iter().all(|(_, term)| match term {
+            LCTerm::PolyLabel(label) => self.iter().any(|p| (*p).borrow().label() == label),
+            other => other.is_one(),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -512,8 +541,36 @@ mod tests {
     use super::*;
     use crate::fft::DensePolynomial;
     use snarkvm_curves::bls12_377::fr::Fr;
-    use snarkvm_fields::Zero;
-    use snarkvm_utilities::rand::TestRng;
+    use snarkvm_fields::{One, Zero};
+    use snarkvm_utilities::rand::{TestRng, Uniform};
+
+    /// `has_lc_eval` exists only as a cheap stand-in for
+    /// `get_lc_eval(..).is_ok()`, so the property worth testing is that the two
+    /// never disagree -- including on the inputs that make `get_lc_eval` fail.
+    #[test]
+    fn has_lc_eval_agrees_with_get_lc_eval() {
+        let rng = &mut TestRng::default();
+        let point = Fr::rand(rng);
+        let polys: Vec<LabeledPolynomial<Fr>> = ["a", "b"]
+            .into_iter()
+            .map(|label| LabeledPolynomial::new(label.to_string(), DensePolynomial::rand(1 << 4, rng), None, None))
+            .collect();
+
+        let cases = [
+            // Present, absent, mixed, and a bare `One` term, which `get_lc_eval`
+            // resolves without consulting the provider at all.
+            LinearCombination::new("present", [(Fr::one(), "a")]),
+            LinearCombination::new("absent", [(Fr::one(), "nope")]),
+            LinearCombination::new("both", [(Fr::one(), "a"), (Fr::one(), "b")]),
+            LinearCombination::new("one_present_one_not", [(Fr::one(), "a"), (Fr::one(), "nope")]),
+            LinearCombination::new("constant", [(Fr::one(), LCTerm::One)]),
+            LinearCombination::empty("empty"),
+        ];
+
+        for lc in &cases {
+            assert_eq!(polys.has_lc_eval(lc, point), polys.get_lc_eval(lc, point).is_ok(), "disagreed on {}", lc.label);
+        }
+    }
 
     #[test]
     fn test_summation() {

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
@@ -44,7 +44,7 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         mut state: prover::State<'a, F, SM>,
         _r: &mut R,
     ) -> Result<(prover::ThirdMessage<F>, prover::State<'a, F, SM>), AHPError> {
-        let round_time = start_timer!(|| "AHP::Prover::ThirdRound");
+        let round_time = start_timer!(|| "AHP::Prover::PrepareThirdRound");
 
         let verifier::FirstMessage { first_round_batch_combiners } = verifier_message;
         let verifier::SecondMessage { alpha, eta_b, eta_c } = verifier_second_message;

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
@@ -83,10 +83,14 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         let total_instances = num_instances.iter().sum::<usize>();
         let matrix_labels = ["a", "b", "c"];
 
+        // Borrowed, not cloned. Each precomputation holds a root-of-unity table sized
+        // by the circuit's largest multiplicative domain, so cloning copies
+        // megabytes per circuit per proof to produce a byte-identical result --
+        // the tables are circuit data, fixed for the life of the process.
         let fft_precomputations = state
             .circuit_specific_states
             .keys()
-            .map(|circuit| (circuit.fft_precomputation.clone(), circuit.ifft_precomputation.clone()))
+            .map(|circuit| (&circuit.fft_precomputation, &circuit.ifft_precomputation))
             .collect_vec();
 
         // Compute lineval sumcheck witnesses
@@ -134,8 +138,8 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                             label,
                             &l_at_alpha,
                             &circuit_specific_state.variable_domain,
-                            &precomp.0,
-                            &precomp.1,
+                            precomp.0,
+                            precomp.1,
                             assignment,
                             matrix_transpose,
                         )?;

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/prepare_third.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 use snarkvm_fields::PrimeField;
 use snarkvm_utilities::ExecutionPool;
+use std::sync::Arc;
 
 use anyhow::Result;
 use itertools::Itertools;
@@ -116,21 +117,27 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
             .zip_eq(assignments.values())
             .zip_eq(matrix_transposes.values())
         {
+            // One Lagrange vector per circuit rather than one per matrix: it depends only
+            // on the constraint domain and alpha, both of which are fixed
+            // across the jobs below.
+            let l_at_alpha =
+                Arc::new(circuit_specific_state.constraint_domain.evaluate_all_lagrange_coefficients(*alpha));
+
             // Iterate for each instance in the batch.
             for assignment in assignments_i {
                 // Iterate for each R1CS matrix corresponding to the circuit and instance.
                 for label in matrix_labels {
                     let matrix_transpose = &matrix_transposes_i[label];
+                    let l_at_alpha = l_at_alpha.clone();
                     job_pool.add_job(move || {
                         let z_m_at_alpha = Self::calculate_lineval_sumcheck_instance_witness(
                             label,
-                            &circuit_specific_state.constraint_domain,
+                            &l_at_alpha,
                             &circuit_specific_state.variable_domain,
                             &precomp.0,
                             &precomp.1,
                             assignment,
                             matrix_transpose,
-                            *alpha,
                         )?;
                         // sum_{h in H} f(h) = n*(c_0 + c_n) for deg(p) < 2n, where c_0 and c_n are the
                         // coeffs of f at degree 0 and n, resp. and in [0, 2n-2]

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/second.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/second.rs
@@ -97,7 +97,6 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                 itertools::izip!(instance_combiners, z_a, z_b, z_c).enumerate()
             {
                 job_pool.add_job(move || {
-                    let mut instance_lhs = DensePolynomial::zero();
                     let za_label = witness_label(circuit.id, "z_a", j);
                     let zb_label = witness_label(circuit.id, "z_b", j);
                     let zc_label = witness_label(circuit.id, "z_c", j);
@@ -111,7 +110,21 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                     let mut rowcheck = multiplier_2.multiply().unwrap();
                     rowcheck.coeffs.iter_mut().zip(&z_c.coeffs).for_each(|(ab, c)| *ab -= c);
 
-                    instance_lhs += &(&rowcheck * instance_combiner);
+                    // `instance_lhs` is this and nothing else -- one job, one instance combiner,
+                    // one `+=` onto a zero polynomial -- so the accumulation
+                    // the expression was named for never accumulated. Written
+                    // that way it costs three passes over the coefficients and two
+                    // allocations: `Mul<F> for &DensePolynomial` clones and then scales the clone,
+                    // and `AddAssign<&DensePolynomial>` onto a zero `self`
+                    // clears and copies it again. On the larger circuit
+                    // `rowcheck` is twice the constraint domain, so those are not small.
+                    //
+                    // Scaling it where it lies is one pass and no allocation. The trim is not
+                    // tidiness: `AddAssign` used to do it, and
+                    // `apply_randomized_selector` below is degree-sensitive.
+                    let mut instance_lhs = rowcheck;
+                    instance_lhs.coeffs.iter_mut().for_each(|c| *c *= instance_combiner);
+                    instance_lhs.trim_trailing_zeros();
 
                     let (h_0_i, remainder) = apply_randomized_selector(
                         &mut instance_lhs,

--- a/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
+++ b/algorithms/src/snark/varuna/ahp/prover/round_functions/third.rs
@@ -211,15 +211,15 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
                     let combiner = circuit_combiner * instance_combiner * matrix_combiner;
                     job_pool.add_job(move || match varuna_version {
                         VarunaVersion::V1 => {
+                            let l_at_alpha = constraint_domain.evaluate_all_lagrange_coefficients(*alpha);
                             let z_m_at_alpha = Self::calculate_lineval_sumcheck_instance_witness(
                                 label,
-                                constraint_domain,
+                                &l_at_alpha,
                                 variable_domain,
                                 fft_precomputation,
                                 ifft_precomputation,
                                 assignment,
                                 matrix_transpose,
-                                *alpha,
                             )?;
                             Self::calculate_lineval_sumcheck_instance_witness_polys(
                                 label,
@@ -343,13 +343,12 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
     #[allow(clippy::too_many_arguments)]
     pub(in crate::snark::varuna) fn calculate_lineval_sumcheck_instance_witness(
         _matrix_label: &str,
-        constraint_domain: &EvaluationDomain<F>,
+        l_at_alpha: &[F],
         variable_domain: &EvaluationDomain<F>,
         fft_precomputation: &FFTPrecomputation<F>,
         ifft_precomputation: &IFFTPrecomputation<F>,
         assignment: &DensePolynomial<F>,
         matrix_transpose: &Matrix<F>,
-        alpha: F,
     ) -> Result<DensePolynomial<F>> {
         // Let C = variable_domain
         // Let R = constraint_domain
@@ -361,7 +360,6 @@ impl<F: PrimeField, SM: SNARKMode> AHPForR1CS<F, SM> {
         // Instead of calculating L^C_col(κ)(c), we add val(k)*L^R_row(α) where we know
         // L^C_col(k)(X) will be 1
         let m_at_alpha_evals_time = start_timer!(|| format!("Compute m_at_alpha_evals parallel for {_matrix_label}"));
-        let l_at_alpha = constraint_domain.evaluate_all_lagrange_coefficients(alpha);
         let m_at_alpha_evals: Vec<_> = matrix_transpose
             .iter()
             .map(|col| col.iter().map(|(val, row_index)| *val * l_at_alpha[*row_index]).sum::<F>())

--- a/algorithms/src/snark/varuna/ahp/selectors.rs
+++ b/algorithms/src/snark/varuna/ahp/selectors.rs
@@ -133,15 +133,34 @@ pub(crate) fn apply_randomized_selector<F: PrimeField>(
         let updated_xg_i = if src_domain.size == target_domain.size {
             xg_i
         } else {
-            let xg_i = xg_i.mul_by_vanishing_poly(*target_domain);
-
-            let (xg_i, remainder) = xg_i.divide_by_vanishing_poly(*src_domain)?;
+            // `xg * (v_H / v_H_i)` is a concatenation, not a multiplication.
+            //
+            // With `m = |H_i|` and `n = |H|`, both powers of two and `m` dividing `n`, the
+            // quotient `v_H / v_H_i` is `(X^n - 1) / (X^m - 1) = 1 + X^m + X^2m
+            // + ... + X^(n-m)`. Multiplying `xg` by that places a copy of `xg`
+            // at every multiple of `m`, and since `deg(xg) < m` the copies do
+            // not overlap and nothing has to be added. So the result is `xg`'s
+            // coefficients repeated `n/m` times.
+            //
+            // Written as a multiply followed by a divide it was two passes over an
+            // `n`-sized polynomial to produce something that is a memcpy.
+            let m = src_domain.size();
+            let n = target_domain.size();
             ensure!(
-                remainder.is_zero(),
-                "[Returning remainder witness] Failed to divide by vanishing polynomial - non-zero remainder ({remainder:?})"
+                m > 0 && m <= n && n % m == 0,
+                "[Returning remainder witness] Source domain {m} does not divide target domain {n}"
+            );
+            ensure!(
+                xg_i.coeffs.len() <= m,
+                "[Returning remainder witness] Remainder has {} coefficients, expected at most {m}; the copies would overlap",
+                xg_i.coeffs.len()
             );
 
-            xg_i
+            let mut coeffs = vec![F::zero(); n];
+            for block in coeffs.chunks_exact_mut(m) {
+                block[..xg_i.coeffs.len()].copy_from_slice(&xg_i.coeffs);
+            }
+            DensePolynomial::from_coefficients_vec(coeffs)
         };
 
         end_timer!(selector_time);
@@ -156,6 +175,46 @@ mod tests {
     use snarkvm_curves::bls12_377::fr::Fr;
     use snarkvm_fields::{One, Zero};
     use snarkvm_utilities::rand::TestRng;
+
+    #[test]
+    fn repeat_matches_multiply_then_divide() {
+        let mut rng = TestRng::default();
+
+        for lg_m in 1..7 {
+            for lg_n in lg_m..9 {
+                let src = EvaluationDomain::<Fr>::new(1 << lg_m).unwrap();
+                let tgt = EvaluationDomain::<Fr>::new(1 << lg_n).unwrap();
+                let (m, n) = (src.size(), tgt.size());
+
+                for len in [0, 1, m / 2, m] {
+                    let xg = DensePolynomial::<Fr>::rand(len.saturating_sub(1), &mut rng);
+                    let xg = if len == 0 { DensePolynomial::from_coefficients_vec(vec![]) } else { xg };
+
+                    let mut coeffs = vec![Fr::zero(); n];
+                    for block in coeffs.chunks_exact_mut(m) {
+                        block[..xg.coeffs.len()].copy_from_slice(&xg.coeffs);
+                    }
+                    let repeated = DensePolynomial::from_coefficients_vec(coeffs);
+
+                    let (expected, remainder) = xg.mul_by_vanishing_poly(tgt).divide_by_vanishing_poly(src).unwrap();
+                    assert!(remainder.is_zero(), "m={m} n={n} len={len}");
+                    assert_eq!(repeated, expected, "m={m} n={n} len={len}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn repeat_rejects_a_source_domain_larger_than_the_target() {
+        let mut rng = TestRng::default();
+        let src = EvaluationDomain::<Fr>::new(8).unwrap();
+        let tgt = EvaluationDomain::<Fr>::new(4).unwrap();
+
+        let mut poly = DensePolynomial::<Fr>::rand(15, &mut rng);
+        let err = apply_randomized_selector(&mut poly, Fr::one(), &tgt, &src, true)
+            .expect_err("a source domain larger than the target must not produce a polynomial");
+        assert!(err.to_string().contains("does not divide"), "{err}");
+    }
 
     /// Given two domains H and K such that H \subseteq K,
     /// evaluate polynomial that outputs 0 on all elements in K \ H, but 1 on

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -87,6 +87,24 @@ locktick = [
   "snarkvm-synthesizer/locktick"
 ]
 metrics = [ "snarkvm-ledger-committee/metrics", "snarkvm-ledger-store/metrics" ]
+# Enables the proving benchmarks in `benches/transaction.rs`.
+#
+# Off by default because proving a transaction takes seconds: on a shared CI
+# runner the group adds tens of minutes, needs the multi-gigabyte universal SRS,
+# and is variable enough to trip the benchmark action's alert threshold. The
+# same three reasons the `varuna` and `store`/`advance` benchmarks are skipped
+# in `.github/workflows/benchmarks.yml`.
+#
+# It requires `test_consensus_heights`, and that is not a convenience. The
+# Varuna version is chosen from the block height, and the mainnet table does not
+# reach `ConsensusVersion::V4` -- the V1 to V2 boundary -- until height
+# 6_135_000. A benchmark on a freshly created chain would therefore prove with
+# Varuna V1, which the network has not used since that height, and which does
+# not even call `prover_prepare_third_round`. The test heights put V4 at height
+# 7, which a benchmark can actually reach.
+bench-prove = [ "test_consensus_heights" ]
+profiler = [ "snarkvm-synthesizer/profiler" ]
+test_consensus_heights = [ "snarkvm-console/test_consensus_heights", "snarkvm-synthesizer/test_consensus_heights" ]
 prop-tests = [ "snarkvm-ledger-committee/prop-tests" ]
 rocks = [ "snarkvm-ledger-store/rocks" ]
 serial = [

--- a/ledger/benches/transaction.rs
+++ b/ledger/benches/transaction.rs
@@ -23,43 +23,160 @@ use snarkvm_console::{
     network::{MainnetV0, Network},
     program::{Plaintext, Record, Value},
 };
+use snarkvm_ledger::Ledger;
 use snarkvm_ledger_block::Transition;
 use snarkvm_ledger_store::ConsensusStore;
 use snarkvm_synthesizer::{VM, program::Program};
 
+#[cfg(feature = "bench-prove")]
+use snarkvm_console::network::ConsensusVersion;
+
 use aleo_std::StorageMode;
 use criterion::Criterion;
+#[cfg(not(feature = "bench-prove"))]
 use indexmap::IndexMap;
+#[cfg(feature = "bench-prove")]
+use std::time::Duration;
 
 #[cfg(not(feature = "rocks"))]
 type LedgerType = snarkvm_ledger_store::helpers::memory::ConsensusMemory<MainnetV0>;
 #[cfg(feature = "rocks")]
 type LedgerType = snarkvm_ledger_store::helpers::rocksdb::ConsensusDB<MainnetV0>;
 
+/// The consensus version the proving benchmarks run at.
+///
+/// **This is load-bearing, not cosmetic.** `VM::execute_authorization` reads the consensus version
+/// out of the current block height and derives the Varuna version from it, and Varuna's V1 to V2
+/// boundary is `ConsensusVersion::V4`. A benchmark on a chain that has only just been created runs
+/// at height 1, which is `ConsensusVersion::V1`, so it proves with Varuna V1 -- a prover the network
+/// stopped using at height 6_135_000, and one that never calls `prover_prepare_third_round` at all.
+///
+/// V19 is the most recent version the mainnet table activates at a real height; V20 and V21 sit at
+/// `u32::MAX`. Under `test_consensus_heights`, which `bench-prove` requires, it is reachable in a
+/// couple of dozen empty blocks.
+#[cfg(feature = "bench-prove")]
+const BENCH_CONSENSUS_VERSION: ConsensusVersion = ConsensusVersion::V19;
+
+/// Mints a private credits record at the current consensus version, and returns it.
+///
+/// The genesis records cannot be used for this. They are created under `ConsensusVersion::V1`, which
+/// makes them record **Version 0**, and from `ConsensusVersion::V8` onward the credits circuit
+/// expects **Version 1** -- see `verify_execution`'s output-record check, and the note in
+/// `Stack::deploy` that circuit synthesis changed incompatibly at V8. Feeding a Version 0 record to
+/// a V8+ circuit produces an assignment that does not satisfy the constraints, which then surfaces a
+/// long way from its cause: as a non-zero remainder when Varuna divides by the vanishing polynomial.
+///
+/// `transfer_public_to_private` takes no private input, only the beacon's public balance, so it is
+/// the way to obtain a spendable record at a version the genesis records predate.
+#[cfg(feature = "bench-prove")]
+fn mint_private_record<R: Rng + CryptoRng>(
+    ledger: &Ledger<MainnetV0, LedgerType>,
+    private_key: &PrivateKey<MainnetV0>,
+    rng: &mut R,
+) -> Record<MainnetV0, Plaintext<MainnetV0>> {
+    let address = Address::try_from(private_key).unwrap();
+    let inputs = [
+        Value::<MainnetV0>::from_str(&address.to_string()).unwrap(),
+        Value::<MainnetV0>::from_str("100000000u64").unwrap(),
+    ];
+
+    let transaction = ledger
+        .vm()
+        .execute(private_key, ("credits.aleo", "transfer_public_to_private"), inputs.into_iter(), None, 0, None, rng)
+        .unwrap();
+
+    // The record has to be in a block before it can be spent: the transfer that spends it needs an
+    // inclusion proof against a committed state root.
+    let block = ledger
+        .prepare_advance_to_next_beacon_block(private_key, vec![], vec![], vec![transaction.clone()], rng)
+        .unwrap();
+    ledger.advance_to_next_block(&block).unwrap();
+
+    let view_key = ViewKey::try_from(private_key).unwrap();
+    transaction
+        .transitions()
+        .cloned()
+        .flat_map(Transition::into_records)
+        .map(|(_, record)| record.decrypt(&view_key).unwrap())
+        .next()
+        .expect("transfer_public_to_private must output a record")
+}
+
 /// Fixed RNG seed so benchmark inputs are reproducible across CI runs.
 const BENCH_RNG_SEED: u64 = 0xB34D_CAFE_CDEC_0123;
+
+/// Criterion configuration for the proving benchmarks.
+///
+/// Proving a transaction takes seconds, so the default sample size of 100 would
+/// put a single benchmark into the tens of minutes. Ten is criterion's minimum
+/// and is enough to resolve the differences these benchmarks exist to show.
+///
+/// The measurement time is deliberately *not* generous. Criterion fills the
+/// window by running several iterations per sample, so a large value multiplies
+/// the cost without improving what this benchmark is used for: a value near one
+/// sample per iteration keeps a run short enough to repeat, and repetition is
+/// what separates a real difference from the drift between two runs. Expect a
+/// warning that the samples did not fit; that is the intended trade.
+///
+/// Scoped to a group rather than set on `criterion_group!` so that the
+/// verification benchmarks, which run in microseconds, keep the defaults.
+#[cfg(feature = "bench-prove")]
+fn prove_group(c: &mut Criterion) -> criterion::BenchmarkGroup<'_, criterion::measurement::WallTime> {
+    let mut group = c.benchmark_group("prove");
+    group.sample_size(10).measurement_time(Duration::from_secs(60));
+    group
+}
 
 fn initialize_vm<R: Rng + CryptoRng>(
     private_key: &PrivateKey<MainnetV0>,
     rng: &mut R,
-) -> (VM<MainnetV0, LedgerType>, Vec<Record<MainnetV0, Plaintext<MainnetV0>>>) {
-    // Initialize the VM.
-    let vm = VM::from(ConsensusStore::open(StorageMode::new_test(None)).unwrap()).unwrap();
-
+) -> (Ledger<MainnetV0, LedgerType>, Vec<Record<MainnetV0, Plaintext<MainnetV0>>>) {
     // Initialize the genesis block.
+    let vm = VM::<MainnetV0, LedgerType>::from(ConsensusStore::open(StorageMode::new_test(None)).unwrap()).unwrap();
     let genesis = vm.genesis_beacon(private_key, rng).unwrap();
 
-    // Fetch the unspent records.
-    let records = genesis.transitions().cloned().flat_map(Transition::into_records).collect::<IndexMap<_, _>>();
+    // Fetch the unspent records. Only the genesis records are available here; with `bench-prove`
+    // they are replaced below by one minted at the benchmark's consensus version, because a record
+    // created at genesis is the wrong record version to spend there.
+    #[cfg(not(feature = "bench-prove"))]
+    let records: Vec<Record<MainnetV0, Plaintext<MainnetV0>>> = {
+        let records = genesis.transitions().cloned().flat_map(Transition::into_records).collect::<IndexMap<_, _>>();
+        let view_key = ViewKey::try_from(private_key).unwrap();
+        records.values().map(|record| record.decrypt(&view_key).unwrap()).collect()
+    };
 
-    // Select a record to spend.
-    let view_key = ViewKey::try_from(private_key).unwrap();
-    let records = records.values().map(|record| record.decrypt(&view_key).unwrap()).collect();
+    // Initialize the ledger with the genesis block.
+    let ledger = Ledger::<MainnetV0, LedgerType>::load(genesis, StorageMode::new_test(None)).unwrap();
 
-    // Update the VM.
-    vm.add_next_block(&genesis).unwrap();
+    // Advance to the consensus version the proving benchmarks need, then mint a record that is
+    // spendable there. The block height decides the consensus version, which decides which Varuna
+    // prover runs and which record version the credits circuit expects, so a benchmark left at
+    // genesis measures a prover the network no longer uses, with a record it would reject.
+    #[cfg(feature = "bench-prove")]
+    let records = {
+        // One block below the target, so the block that mints the record lands exactly on it. These
+        // blocks are empty, so none of this costs any proving.
+        let target = MainnetV0::CONSENSUS_HEIGHT(BENCH_CONSENSUS_VERSION).unwrap();
+        while ledger.latest_height() + 1 < target {
+            let block = ledger.prepare_advance_to_next_beacon_block(private_key, vec![], vec![], vec![], rng).unwrap();
+            ledger.advance_to_next_block(&block).unwrap();
+        }
 
-    (vm, records)
+        let records = vec![mint_private_record(&ledger, private_key, rng)];
+
+        // Fail loudly rather than silently benchmarking a prover the network does not run.
+        let consensus_version = MainnetV0::CONSENSUS_VERSION(ledger.latest_height()).unwrap();
+        assert_eq!(
+            consensus_version,
+            BENCH_CONSENSUS_VERSION,
+            "the proving benchmarks must run at {BENCH_CONSENSUS_VERSION:?}, but height {} is {consensus_version:?}",
+            ledger.latest_height(),
+        );
+
+        records
+    };
+
+    (ledger, records)
 }
 
 fn deploy(c: &mut Criterion) {
@@ -69,7 +186,8 @@ fn deploy(c: &mut Criterion) {
     let private_key = PrivateKey::<MainnetV0>::new(rng).unwrap();
 
     // Initialize the VM.
-    let (vm, records) = initialize_vm(&private_key, rng);
+    let (ledger, records) = initialize_vm(&private_key, rng);
+    let vm = ledger.vm();
 
     // Create a sample program.
     let program = Program::<MainnetV0>::from_str(
@@ -104,7 +222,8 @@ fn execute(c: &mut Criterion) {
     let address = Address::try_from(&private_key).unwrap();
 
     // Initialize the VM.
-    let (vm, records) = initialize_vm(&private_key, rng);
+    let (ledger, records) = initialize_vm(&private_key, rng);
+    let vm = ledger.vm();
 
     {
         // Prepare the inputs.
@@ -121,17 +240,18 @@ fn execute(c: &mut Criterion) {
         // Authorize the fee.
         let fee_authorization = vm.authorize_fee_public(&private_key, 300000, 1000, execution_id, rng).unwrap();
 
-        // c.bench_function("Transaction::Execute(transfer_public)", |b| {
-        //     b.iter(|| {
-        //         vm.execute_authorization(
-        //             execute_authorization.replicate(),
-        //             Some(fee_authorization.replicate()),
-        //             None,
-        //             rng,
-        //         )
-        //         .unwrap();
-        //     })
-        // });
+        #[cfg(feature = "bench-prove")]
+        prove_group(c).bench_function("Transaction::Execute(transfer_public)", |b| {
+            b.iter(|| {
+                vm.execute_authorization(
+                    execute_authorization.replicate(),
+                    Some(fee_authorization.replicate()),
+                    None,
+                    rng,
+                )
+                .unwrap();
+            })
+        });
 
         let transaction = vm
             .execute_authorization(execute_authorization.replicate(), Some(fee_authorization.replicate()), None, rng)
@@ -171,17 +291,18 @@ fn execute(c: &mut Criterion) {
         let fee_authorization = vm.authorize_fee_public(&private_key, 300000, 1000, execution_id, rng).unwrap();
 
         // Bench the execution of transfer_private.
-        // c.bench_function("Transaction::Execute(transfer_private)", |b| {
-        //     b.iter(|| {
-        //         vm.execute_authorization(
-        //             execute_authorization.replicate(),
-        //             Some(fee_authorization.replicate()),
-        //             None,
-        //             rng,
-        //         )
-        //         .unwrap();
-        //     })
-        // });
+        #[cfg(feature = "bench-prove")]
+        prove_group(c).bench_function("Transaction::Execute(transfer_private)", |b| {
+            b.iter(|| {
+                vm.execute_authorization(
+                    execute_authorization.replicate(),
+                    Some(fee_authorization.replicate()),
+                    None,
+                    rng,
+                )
+                .unwrap();
+            })
+        });
 
         let transaction = vm
             .execute_authorization(execute_authorization.replicate(), Some(fee_authorization.replicate()), None, rng)

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -33,6 +33,7 @@ locktick = [
 ]
 async = [ "snarkvm-ledger-query/async", "snarkvm-synthesizer-process/async" ]
 cuda = [ "snarkvm-algorithms/cuda" ]
+profiler = [ "snarkvm-algorithms/profiler" ]
 history = [ "snarkvm-ledger-store/history", "snarkvm-synthesizer-process/history" ]
 history-staking-rewards = [ "snarkvm-ledger-store/history-staking-rewards" ]
 slipstream-plugins = [ "snarkvm-ledger-store/slipstream-plugins" ]


### PR DESCRIPTION
## Motivation

An agent noticed that we don't use Ruffini's rule for division when doing CPU proving and use a naive algorithm instead.

This kicked off a swarm of agents looking for similar algorithmic improvements to improve the speed of CPU proving, and they found 12 improvements. I reviewed each of these changes and they seem simple and correct to me, and the measurement process we converged on seems very sound to me.

### Speed up CPU proving: −8% on a private transfer

Twelve changes to the prover, each of which deletes arithmetic or allocation
without changing a single field element that comes out. Measured end to end on
`credits.aleo/transfer_private`:

| threads | before | after | change |
|---:|---:|---:|---:|
| **16** | 5.863 s | 5.390 s | **−8.06%** (−474 ms) |
| **4** | 12.545 s | 12.055 s | **−3.91%** (−490 ms) |

The first commit adds the benchmark these numbers come from, so the claim is
reproducible from this branch:

```
cargo bench -p snarkvm-ledger --bench transaction --features bench-prove \
    -- 'Execute\(transfer_private\)'
```

### Why

Proving is dominated by multi-scalar multiplication, which is already well
optimized, so there is no single large win available here. The work *around* the
MSM is a different matter: several routines on the proving path do more
arithmetic, or more allocation, than the operation they implement requires.
Individually most are small. Together they are the numbers above.

Two things this helps:

1. **Anyone proving locally.** Proof latency is the whole experience for a user
   generating their own transactions.
2. **This repository's own tests and CI.** Proving dominates the synthesizer and
   ledger suites, so anything that shortens a proof shortens all of them.

The saving is *larger* on more cores — −8.1% at 16 threads against −3.9% at 4 —
and the absolute saving is nearly identical at both (474 ms and 490 ms). That is
the signature of deleted work rather than improved parallelism: most of these
changes remove **serial** work, so by Amdahl's law they matter more as core count
rises, and the benefit grows on larger machines instead of shrinking.

### The changes

Each is a single commit, and each stands on an argument you can check by reading
it, independent of the measurement.

| # | commit | what it deletes |
|---|---|---|
| 1 | add the proving benchmark | *(no behaviour change)* |
| 2 | divide by the vanishing polynomial in closed form | `p = q(Xⁿ−1)+r` matched coefficient-wise is `n` independent carry chains; for `deg p < 2n` — every call the prover makes — the quotient is literally `p[n..]`. Generic long division rediscovers this one coefficient at a time |
| 3 | Ruffini's rule for `X − z` | one multiply-add per coefficient instead of two multiplications, a clone of the dividend, and a degree re-check every iteration. The remainder falls out as `self(z)` |
| 4 | Horner's rule for `evaluate` | `deg` multiplications instead of `2·deg`, and no vector of powers the size of the polynomial |
| 5 | scale the rowcheck in place | `lhs += &(&rowcheck * c)` onto a zero polynomial is three passes and two allocations; the accumulation it is named for only ever has one term |
| 6 | fuse `add_assign`'s zero branch | copy-then-scale walks the coefficients twice to produce what one walk produces |
| 7 | `has_lc_eval` | the "is this polynomial present?" probe was answered by evaluating it and discarding the value, twice per matrix |
| 8 | hoist the Lagrange coefficients | they depend only on the constraint domain and `alpha`, both fixed across the `a`/`b`/`c` jobs, and were built three times per circuit |
| 9 | borrow the FFT precomputations | root-of-unity tables are circuit data, fixed for the life of the process, and were deep-copied per circuit per proof |
| 10 | selector `xg · (v_H / v_H_i)` as a repeat | the quotient of the two vanishing polynomials is `1 + Xᵐ + X²ᵐ + …`, so the product is `xg` repeated. It was a multiply and a divide over the larger domain to compute a memcpy |
| 11 | block the Lagrange setup loop | one dependency chain the length of the domain, where each block can seed itself with `gˢᵗᵃʳᵗ` |
| 12 | collapse the opening's two accumulation levels | both levels are linear, so `Σⱼ dⱼ(Σᵢ cⱼᵢPᵢ) = Σᵢ(Σⱼ dⱼcⱼᵢ)Pᵢ` — one pass per term instead of two |

Two of these change behaviour in ways worth calling out rather than burying:

- **Horner (4) widens `evaluate`.** It never calls `degree()`, so it evaluates a
  polynomial carrying trailing zero coefficients where the powers form hit
  `degree()`'s `assert!` and panicked. `coeffs` is a public field and callers do
  construct such polynomials, so the tolerance is wanted — but it is a widening,
  and a test pins it.
- **The opening collapse (12) is only sound because the sponge is squeezed and
  never absorbed** between `open_combinations` and the KZG open, so every
  challenge is fixed before any polynomial arithmetic. Squeeze order is preserved
  exactly: groups in query-set order, combinations in label order within a group,
  and the trailing squeeze per group.

### Correctness

Every change computes the same field elements by a cheaper route, so no proof
changes and there is no consensus impact.

Each commit brings tests that compare the new path against the one it replaces —
over random inputs and over the boundary cases: empty, constant, degree zero,
exact multiples, coefficient vectors carrying trailing zeros, and domains from 2
to 256. The Varuna suite (25 prove-and-verify tests), the polycommit suite (19)
and the FFT suite all pass at every commit, as does
`cargo clippy --workspace --all-targets --all-features -- -D warnings`.

For the opening change in particular, prove-and-verify is the load-bearing test:
a reordered Fiat–Shamir squeeze does not produce a slower proof, it produces one
that fails verification.

### How it was measured

**The benchmark proves at the consensus version mainnet actually runs, and
asserts that it does.** This turned out to matter more than expected.
`execute_authorization` derives the Varuna version from the current block height,
and a benchmark on a freshly created chain sits at height 1 — `ConsensusVersion::V1`,
so **Varuna V1**, a prover the network stopped using at height 6,135,000, and one
that never calls `prover_prepare_third_round` at all. The benchmark therefore
advances to `ConsensusVersion::V19` and asserts it got there.

Reaching that version also means the genesis records cannot be spent: they are
Version 0, and from `ConsensusVersion::V8` onward the credits circuit expects
Version 1. Spending one anyway produces an assignment that does not satisfy the
constraints, which surfaces a long way from its cause — as a non-zero remainder
when Varuna divides by the vanishing polynomial. The benchmark mints a spendable
record with `transfer_public_to_private` instead.

**Hardware.** Intel Xeon w9-3475X (Sapphire Rapids-WS), 36 cores / 72 threads,
82.5 MiB L3, 125 GiB RAM, Ubuntu 24.04.4 (kernel 6.17), rustc 1.88.0, governor
`powersave` with turbo enabled. Built with the repository's own
`.cargo/config.toml`, which sets `-C target-cpu=native`.

**Protocol.** Criterion's `--save-baseline`/`--baseline` runs one arm to
completion and then the other, which on an interactive machine is exposed to
drift — run medians moved by up to 4% across a single session here. Instead both
arms' benchmark binaries were built once, checksummed to confirm they differ, and
then alternated block by block with the arm order flipping each block. Each block
is one `sample_size(10)` run per arm; the table reports ten blocks.

**A null was run at each thread count** — the same binary against itself — so the
noise floor is measured under the same conditions as the treatment rather than
assumed:

| run | mean | median | SD | *t* | blocks favouring |
|---|---:|---:|---:|---:|---:|
| null, 16 threads | −0.022% | +0.178% | 1.04% | −0.07 | 5/10 |
| **change, 16 threads** | **−8.064%** | **−8.042%** | 1.01% | **−25.3** | **10/10** |
| null, 4 threads | −0.171% | −0.745% | 3.10% | −0.17 | 6/10 |
| **change, 4 threads** | **−3.910%** | **−3.994%** | 0.90% | **−13.8** | **10/10** |

Both nulls land on zero, with blocks splitting 5/10 and 6/10 — what no effect
looks like. Both treatments are unanimous across ten blocks.

The 4-thread null is noticeably noisier than the treatment it calibrates
(SD 3.10% against 0.90%), which suggests it caught a disturbed period on the
machine. It is reported as measured rather than re-run, because the conclusion
does not depend on it: −3.91% at *t* = −13.8 sits more than a standard deviation
of the null's own spread away from zero, with every block agreeing.

**The benchmark is off by default.** It sits behind a `bench-prove` feature
because proving takes seconds: enabled, it would add tens of minutes to the
`benchmarks.yml` job, needs the universal SRS, and is variable enough to risk the
benchmark action's alert threshold — the same three reasons that workflow already
gives for skipping the `varuna` and `store`/`advance` benchmarks.

Two small instrumentation fixes ride along in the first commit, because without
them the profile cannot be read: `prover_prepare_third_round` was emitting
`AHP::Prover::ThirdRound`, the same label `prover_third_round` uses, so two
distinct phases were indistinguishable in the tree; and `open_combinations` had
no timer, so its cost landed in its caller's self time. The `profiler` feature is
also now forwarded from `snarkvm-algorithms` through `snarkvm-synthesizer` and
`snarkvm-ledger`, so the instrumentation that already exists can be reached from
a benchmark that drives the whole stack.

### On splitting this up

These are presented together because the headline number is a property of the set
and each commit on its own moves less than a single benchmark run can resolve.
Every commit is self-contained and independently revertible, so if you would
rather review them as separate pull requests — or want per-change measurements
for any that look suspect — say which and I will split it accordingly.

## Test Plan

Extensive unit test coverage with each individual change, in the commit that introduced the change.
Benchmarks show that we get a measurable win overall.

## Documentation

N/A

## Backwards compatibility

Backwards compatible, no consensus guard needed.