### PR TITLE
fix(curve): reject non canonical infinity encoding

### DIFF
--- a/curves/src/templates/macros.rs
+++ b/curves/src/templates/macros.rs
@@ -126,6 +126,11 @@ macro_rules! impl_sw_curve_serializer {
                 let point = if let Compress::Yes = compress {
                     let (x, flags) = P::BaseField::deserialize_with_flags::<_, SWFlags>(&mut reader)?;
                     if flags.is_infinity() {
+                        // The x-coordinate must be zero when the infinity flag is
+                        // set, or the encoding is non-canonical.
+                        if !x.is_zero() {
+                            return Err(snarkvm_utilities::serialize::SerializationError::InvalidData);
+                        }
                         Self::zero()
                     } else {
                         Affine::<P>::from_x_coordinate(x, flags.is_positive().unwrap())

--- a/curves/src/templates/short_weierstrass_jacobian/tests.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/tests.rs
@@ -17,7 +17,7 @@ use std::io::Cursor;
 
 use super::{Affine, Projective};
 use crate::{AffineCurve, ProjectiveCurve, ShortWeierstrassParameters};
-use snarkvm_fields::Zero;
+use snarkvm_fields::{One, Zero};
 use snarkvm_utilities::{
     Compress,
     TestRng,
@@ -48,6 +48,26 @@ pub fn sw_tests<P: ShortWeierstrassParameters>(rng: &mut TestRng) {
 /// decoders, and the same predicate `Affine::from_random_bytes` already applies
 /// a few lines away: `if x.is_zero() && flags.is_infinity()`.
 pub fn sw_non_canonical_infinity_is_rejected<P: ShortWeierstrassParameters>() {
+    // First, the other direction: the serializer must never *emit* a
+    // non-canonical infinity, or the rejection below would refuse our own
+    // output. This is reachable rather than hypothetical -- the uncompressed
+    // deserializer builds `Affine::new(x, y, flags.is_infinity())`, keeping
+    // whatever coordinates were sent, so a point can carry the infinity flag
+    // alongside a non-zero x.
+    {
+        let dirty = Affine::<P>::new(P::BaseField::one(), P::BaseField::one(), true);
+        let mut written = Vec::new();
+        dirty.serialize_with_mode(&mut written, Compress::Yes).unwrap();
+
+        let mut canonical = Vec::new();
+        Affine::<P>::zero().serialize_with_mode(&mut canonical, Compress::Yes).unwrap();
+
+        assert_eq!(
+            written, canonical,
+            "compressing an infinity point with dirty coordinates must still emit the canonical form"
+        );
+    }
+
     for validate in [Validate::Yes, Validate::No] {
         // Validate does not implement Debug, and the mode matters to the report:
         // this must be rejected on the structure of the encoding, not by the

--- a/curves/src/templates/short_weierstrass_jacobian/tests.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/tests.rs
@@ -32,6 +32,66 @@ pub fn sw_tests<P: ShortWeierstrassParameters>(rng: &mut TestRng) {
     sw_curve_serialization_test::<P>(rng);
     sw_from_random_bytes::<P>(rng);
     sw_from_x_coordinate::<P>(rng);
+    sw_non_canonical_infinity_is_rejected::<P>();
+}
+
+/// The point at infinity must have exactly one compressed encoding.
+///
+/// When the infinity flag is set, the x-coordinate carries no information and
+/// must be zero. A deserializer that ignores it instead of rejecting it admits
+/// roughly 2^(8*(N-1)) encodings of the identity, all of which re-serialize to
+/// the single canonical form -- so an object containing one has many byte
+/// representations, and anything that hashes those bytes disagrees with anything
+/// that hashes a re-serialization.
+///
+/// This is the same requirement the BLS12-381 serialization spec places on
+/// decoders, and the same predicate `Affine::from_random_bytes` already applies
+/// a few lines away: `if x.is_zero() && flags.is_infinity()`.
+pub fn sw_non_canonical_infinity_is_rejected<P: ShortWeierstrassParameters>() {
+    for validate in [Validate::Yes, Validate::No] {
+        // Validate does not implement Debug, and the mode matters to the report:
+        // this must be rejected on the structure of the encoding, not by the
+        // subgroup check, so it has to fail under Validate::No as well.
+        let mode = match validate {
+            Validate::Yes => "Validate::Yes",
+            Validate::No => "Validate::No",
+        };
+        // The canonical encoding of infinity: zero x, with the flag set.
+        let mut canonical = Vec::new();
+        Affine::<P>::zero().serialize_with_mode(&mut canonical, Compress::Yes).unwrap();
+
+        // It must keep working. A fix for the case below that also rejects this
+        // one would break every proof in existence.
+        let mut cursor = Cursor::new(&canonical[..]);
+        let point = Affine::<P>::deserialize_with_mode(&mut cursor, Compress::Yes, validate).unwrap();
+        assert!(point.is_zero(), "the canonical infinity encoding must still deserialize");
+
+        // The same encoding with a non-zero x-coordinate. The flag lives in the
+        // high bits of the last byte, so touching the first byte changes x and
+        // leaves the flag set.
+        let mut non_canonical = canonical.clone();
+        non_canonical[0] = 1;
+        assert_ne!(non_canonical, canonical);
+
+        let mut cursor = Cursor::new(&non_canonical[..]);
+        let result = Affine::<P>::deserialize_with_mode(&mut cursor, Compress::Yes, validate);
+
+        // Before the fix this succeeds and yields the identity, which is the
+        // bug: two byte strings, one value. The assertion below is written
+        // against the desired behaviour, so it fails on an unfixed tree.
+        if let Ok(point) = result {
+            let mut round_tripped = Vec::new();
+            point.serialize_with_mode(&mut round_tripped, Compress::Yes).unwrap();
+            panic!(
+                "a non-canonical infinity encoding was accepted ({mode}).\n\
+                 It deserialized to infinity = {}, and re-serialized to the canonical form, so\n\
+                 {:?}... and {:?}... are two encodings of one value.",
+                point.is_zero(),
+                &non_canonical[..4],
+                &round_tripped[..4],
+            );
+        }
+    }
 }
 
 pub fn sw_curve_serialization_test<P: ShortWeierstrassParameters>(rng: &mut TestRng) {


### PR DESCRIPTION
## Motivation

A compressed Short Weierstrass point sets a flag bit to mark the point at
infinity. When that flag is set the x-coordinate carries no information and must
be zero — but `deserialize_with_mode` ignores it entirely:

https://github.com/ProvableHQ/snarkVM/blob/55c15e2d35ea5d6fbcb8c79d26bb3ed111172a87/curves/src/templates/macros.rs#L127-L133

This means that there are many non-canonical representations of the identity point, which are accepted by the deserializer. The BLS12-381serialization spec requires of decoders, for exactly this reason: an infinity
encoding whose remaining bits are not zero must be rejected.

The same predicate is already applied correctly thirty lines away, in
`Affine::from_random_bytes`:

https://github.com/ProvableHQ/snarkVM/blob/55c15e2d35ea5d6fbcb8c79d26bb3ed111172a87/curves/src/templates/short_weierstrass_jacobian/affine.rs#L117-L120

```rust
// If x is valid and is zero and only the infinity flag is set, then parse this
// point as infinity. For all other choices, get the original point.
if x.is_zero() && flags.is_infinity() {
```

This change brings the deserializer into line with it.

## What this is not

It is **not** a soundness break. The mapping is many-to-one *onto the identity*:
every non-canonical encoding decodes to the same point, so a verifier sees
identical values whichever encoding arrived. It does not let anyone change what
a proof asserts, make an invalid proof verify, or produce a point of their
choosing. It is byte-level malleability and nothing more.

## Test Plan

In the generic `sw_tests<P>` harness, so it covers every Short Weierstrass curve
rather than BLS12-377 G1 alone. It asserts the desired behaviour, so it fails
without the fix:

```
test bls12_377::tests::test_g1_projective_curve ... FAILED
a non-canonical infinity encoding was accepted (Validate::Yes).
[1, 0, 0, 0]... and [0, 0, 0, 0]... are two encodings of one value.
```

- It checks the **canonical** infinity encoding still deserializes *first*. A fix
  that rejected both would break every proof in existence, and that should fail
  loudly rather than pass quietly.
- It runs under `Validate::No` as well as `Validate::Yes`, because the rejection
  must come from the structure of the encoding rather than the subgroup check.
- It mutates byte 0, not the last byte — the flag lives in the high bits of the
  final byte, so touching byte 0 changes x and leaves the flag set.

## Backwards compatibility

This is backwards compatible in that the serializer only emits canonical points, so the
blockchain itself should only consist of canonical encodings. The transactions that
we have consensed on would contain only canonical encodings, since they go through
at least one serialization deserialization round trip when they are gossipped to other nodes.
So this will not break our ability to parse historical blocks and transactions.