### PR TITLE
build: disable incremental compilation for the release and bench profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -661,14 +661,14 @@ version = "2"
 [profile.release]
 opt-level = 3
 lto = "thin"
-incremental = true
+incremental = false
 
 [profile.bench]
 opt-level = 3
 debug = false
 rpath = false
 lto = "thin"
-incremental = true
+incremental = false
 debug-assertions = false
 
 [profile.dev]


### PR DESCRIPTION
Sets `incremental = false` for `[profile.release]` and `[profile.bench]`. No source changes.

Refs #3229.

## Motivation

Cargo's default for the release profile is `incremental = false`, and the rustc book states that incremental compilation "inhibits certain optimizations (for example by increasing the amount of codegen units) and is therefore not recommended for release builds". (https://doc.rust-lang.org/rustc/codegen-options/index.html#incremental)

 `-C incremental` raises the default codegen-units from 16 to 256 per crate, so each crate is split into many more, much smaller LLVM modules, and `lto = "thin"` is then left to recover the lost inlining across them at link time. That is both a weaker optimization pipeline and a far less exercised one: it is the configuration implicated in #3229, where thin LTO miscompiles `evaluate_all_lagrange_coefficients` on aarch64-unknown-linux-gnu. (https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units)

The rebuild-time cost is small, since incremental caching only covers the pre-LTO codegen phase while the thin LTO link is redone in full on every build, and is the majority of the build time in such a build.

## History

This combination (lto=thin, incremantal=true) first appeared in 2020 very early without explanation: 79ff75d67
It was later mirrored onto the dev profile. 37625d014

This all sat untouched for 6 years until we fixed the test profile to not use lto: 9a8301341