### PR TITLE
chore: finish the 1.96 MSRV bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,24 +18,12 @@ parameters:
     default: 2xlarge
   # The toolchain `check-fmt` formats with.
   #
-  # `.rustfmt.toml` uses options that only exist on nightly -- imports_layout,
-  # imports_granularity, overflow_delimited_expr, reorder_impl_items and
-  # style_edition -- so the formatter cannot be the 1.88.0 this project builds
-  # with, and `cargo fmt` without a toolchain silently drops all five rather
-  # than refusing. The formatter is therefore a second toolchain, and pinning
-  # it is the same act as pinning the first.
+  # `.rustfmt.toml` uses nightly-only options, so the formatter is a second
+  # toolchain, pinned separately. Bumping it may reformat the tree.
   #
-  # Resolves to rustfmt 1.9.0-nightly (7e46c5f6fb 2026-04-01); rustup's dated
-  # nightlies are built from the previous day's commit. Bumping it may reformat
-  # the tree, so it should be a deliberate change with the reformatting in the
-  # same commit.
-  #
-  # `enum` rather than `string`: this value is interpolated unquoted into the
-  # `rustup toolchain install` and `cargo fmt` commands below, so a `string`
-  # parameter would let anyone able to trigger a pipeline with custom
-  # parameters inject arbitrary shell commands into the job. `enum` rejects
-  # any pipeline-trigger value that isn't in the list below before the config
-  # is compiled, closing that off. Add the new pin to the list when bumping.
+  # `enum` rather than `string`: the value is interpolated unquoted into the
+  # commands below, where a `string` would admit shell injection from a
+  # pipeline trigger.
   fmt_nightly:
     type: enum
     enum: [nightly-2026-04-02]

--- a/synthesizer/error/Cargo.toml
+++ b/synthesizer/error/Cargo.toml
@@ -22,7 +22,7 @@ categories = [
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.88.0" # Attention - Change the MSRV in rust-toolchain and in .circleci/config.yml as well
+rust-version = "1.96.0" # Attention - Change the MSRV in rust-toolchain and in .circleci/config.yml as well
 
 [dependencies.snarkvm-circuit-environment]
 workspace = true


### PR DESCRIPTION
Two leftovers from the 1.96 MSRV bump, both in files the bump was already touching.

### `synthesizer/error/Cargo.toml`

It still declares `rust-version = "1.88.0"` while `rust-toolchain.toml` pins 1.96 and the root manifest says `1.96.0`. Those two are the whole set — `git grep rust-version -- '*Cargo.toml'` returns exactly the root and this crate — so nothing else was missed.

Nothing built against the stale value, since the toolchain pin decides what actually compiles. But the manifest field is what downstream consumers and `cargo`'s MSRV-aware resolver read, so `snarkvm-synthesizer-error` was published advertising support for a compiler this workspace no longer builds on.

### `.circleci/config.yml`

The comment above `fmt_nightly` also named 1.88.0, inside twenty-four lines that restated the pin, the exact rustfmt build it resolves to, and the five nightly-only options by name. All of that lives elsewhere and goes stale on its own schedule — the 1.88.0 is what happened to get caught this time.

Shortened to three sentences: what the parameter is, why the formatter is pinned apart from the toolchain the project builds with, and why the type is `enum`. The last one stays because switching it back to `string` looks harmless and would reopen shell injection from pipeline-trigger parameters.

### Checks

`cargo clippy --workspace --all-targets --all-features -- -D warnings` and the pinned-nightly `cargo fmt --all -- --check` both pass. No Rust source is touched.