### PR TITLE
build: document that the `noconfig` feature is a no-op

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,10 @@
-[target.'cfg(all(not(target_arch = "wasm32"), not(feature = "noconfig")))']
+# Note: override by setting RUSTFLAGS
+[target.'cfg(not(target_arch = "wasm32"))']
 rustflags = ["-C", "target-cpu=native"]
 
 [target.x86_64-unknown-linux-gnu]
 rustflags = [
     # LLD is generally faster and might be the default for Rust in the future.
     # See here: https://github.com/rust-lang/rust/issues/71515
-    "-C", "link-arg=-fuse-ld=lld",
-    "-C", "target-cpu=native"
+    "-C", "link-arg=-fuse-ld=lld"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ locktick = [
   "snarkvm-parameters?/locktick",
   "snarkvm-synthesizer?/locktick"
 ]
+# No-op: Cargo features are not evaluated in `[target.<cfg>]` selectors.
 noconfig = [ ]
 prop-tests = [ "snarkvm-ledger?/prop-tests" ]
 rocks = [ "snarkvm-ledger/rocks", "snarkvm-synthesizer/rocks" ]


### PR DESCRIPTION
Config and comments only. No source changes, and no change to the flags any build actually receives (verified below).

## The problem

`.cargo/config.toml` gated `-C target-cpu=native` behind a Cargo feature:

```toml
[target.'cfg(all(not(target_arch = "wasm32"), not(feature = "noconfig")))']
rustflags = ["-C", "target-cpu=native"]
```

`Cargo.toml` declares `noconfig = [ ]`, referenced nowhere else, so the intent reads clearly: build with `--features noconfig` to suppress `target-cpu=native`. That has never worked. From the [cargo config reference](https://doc.rust-lang.org/cargo/reference/config.html#targetcfgrustflags):

> `cfg` values come from those built-in to the compiler (run `rustc --print=cfg` to view) and extra `--cfg` flags passed to `rustc` (such as those defined in `RUSTFLAGS`). Do not try to match on `debug_assertions`, `test`, **Cargo features like `feature="foo"`**, or values set by build scripts.

The predicate is not evaluated the way it reads, so the section always matched and the flag was always applied.

There was a second, smaller bug in the same file: `[target.x86_64-unknown-linux-gnu]` set `target-cpu=native` again. Since "if several `<cfg>` and `<triple>` entries match the current target, the flags are joined together", that target was passing the flag twice. Confirmed on the pinned 1.96 toolchain, where a host build emitted:

```
-C link-arg=-fuse-ld=lld -C target-cpu=native -C target-cpu=native
```

## The change

- Drop the inert `not(feature = "noconfig")` predicate from the `cfg` selector.
- Keep the `noconfig` feature, documented in `Cargo.toml` as a no-op. Removing it would break anyone already passing `--features noconfig`, and an empty feature costs nothing.
- Drop the duplicated `target-cpu=native` from the `x86_64-unknown-linux-gnu` section; the `cfg` section already covers that target.
- Record in the config the one thing that does override these flags — `RUSTFLAGS`, which per the docs *replaces* the config's flags rather than merging with them. That is a sharp edge: setting `RUSTFLAGS` to drop `target-cpu=native` also silently drops `-fuse-ld=lld`. `.github/workflows/benchmarks.yml` already hits this and works around it by hand, so the comment now points the next person at it directly.

## Verification

`cargo build -v` before and after, on 1.96:

| Build | Before | After |
|---|---|---|
| host (`x86_64-unknown-linux-gnu`) | `-C link-arg=-fuse-ld=lld`, `-C target-cpu=native` ×2 | `-C link-arg=-fuse-ld=lld`, `-C target-cpu=native` ×1 |
| `wasm32-unknown-unknown` | no `target-cpu` | no `target-cpu` |

So the effective compiler invocation is unchanged apart from the removed duplicate, on both a host and a wasm target. No consensus or serialization impact.

## Note

This documents the status quo rather than changing it: `target-cpu=native` remains on by default for all non-wasm builds, so binaries built from this repo are still tuned to the machine that built them and are not portable across CPUs. Whether that default belongs in a checked-in config for a consensus-critical library is a separate discussion, and deliberately not part of this PR. Related: #3402, and #3229, where host-dependent codegen is part of why the reported miscompile needed such a specific machine to reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5mtJ1Qr73t8KRHZP8RBkA