### PR TITLE
Migrate legacy history entries on raw bytes

### DIFF
--- a/ledger/store/src/helpers/rocksdb/internal/history_migration.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/history_migration.rs
@@ -1,0 +1,342 @@
+// Copyright 2024-2025 Aleo Network Foundation
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A one-time migration of historical mapping updates from little-endian to big-endian
+//! height keys.
+//!
+//! # Why this is done on raw bytes
+//!
+//! A `MappingUpdateMap` key is `(ProgramID, Identifier, Plaintext, HeightBytes)`, serialized by
+//! `bincode` behind a 4-byte context of `[network_id, map_id]`. `HeightBytes` is a `[u8; 4]`,
+//! which `bincode` writes as four raw bytes with no length prefix, and it is the *last* field of
+//! the tuple. **The height is therefore the final four bytes of the raw key, and the migration is
+//! a suffix byte-reversal that leaves the value bytes completely untouched.**
+//!
+//! Going through the typed `Map` API instead would deserialize a `Plaintext` and a `Value<N>` per
+//! entry and immediately re-serialize both to the identical bytes. That round-trip costs ~4 KiB of
+//! peak RSS per entry, which is unaffordable here: on mainnet the `credits.aleo` `bonded`,
+//! `delegated` and `committee` mappings are rewritten in full by `replace_mapping` on *every*
+//! block, so each of their ~507 keys accrues one history entry per block. A node with a few months
+//! of history has billions of entries concentrated in a few hundred keys.
+//!
+//! # Shape of the work
+//!
+//! Two very different populations share the heights map, and this migration has to be efficient
+//! for both:
+//!
+//! - a few hundred staking keys carrying *millions* of heights each, which dominate the entry
+//!   count, and
+//! - potentially millions of ordinary keys carrying a handful of heights each, which dominate the
+//!   key count.
+//!
+//! So the scan advances a cursor forward (never re-seeking from the head of the map, which would
+//! make each pass skip every tombstone left by the last one), and a single key's history is
+//! streamed in bounded chunks rather than materialized.
+//!
+//! # Endianness collisions
+//!
+//! Both encodings occupy the same keyspace and are the same width, so a destination key can be
+//! byte-identical to a source key that has not been consumed yet: `BE(h')` equals `LE(h)` exactly
+//! when `h' == byte_reverse(h)`. Heights whose partner is also present are therefore separated out
+//! and migrated together in one final batch, where reading everything before writing anything makes
+//! the ordering safe. Every other height provably collides with nothing in the set, so it can be
+//! streamed freely. Palindromic heights (`LE(h) == BE(h)`, e.g. 65_792) are their own partner and
+//! fall into the same batch.
+//!
+//! # Resumption
+//!
+//! A key's heights row is deleted only once all of its entries have moved, so an interrupted
+//! migration simply redoes the key it was working on. An entry whose source is already gone is
+//! recognised as already-migrated by confirming its destination exists; if *neither* exists the
+//! migration fails loudly rather than silently dropping history.
+
+use super::{DataMap, PREFIX_LEN, RocksDB};
+
+use anyhow::{Result, bail, ensure};
+use serde::{Serialize, de::DeserializeOwned};
+use std::time::{Duration, Instant};
+
+/// The number of historical entries moved per write batch.
+///
+/// This bounds memory: a single key's history can run to billions of entries, so it is never read
+/// in one piece. Entries are small (a raw key plus untouched value bytes), so this is a modest
+/// allocation chosen to keep batches large enough to amortize the write path.
+const CHUNK_SIZE: usize = 50_000;
+
+/// How often to report progress while migrating.
+///
+/// This runs before the node serves anything and can take hours on an archive node, so silence
+/// here is indistinguishable from a hang.
+const REPORT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// What a migration run did, for logging and tests.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MigrationStats {
+    /// The number of legacy mapping keys migrated.
+    pub keys: u64,
+    /// The number of historical entries rewritten from little-endian to big-endian.
+    pub entries: u64,
+    /// The number of entries found already migrated, i.e. work redone after an interruption.
+    pub resumed: u64,
+    /// The number of entries that had to be batched together to avoid an encoding collision.
+    pub collisions: u64,
+}
+
+/// Returns the height whose big-endian encoding is byte-identical to `height`'s little-endian one.
+///
+/// This is an involution, so it maps a source key to the destination key that would overwrite it
+/// and vice versa.
+const fn byte_reverse(height: u32) -> u32 {
+    u32::from_be_bytes(height.to_le_bytes())
+}
+
+/// Returns the raw key for `height` under `prefix`, using the given 4-byte encoding.
+fn entry_key(prefix: &[u8], height_bytes: [u8; 4]) -> Vec<u8> {
+    let mut key = Vec::with_capacity(prefix.len() + 4);
+    key.extend_from_slice(prefix);
+    key.extend_from_slice(&height_bytes);
+    key
+}
+
+/// Migrates every legacy little-endian historical mapping update to a big-endian height key.
+///
+/// `heights_context` and `update_context` are the 4-byte `[network_id, map_id]` prefixes of the
+/// `MappingUpdateHeightsMap` and `MappingUpdateMap` respectively.
+///
+/// This is intended to run at startup, before the store serves any request, and writes directly to
+/// the database rather than through the atomic-batch machinery: there is no concurrent writer, and
+/// the batches here are far larger than that path is meant to carry.
+pub(crate) fn migrate_legacy_history(
+    database: &RocksDB,
+    heights_context: &[u8],
+    update_context: &[u8],
+) -> Result<MigrationStats> {
+    ensure!(heights_context.len() == PREFIX_LEN, "Malformed heights-map context");
+    ensure!(update_context.len() == PREFIX_LEN, "Malformed update-map context");
+
+    let mut stats = MigrationStats::default();
+    let started = Instant::now();
+    let mut last_report = started;
+    // Whether any work was found. A node with nothing to migrate should say nothing at all.
+    let mut announced = false;
+    // The raw key of the last heights row migrated, used to resume the forward scan. Re-seeking
+    // from the head of the map instead would make every pass walk the tombstones of all previous
+    // passes, which is quadratic in the number of keys.
+    let mut cursor: Option<Vec<u8>> = None;
+
+    while let Some((heights_key, heights_value)) = next_heights_row(database, heights_context, cursor.as_deref())? {
+        if !announced {
+            tracing::info!(
+                "Migrating legacy history entries to the big-endian height schema. \
+                 The node will not serve requests until this completes."
+            );
+            announced = true;
+        }
+
+        // The heights row and its historical entries share a key body; only the context differs.
+        let mut prefix = Vec::with_capacity(PREFIX_LEN + heights_key.len() - PREFIX_LEN);
+        prefix.extend_from_slice(update_context);
+        prefix.extend_from_slice(&heights_key[PREFIX_LEN..]);
+
+        // The only part of a legacy entry that is ever deserialized: the heights themselves.
+        let heights: Vec<u32> = bincode::deserialize(&heights_value)?;
+        // The legacy write path pushed heights in increasing block order, and the legacy read path
+        // binary-searches them, so they are sorted. Verify rather than assume: `binary_search`
+        // below is meaningless otherwise, and a wrong answer here would silently drop entries.
+        ensure!(heights.is_sorted(), "Legacy heights are not sorted; cannot migrate safely");
+
+        // Separate the heights whose destination would overwrite another height's source.
+        let (colliding, isolated): (Vec<u32>, Vec<u32>) =
+            heights.iter().partition(|height| heights.binary_search(&byte_reverse(**height)).is_ok());
+
+        // Isolated heights collide with nothing in this key, so they can stream in any order.
+        for chunk in isolated.chunks(CHUNK_SIZE) {
+            migrate_chunk(database, &prefix, chunk, &mut stats)?;
+        }
+        // Colliding heights must be read before any of them is written. There are few of them
+        // (a height only collides if its byte-reversal is also an update height for this key), so
+        // one batch is safe regardless of how deep the history is.
+        migrate_chunk(database, &prefix, &colliding, &mut stats)?;
+        stats.collisions += colliding.len() as u64;
+
+        // Only now is the key fully migrated, so only now may its heights row go. An interruption
+        // before this point simply repeats the key.
+        database.delete(&heights_key)?;
+
+        stats.keys += 1;
+        cursor = Some(heights_key);
+
+        if last_report.elapsed() >= REPORT_INTERVAL {
+            let elapsed = started.elapsed().as_secs_f64();
+            tracing::info!(
+                "History migration: {} keys, {} entries ({:.0} entries/s)",
+                stats.keys,
+                stats.entries,
+                stats.entries as f64 / elapsed
+            );
+            last_report = Instant::now();
+        }
+    }
+
+    if announced {
+        tracing::info!(
+            "History migration complete: {} keys, {} entries in {:.1?}",
+            stats.keys,
+            stats.entries,
+            started.elapsed()
+        );
+    }
+
+    Ok(stats)
+}
+
+/// Returns the first heights row strictly after `cursor`, or the first row of the map if `cursor`
+/// is `None`. Returns `None` once the map is exhausted.
+fn next_heights_row(
+    database: &RocksDB,
+    heights_context: &[u8],
+    cursor: Option<&[u8]>,
+) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+    let mut iterator = database.raw_iterator();
+    match cursor {
+        // Seek past the row just migrated. Its own tombstone is the only one skipped, because the
+        // scan never rewinds.
+        Some(cursor) => {
+            iterator.seek(cursor);
+            if iterator.valid() && iterator.key() == Some(cursor) {
+                iterator.next();
+            }
+        }
+        None => iterator.seek(heights_context),
+    }
+
+    if !iterator.valid() {
+        iterator.status()?;
+        return Ok(None);
+    }
+    let Some((key, value)) = iterator.item() else {
+        iterator.status()?;
+        return Ok(None);
+    };
+    // Stop at the first key outside this map: the database is one keyspace shared by every map,
+    // partitioned only by the context prefix.
+    if !key.starts_with(heights_context) {
+        return Ok(None);
+    }
+    Ok(Some((key.to_vec(), value.to_vec())))
+}
+
+/// Moves `heights` for one mapping key from little-endian to big-endian keys, in a single batch.
+///
+/// Every source is read before any write is queued, and every deletion is queued before any
+/// insertion, so that where a source and a destination are the same raw key the surviving value is
+/// the migrated one.
+fn migrate_chunk(database: &RocksDB, prefix: &[u8], heights: &[u32], stats: &mut MigrationStats) -> Result<()> {
+    if heights.is_empty() {
+        return Ok(());
+    }
+
+    let legacy_keys = heights.iter().map(|height| entry_key(prefix, height.to_le_bytes())).collect::<Vec<_>>();
+    let values = database.multi_get(&legacy_keys);
+
+    // Entries whose source is missing are either already migrated (an interrupted run being
+    // repeated) or genuinely absent, which would be history loss. Distinguish the two by looking
+    // for the destination, batched so that a resumed run costs one extra lookup per chunk.
+    let mut missing = Vec::new();
+    for (index, value) in values.iter().enumerate() {
+        if value.as_ref().map_err(|e| anyhow::anyhow!("{e}"))?.is_none() {
+            missing.push(index);
+        }
+    }
+    if !missing.is_empty() {
+        let destinations =
+            missing.iter().map(|&index| entry_key(prefix, heights[index].to_be_bytes())).collect::<Vec<_>>();
+        for (slot, present) in missing.iter().zip(database.multi_get(&destinations)) {
+            if present.map_err(|e| anyhow::anyhow!("{e}"))?.is_none() {
+                bail!("Missing legacy mapping update at height {}, and it has no migrated entry", heights[*slot]);
+            }
+        }
+        stats.resumed += missing.len() as u64;
+    }
+
+    let mut batch = rocksdb::WriteBatch::default();
+    for key in &legacy_keys {
+        batch.delete(key);
+    }
+    for (index, value) in values.into_iter().enumerate() {
+        // Already accounted for above; the destination is in place.
+        let Some(value) = value.map_err(|e| anyhow::anyhow!("{e}"))? else { continue };
+        batch.put(entry_key(prefix, heights[index].to_be_bytes()), value);
+        stats.entries += 1;
+    }
+    database.write(batch)?;
+
+    Ok(())
+}
+
+/// Migrates the finalize store's legacy history, given its two maps.
+///
+/// A thin typed shim over [`migrate_legacy_history`]: it exists only to read the two maps' raw
+/// context prefixes and their shared database handle, which the migration works in terms of.
+pub(crate) fn migrate_finalize_history<KH, VH, KU, VU>(
+    heights_map: &DataMap<KH, VH>,
+    update_map: &DataMap<KU, VU>,
+) -> Result<MigrationStats>
+where
+    KH: Serialize + DeserializeOwned,
+    VH: Serialize + DeserializeOwned,
+    KU: Serialize + DeserializeOwned,
+    VU: Serialize + DeserializeOwned,
+{
+    migrate_legacy_history(&heights_map.database, &heights_map.context, &update_map.context)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_byte_reverse_is_an_involution() {
+        for height in [0u32, 1, 255, 256, 65_536, 65_792, 1_000_000, 21_639_560, u32::MAX] {
+            assert_eq!(byte_reverse(byte_reverse(height)), height);
+        }
+    }
+
+    #[test]
+    fn test_byte_reverse_identifies_colliding_encodings() {
+        // A height whose two encodings are identical is its own partner.
+        assert_eq!(65_792u32.to_le_bytes(), 65_792u32.to_be_bytes());
+        assert_eq!(byte_reverse(65_792), 65_792);
+
+        // Heights whose encodings swap with each other are partners.
+        assert_eq!(256u32.to_le_bytes(), 65_536u32.to_be_bytes());
+        assert_eq!(byte_reverse(256), 65_536);
+        assert_eq!(byte_reverse(65_536), 256);
+    }
+
+    #[test]
+    fn test_byte_reverse_matches_raw_encodings_exhaustively() {
+        // The partner relation is the whole basis for which heights are safe to stream, so check
+        // it against the encodings themselves rather than against hand-picked examples.
+        let mut rng_state = 0x2545_F491_4F6C_DD1Du64;
+        for _ in 0..100_000 {
+            rng_state ^= rng_state << 13;
+            rng_state ^= rng_state >> 7;
+            rng_state ^= rng_state << 17;
+            let height = rng_state as u32;
+            assert_eq!(height.to_le_bytes(), byte_reverse(height).to_be_bytes());
+        }
+    }
+}

--- a/ledger/store/src/helpers/rocksdb/internal/history_migration.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/history_migration.rs
@@ -66,7 +66,10 @@ use super::{DataMap, PREFIX_LEN, RocksDB};
 
 use anyhow::{Result, bail, ensure};
 use serde::{Serialize, de::DeserializeOwned};
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashSet,
+    time::{Duration, Instant},
+};
 
 /// The number of historical entries moved per write batch.
 ///
@@ -161,19 +164,36 @@ pub(crate) fn migrate_legacy_history(
         let (colliding, isolated): (Vec<u32>, Vec<u32>) =
             heights.iter().partition(|height| heights.binary_search(&byte_reverse(**height)).is_ok());
 
-        // Isolated heights collide with nothing in this key, so they can stream in any order.
+        // Isolated heights collide with nothing in this key, so they can stream in any order and
+        // in independent batches: a repeated one is recognised by its destination already existing.
         for chunk in isolated.chunks(CHUNK_SIZE) {
-            migrate_chunk(database, &prefix, chunk, &mut stats)?;
+            migrate_isolated_chunk(database, &prefix, chunk, &mut stats)?;
         }
-        // Colliding heights must be read before any of them is written. There are few of them
-        // (a height only collides if its byte-reversal is also an update height for this key), so
-        // one batch is safe regardless of how deep the history is.
-        migrate_chunk(database, &prefix, &colliding, &mut stats)?;
+
+        // Colliding heights cannot use that recovery, because a migrated entry is byte-identical
+        // to its partner's un-migrated source: re-reading one after a crash would yield the
+        // partner's value and transpose the pair. So each batch instead *shrinks the heights row*
+        // to the heights it has not yet moved, in the same write. A resumed run then never sees a
+        // height that has already been migrated, and the aliasing is unobservable.
+        //
+        // Partners are kept together in a batch so the surviving set always holds whole pairs,
+        // which keeps the isolated/colliding split stable across a resume.
+        let groups = partner_groups(&colliding);
+        let mut remaining = colliding.clone();
+        let mut migrated_row = false;
+        for group_chunk in chunk_groups(&groups, CHUNK_SIZE) {
+            remaining.retain(|height| !group_chunk.contains(height));
+            migrate_colliding_chunk(database, &prefix, &group_chunk, &heights_key, &remaining, &mut stats)?;
+            migrated_row = true;
+        }
         stats.collisions += colliding.len() as u64;
 
-        // Only now is the key fully migrated, so only now may its heights row go. An interruption
-        // before this point simply repeats the key.
-        database.delete(&heights_key)?;
+        // With no colliding heights nothing above touched the row, so retire it here. An
+        // interruption before this point simply repeats the key: its isolated entries are all
+        // recognised as already migrated.
+        if !migrated_row {
+            database.delete(&heights_key)?;
+        }
 
         stats.keys += 1;
         cursor = Some(heights_key);
@@ -238,12 +258,105 @@ fn next_heights_row(
     Ok(Some((key.to_vec(), value.to_vec())))
 }
 
+/// Groups colliding heights with their partners, so a batch never splits a pair.
+///
+/// `byte_reverse` is an involution, so the colliding set decomposes into disjoint pairs
+/// `{h, byte_reverse(h)}` and palindromic singletons where `h == byte_reverse(h)`. A partner is
+/// always present: `h` is only classified as colliding because its partner is an update height too.
+fn partner_groups(colliding: &[u32]) -> Vec<Vec<u32>> {
+    let mut claimed = HashSet::with_capacity(colliding.len());
+    let mut groups = Vec::new();
+    for &height in colliding {
+        if !claimed.insert(height) {
+            continue;
+        }
+        let partner = byte_reverse(height);
+        if partner == height {
+            groups.push(vec![height]);
+        } else {
+            claimed.insert(partner);
+            groups.push(vec![height, partner]);
+        }
+    }
+    groups
+}
+
+/// Packs whole groups into batches of at most `limit` heights, so partners stay together.
+fn chunk_groups(groups: &[Vec<u32>], limit: usize) -> Vec<Vec<u32>> {
+    let mut chunks = Vec::new();
+    let mut current: Vec<u32> = Vec::new();
+    for group in groups {
+        if !current.is_empty() && current.len() + group.len() > limit {
+            chunks.push(std::mem::take(&mut current));
+        }
+        current.extend_from_slice(group);
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+/// Moves a batch of colliding heights, and in the same write records what is left to do.
+///
+/// The heights row is rewritten to `remaining` (or deleted when that is empty) inside this batch,
+/// so the row always lists exactly the heights still held in little-endian form. That is what makes
+/// the operation safe to repeat: a crash either loses the whole batch, leaving the row unchanged,
+/// or commits it, and the heights it moved are no longer listed for a resumed run to re-read.
+fn migrate_colliding_chunk(
+    database: &RocksDB,
+    prefix: &[u8],
+    heights: &[u32],
+    heights_key: &[u8],
+    remaining: &[u32],
+    stats: &mut MigrationStats,
+) -> Result<()> {
+    if heights.is_empty() {
+        return Ok(());
+    }
+
+    let legacy_keys = heights.iter().map(|height| entry_key(prefix, height.to_le_bytes())).collect::<Vec<_>>();
+    let values = database.multi_get(&legacy_keys);
+
+    let mut batch = rocksdb::WriteBatch::default();
+    // Read everything before writing anything, and delete before inserting, so that where a source
+    // and a destination are the same raw key the migrated value is the one that survives.
+    let mut migrated = Vec::with_capacity(heights.len());
+    for (index, value) in values.into_iter().enumerate() {
+        // Unlike the isolated path there is no already-migrated case to tolerate: a migrated height
+        // is dropped from the heights row, so it is never presented here again.
+        let Some(value) = value.map_err(|e| anyhow::anyhow!("{e}"))? else {
+            bail!("Missing legacy mapping update at height {}", heights[index]);
+        };
+        migrated.push((heights[index], value));
+    }
+    for key in &legacy_keys {
+        batch.delete(key);
+    }
+    for (height, value) in migrated {
+        batch.put(entry_key(prefix, height.to_be_bytes()), value);
+        stats.entries += 1;
+    }
+    match remaining.is_empty() {
+        true => batch.delete(heights_key),
+        false => batch.put(heights_key, bincode::serialize(&remaining.to_vec())?),
+    }
+    database.write(batch)?;
+
+    Ok(())
+}
+
 /// Moves `heights` for one mapping key from little-endian to big-endian keys, in a single batch.
 ///
-/// Every source is read before any write is queued, and every deletion is queued before any
-/// insertion, so that where a source and a destination are the same raw key the surviving value is
-/// the migrated one.
-fn migrate_chunk(database: &RocksDB, prefix: &[u8], heights: &[u32], stats: &mut MigrationStats) -> Result<()> {
+/// Only for heights that collide with nothing: their sources and destinations are disjoint from
+/// every other height of this key, so a repeated batch is harmless and is detected by the
+/// destination already existing.
+fn migrate_isolated_chunk(
+    database: &RocksDB,
+    prefix: &[u8],
+    heights: &[u32],
+    stats: &mut MigrationStats,
+) -> Result<()> {
     if heights.is_empty() {
         return Ok(());
     }

--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -13,6 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "history")]
+mod history_migration;
+#[cfg(feature = "history")]
+pub(crate) use history_migration::*;
+
 mod id;
 pub use id::*;
 

--- a/ledger/store/src/helpers/rocksdb/program.rs
+++ b/ledger/store/src/helpers/rocksdb/program.rs
@@ -89,8 +89,8 @@ impl<N: Network> FinalizeStorage<N> for FinalizeDB<N> {
         // Returns 0 for a fresh database that has no committee data yet.
         #[cfg(feature = "history")]
         let initial_height = committee_store.current_height().unwrap_or(0);
-        // Return the finalize storage.
-        Ok(Self {
+        // Initialize the finalize storage.
+        let storage = Self {
             committee_store,
             program_id_map: rocksdb::RocksDB::open_map(N::ID, storage.clone(), MapID::Program(ProgramMap::ProgramID))?,
             key_value_map: rocksdb::RocksDB::open_nested_map(N::ID, storage.clone(), MapID::Program(ProgramMap::KeyValueID))?,
@@ -104,7 +104,12 @@ impl<N: Network> FinalizeStorage<N> for FinalizeDB<N> {
             #[cfg(feature = "history-staking-rewards")]
             staking_rewards_map: rocksdb::RocksDB::open_map(N::ID, storage.clone(), MapID::Program(ProgramMap::StakingRewards))?,
             storage_mode: storage,
-        })
+        };
+        // Rewrite any legacy little-endian history entries before the store serves anything.
+        // This is a no-op once a node has been migrated, costing a single seek.
+        #[cfg(feature = "history")]
+        rocksdb::migrate_finalize_history(&storage.mapping_update_heights_map, &storage.mapping_update_map)?;
+        Ok(storage)
     }
 
     /// Returns the committee store.

--- a/ledger/store/src/program/finalize.rs
+++ b/ledger/store/src/program/finalize.rs
@@ -2251,4 +2251,210 @@ mod tests {
             assert_matches_oracle(&store, program_id, mapping_name, key, updates);
         }
     }
+
+    // =======================================================================================
+    // ADVERSARIAL REVIEW TESTS (added by review; not part of the commit under audit)
+    // =======================================================================================
+
+    /// PROOF: a run interrupted between the colliding write-batch and the heights-row deletion
+    /// SWAPS the values of every colliding pair when it is resumed.
+    ///
+    /// The colliding batch is a single atomic `WriteBatch`, but deleting the heights row is a
+    /// *separate* DB write. A crash / SIGTERM / OOM in that window leaves exactly the state
+    /// reproduced below: every entry already migrated, heights row still present. On resume,
+    /// `migrate_chunk` re-reads raw key LE(a) -- which is byte-identical to BE(b) and therefore
+    /// now holds height b's value -- and writes it back out under BE(a).
+    #[test]
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    #[ignore = "known failure: an interrupted run transposes byte-reversal pairs. Repro for the open defect; remove the ignore once the colliding path is made resumable."]
+    fn adv_resume_after_colliding_batch_swaps_values() {
+        let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+        let mapping_name = Identifier::from_str("bonded").unwrap();
+        let key = Plaintext::from_str("7field").unwrap();
+
+        // 256 and 65_536 are byte-reversal partners: LE(256) == BE(65_536).
+        let a = 256u32;
+        let b = 65_536u32;
+        assert_eq!(a.to_le_bytes(), b.to_be_bytes());
+
+        let mut updates = vec![
+            (a, Value::from_str("111u64").unwrap()),
+            (b, Value::from_str("222u64").unwrap()),
+            (1_000u32, Value::from_str("333u64").unwrap()),
+        ];
+        updates.sort_by_key(|(h, _)| *h);
+
+        let storage = rocks_store();
+        seed_legacy_key(&storage, program_id, mapping_name, &key, &updates);
+        storage.current_block_height().store(u32::MAX - 1, Ordering::SeqCst);
+
+        // Pass 1: completes the data move.
+        let stats = migrate(&storage);
+        assert_eq!(stats.collisions, 2);
+
+        {
+            let store = FinalizeStore::from(storage.clone()).unwrap();
+            assert_matches_oracle(&store, program_id, mapping_name, &key, &updates);
+        }
+
+        // Reproduce the crash window: entries moved, heights row not yet deleted.
+        let heights = updates.iter().map(|(h, _)| *h).collect::<Vec<_>>();
+        storage.mapping_update_heights_map().insert((program_id, mapping_name, key.clone()), heights).unwrap();
+
+        // Pass 2: the resumed run.
+        let stats = migrate(&storage);
+        // The isolated height is correctly recognised as already migrated...
+        assert_eq!(stats.resumed, 1, "isolated height should be detected as already-migrated");
+
+        let store = FinalizeStore::from(storage).unwrap();
+        let at_a = store.get_historical_mapping_value(program_id, mapping_name, key.clone(), a).unwrap();
+        let at_b = store.get_historical_mapping_value(program_id, mapping_name, key.clone(), b).unwrap();
+        println!("after resumed run: height {a} -> {at_a:?}, height {b} -> {at_b:?}");
+        assert_matches_oracle(&store, program_id, mapping_name, &key, &updates);
+    }
+
+    /// PROOF: the `colliding` batch is NOT bounded -- for a key updated at every block (which the
+    /// commit message names as the dominant workload: credits.aleo bonded/delegated/committee via
+    /// `replace_mapping`), the colliding subset is ~0.5% of the whole history at today's mainnet
+    /// height and grows quadratically. It is passed to a single unchunked `multi_get` +
+    /// `WriteBatch`.
+    #[test]
+    #[ignore = "known failure: the colliding subset is not chunked and grows quadratically with chain height (109,100 entries at today's tip)."]
+    fn adv_colliding_subset_is_unbounded() {
+        fn byte_reverse(h: u32) -> u32 {
+            u32::from_be_bytes(h.to_le_bytes())
+        }
+        for tip in [1_000_000u32, 5_000_000, 21_639_560] {
+            let n = (0..=tip).filter(|h| byte_reverse(*h) <= tip).count();
+            println!("chain tip {tip}: colliding heights for an every-block key = {n}");
+            if tip == 21_639_560 {
+                assert!(
+                    n <= 50_000,
+                    "colliding subset is {n} entries at mainnet tip -- more than CHUNK_SIZE, \
+                     yet it is migrated in one unchunked batch"
+                );
+            }
+        }
+    }
+
+    /// CLAIM 1: the height is unconditionally the final four bytes of the raw key, and the
+    /// heights-map key body is a strict prefix of the update-map key body.
+    #[test]
+    #[cfg(feature = "history")]
+    fn adv_bincode_height_suffix_holds_for_every_plaintext() {
+        let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+        let mapping_name = Identifier::<CurrentNetwork>::from_str("bonded").unwrap();
+
+        let sources = [
+            "0field",
+            "1field",
+            "123456789field",
+            "0u8",
+            "255u8",
+            "0i8",
+            "-128i8",
+            "0u128",
+            "340282366920938463463374607431768211455u128",
+            "true",
+            "false",
+            "0group",
+            "1group",
+            "0scalar",
+            "aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+            "{ a: 1u64 }",
+            "{ a: 1u64, b: 2u64 }",
+            "{ a: { b: { c: 1field } } }",
+            "[ 0u8, 1u8, 2u8, 3u8 ]",
+            "[ 0u32, 1u32 ]",
+            "{ x: [ 1u8, 2u8, 3u8, 4u8 ], y: 5field }",
+            // A struct whose trailing bytes are themselves four zero bytes, to make sure a
+            // trailing-zero body cannot be confused with the height suffix.
+            "{ z: 0u32 }",
+            "0u32",
+            "4294967295u32",
+        ];
+
+        let mut checked = 0usize;
+        for src in sources {
+            let Ok(pt) = Plaintext::<CurrentNetwork>::from_str(src) else { continue };
+            let body = bincode::serialize(&(program_id, mapping_name, pt.clone())).unwrap();
+            for h in [0u32, 1, 255, 256, 65_535, 65_792, 16_777_216, 21_639_560, u32::MAX] {
+                for bytes in [h.to_le_bytes(), h.to_be_bytes()] {
+                    let full = bincode::serialize(&(program_id, mapping_name, pt.clone(), bytes)).unwrap();
+                    assert_eq!(full.len(), body.len() + 4, "height is not 4 raw bytes for `{src}`");
+                    assert_eq!(&full[..body.len()], &body[..], "heights body is not a prefix for `{src}`");
+                    assert_eq!(&full[body.len()..], &bytes[..], "height is not the final 4 bytes for `{src}`");
+                    checked += 1;
+                }
+            }
+        }
+        assert!(checked > 100, "only {checked} cases exercised");
+        println!("claim 1 verified over {checked} (plaintext, height) encodings");
+    }
+
+    /// Demonstrates that the migration turns a *correct* historical read into a wrong one when a
+    /// legacy key carries entries that its heights row does not list.
+    ///
+    /// Such entries are real and are already on disk in production. snarkOS v4.7.5 and v4.8.0
+    /// (snarkVM `a108e8159`..`58a1359ea`) wrote little-endian history entries while writing **no**
+    /// heights rows at all -- the three `mapping_update_heights_map().insert` sites present in
+    /// v4.7.4's snarkVM are absent in theirs. A node that ran v4.7.4, then v4.8.0, then v4.8.1+
+    /// therefore has a *hole* in its heights row covering the middle era.
+    ///
+    /// Those unlisted entries are invisible to the migration, which trusts the heights row as the
+    /// inventory of a key's history. They survive it, still little-endian, in the same keyspace the
+    /// migrated entries now occupy -- and an unlisted height `h` is indistinguishable from a
+    /// migrated entry at height `byte_reverse(h)`, because those are the same four bytes. Where
+    /// `byte_reverse(h)` is itself a plausible height, a floor seek will find the orphan and return
+    /// its value for a completely unrelated height.
+    #[test]
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    #[ignore = "known failure: entries written by snarkOS v4.7.5/v4.8.0 carry no heights row, so a heights-driven migration cannot see them and leaves them aliasing a big-endian height."]
+    fn test_migration_exposes_unlisted_entries_as_wrong_heights() {
+        let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+        let mapping_name = Identifier::from_str("bonded").unwrap();
+        let key = Plaintext::from_str("9field").unwrap();
+
+        let v100 = Value::<CurrentNetwork>::from_str("100u64").unwrap();
+        let v1000 = Value::<CurrentNetwork>::from_str("1000u64").unwrap();
+        let orphan_value = Value::<CurrentNetwork>::from_str("256u64").unwrap();
+
+        // The orphan sits at a height whose byte-reversal is itself a plausible block height,
+        // which is what makes it reachable by a floor seek after migration.
+        let orphan_height = 256u32;
+        let masquerades_as = 65_536u32;
+        assert_eq!(orphan_height.to_le_bytes(), masquerades_as.to_be_bytes());
+
+        let storage = rocks_store();
+        storage.current_block_height().store(100_000, Ordering::SeqCst);
+
+        // The v4.7.4-era entries: little-endian, and listed in the heights row.
+        seed_legacy_key(&storage, program_id, mapping_name, &key, &[(100, v100.clone()), (1000, v1000.clone())]);
+
+        // The v4.8.0-era entry: little-endian, written with no heights row of its own, so the
+        // existing row never learns about it.
+        storage
+            .mapping_update_map()
+            .insert((program_id, mapping_name, key.clone(), orphan_height.to_le_bytes()), orphan_value.clone())
+            .unwrap();
+
+        // Before migrating: a query at 65,536 correctly reports the value set at height 1000,
+        // because the only entries the reader can reach are the listed ones and 1000 is the
+        // latest at or before 65,536. The orphan is invisible, which is merely lossy.
+        migrate(&storage);
+
+        let store = FinalizeStore::from(storage).unwrap();
+        let answer = store
+            .get_historical_mapping_value(program_id, mapping_name, key.clone(), masquerades_as)
+            .unwrap()
+            .map(|value| value.into_owned());
+
+        assert_eq!(
+            answer,
+            Some(v1000),
+            "after migration, the query at height {masquerades_as} returned the value written at \
+             height {orphan_height}: an unlisted little-endian entry survived the migration and is \
+             now indistinguishable from a migrated big-endian entry"
+        );
+    }
 }

--- a/ledger/store/src/program/finalize.rs
+++ b/ledger/store/src/program/finalize.rs
@@ -2194,17 +2194,19 @@ mod tests {
     // ADVERSARIAL REVIEW TESTS (added by review; not part of the commit under audit)
     // =======================================================================================
 
-    /// PROOF: a run interrupted between the colliding write-batch and the heights-row deletion
-    /// SWAPS the values of every colliding pair when it is resumed.
+    /// Verifies that an interrupted migration resumes without transposing byte-reversal pairs.
     ///
-    /// The colliding batch is a single atomic `WriteBatch`, but deleting the heights row is a
-    /// *separate* DB write. A crash / SIGTERM / OOM in that window leaves exactly the state
-    /// reproduced below: every entry already migrated, heights row still present. On resume,
-    /// `migrate_chunk` re-reads raw key LE(a) -- which is byte-identical to BE(b) and therefore
-    /// now holds height b's value -- and writes it back out under BE(a).
+    /// A migrated colliding entry is byte-identical to its partner's un-migrated source, so the
+    /// data alone cannot say whether a pair has already moved. The migration therefore never leaves
+    /// that ambiguity observable: each colliding batch shrinks the heights row to the heights it has
+    /// *not* yet moved, in the same atomic write. So the only states a crash can leave are "batch
+    /// not applied, row unchanged" and "batch applied, row already shortened" -- and a resumed run
+    /// is never offered a height it has already migrated.
+    ///
+    /// This reproduces the second of those, which is the one that used to corrupt: the pair has
+    /// moved and the row lists only what is left.
     #[test]
     #[cfg(all(feature = "rocks", feature = "history"))]
-    #[ignore = "known failure: an interrupted run transposes byte-reversal pairs. Repro for the open defect; remove the ignore once the colliding path is made resumable."]
     fn adv_resume_after_colliding_batch_swaps_values() {
         let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
         let mapping_name = Identifier::from_str("bonded").unwrap();
@@ -2226,23 +2228,18 @@ mod tests {
         seed_legacy_key(&storage, program_id, mapping_name, &key, &updates);
         storage.current_block_height().store(u32::MAX - 1, Ordering::SeqCst);
 
-        // Pass 1: completes the data move.
-        let stats = migrate(&storage);
-        assert_eq!(stats.collisions, 2);
-
-        {
-            let store = FinalizeStore::from(storage.clone()).unwrap();
-            assert_matches_oracle(&store, program_id, mapping_name, &key, &updates);
+        // Move the colliding pair by hand, exactly as one committed batch would: both sources
+        // deleted, both destinations written, and the heights row shortened to what remains.
+        for (height, value) in [(a, "111u64"), (b, "222u64")] {
+            storage
+                .mapping_update_map()
+                .insert((program_id, mapping_name, key.clone(), height.to_be_bytes()), Value::from_str(value).unwrap())
+                .unwrap();
         }
+        storage.mapping_update_heights_map().insert((program_id, mapping_name, key.clone()), vec![1_000]).unwrap();
 
-        // Reproduce the crash window: entries moved, heights row not yet deleted.
-        let heights = updates.iter().map(|(h, _)| *h).collect::<Vec<_>>();
-        storage.mapping_update_heights_map().insert((program_id, mapping_name, key.clone()), heights).unwrap();
-
-        // Pass 2: the resumed run.
-        let stats = migrate(&storage);
-        // The isolated height is correctly recognised as already migrated...
-        assert_eq!(stats.resumed, 1, "isolated height should be detected as already-migrated");
+        // The resumed run sees only the height still owed, and must not disturb the moved pair.
+        migrate(&storage);
 
         let store = FinalizeStore::from(storage).unwrap();
         let at_a = store.get_historical_mapping_value(program_id, mapping_name, key.clone(), a).unwrap();
@@ -2251,28 +2248,53 @@ mod tests {
         assert_matches_oracle(&store, program_id, mapping_name, &key, &updates);
     }
 
-    /// PROOF: the `colliding` batch is NOT bounded -- for a key updated at every block (which the
-    /// commit message names as the dominant workload: credits.aleo bonded/delegated/committee via
-    /// `replace_mapping`), the colliding subset is ~0.5% of the whole history at today's mainnet
-    /// height and grows quadratically. It is passed to a single unchunked `multi_get` +
-    /// `WriteBatch`.
+    /// Verifies the colliding subset is bounded per batch even though the subset itself is not.
+    ///
+    /// For a key written on every block the colliding subset is
+    /// `#{h <= H : byte_reverse(h) <= H}`, which grows as `H^2 / 2^24` -- 109,100 entries at
+    /// mainnet tip 21.6M, and 1,048,578 by tip 67M. It is therefore not safe to migrate in one
+    /// batch, and it is not safe to split a byte-reversal pair across two. Both hold here.
     #[test]
-    #[ignore = "known failure: the colliding subset is not chunked and grows quadratically with chain height (109,100 entries at today's tip)."]
+    #[cfg(all(feature = "rocks", feature = "history"))]
     fn adv_colliding_subset_is_unbounded() {
-        fn byte_reverse(h: u32) -> u32 {
-            u32::from_be_bytes(h.to_le_bytes())
-        }
-        for tip in [1_000_000u32, 5_000_000, 21_639_560] {
-            let n = (0..=tip).filter(|h| byte_reverse(*h) <= tip).count();
-            println!("chain tip {tip}: colliding heights for an every-block key = {n}");
-            if tip == 21_639_560 {
-                assert!(
-                    n <= 50_000,
-                    "colliding subset is {n} entries at mainnet tip -- more than CHUNK_SIZE, \
-                     yet it is migrated in one unchunked batch"
-                );
+        // The subset really is large at realistic chain heights.
+        let tip = 21_639_560u32;
+        let colliding = (0..=tip).filter(|h| u32::from_be_bytes(h.to_le_bytes()) <= tip).count();
+        println!("colliding heights for an every-block key at tip {tip}: {colliding}");
+        assert!(colliding > 100_000, "expected the subset to exceed a single batch, got {colliding}");
+
+        // A key whose colliding set spans several batches still migrates correctly, and the
+        // surviving heights row always holds whole pairs so the split stays stable across a resume.
+        let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+        let mapping_name = Identifier::from_str("bonded").unwrap();
+        let key = Plaintext::from_str("13field").unwrap();
+
+        // Every height here has its partner present, so the whole key is colliding.
+        let mut heights = Vec::new();
+        for low in 0..=1u32 {
+            for high in 0..=1u32 {
+                for mid in 0..64u32 {
+                    heights.push(u32::from_le_bytes([low as u8, mid as u8, 0, high as u8]));
+                    heights.push(u32::from_be_bytes([low as u8, mid as u8, 0, high as u8]));
+                }
             }
         }
+        heights.sort_unstable();
+        heights.dedup();
+        let updates = heights
+            .iter()
+            .map(|h| (*h, Value::<CurrentNetwork>::from_str(&format!("{}u64", h % 977)).unwrap()))
+            .collect::<Vec<_>>();
+
+        let storage = rocks_store();
+        seed_legacy_key(&storage, program_id, mapping_name, &key, &updates);
+        storage.current_block_height().store(u32::MAX - 1, Ordering::SeqCst);
+
+        migrate(&storage);
+        assert_eq!(storage.mapping_update_heights_map().iter_confirmed().count(), 0);
+
+        let store = FinalizeStore::from(storage).unwrap();
+        assert_matches_oracle(&store, program_id, mapping_name, &key, &updates);
     }
 
     /// CLAIM 1: the height is unconditionally the final four bytes of the raw key, and the

--- a/ledger/store/src/program/finalize.rs
+++ b/ledger/store/src/program/finalize.rs
@@ -1911,68 +1911,6 @@ mod tests {
         assert_eq!(&*heights, &[10, 20, 50, 100]);
     }
 
-    /// Verifies the legacy (pre-BE schema) read path: keys whose heights are stored in
-    /// `mapping_update_heights_map` continue to be found correctly via binary search.
-    #[test]
-    #[cfg(feature = "history")]
-    fn test_get_historical_mapping_value_legacy() {
-        use std::sync::atomic::Ordering;
-
-        let program_id = ProgramID::<CurrentNetwork>::from_str("hello.aleo").unwrap();
-        let mapping_name = Identifier::from_str("account").unwrap();
-        let key = Plaintext::from_str("1field").unwrap();
-
-        let program_memory = FinalizeMemory::open(StorageMode::Test(None)).unwrap();
-        let finalize_store = FinalizeStore::from(program_memory).unwrap();
-
-        finalize_store.initialize_mapping(program_id, mapping_name).unwrap();
-
-        // Simulate legacy writes: insert directly into the LE-keyed update map AND into the heights map,
-        // exactly as the old code did.
-        let v5 = Value::from_str("5u64").unwrap();
-        let v10 = Value::from_str("10u64").unwrap();
-        finalize_store
-            .storage
-            .mapping_update_map()
-            .insert((program_id, mapping_name, key.clone(), 5u32.to_le_bytes()), v5.clone())
-            .unwrap();
-        finalize_store
-            .storage
-            .mapping_update_map()
-            .insert((program_id, mapping_name, key.clone(), 10u32.to_le_bytes()), v10.clone())
-            .unwrap();
-        finalize_store
-            .storage
-            .mapping_update_heights_map()
-            .insert((program_id, mapping_name, key.clone()), vec![5, 10])
-            .unwrap();
-        finalize_store.storage.current_block_height().store(20, Ordering::SeqCst);
-
-        // Height before first update → None.
-        assert!(
-            finalize_store.get_historical_mapping_value(program_id, mapping_name, key.clone(), 4).unwrap().is_none()
-        );
-        // Height 5 (exact) → v5.
-        let v = finalize_store.get_historical_mapping_value(program_id, mapping_name, key.clone(), 5).unwrap().unwrap();
-        assert_eq!(*v, v5);
-        // Height 7 (floor → 5) → v5.
-        let v = finalize_store.get_historical_mapping_value(program_id, mapping_name, key.clone(), 7).unwrap().unwrap();
-        assert_eq!(*v, v5);
-        // Height 10 (exact) → v10.
-        let v =
-            finalize_store.get_historical_mapping_value(program_id, mapping_name, key.clone(), 10).unwrap().unwrap();
-        assert_eq!(*v, v10);
-        // Height 15 (floor → 10) → v10.
-        let v =
-            finalize_store.get_historical_mapping_value(program_id, mapping_name, key.clone(), 15).unwrap().unwrap();
-        assert_eq!(*v, v10);
-
-        // Heights list comes from the heights map.
-        let heights =
-            finalize_store.get_mapping_update_heights(program_id, mapping_name, key.clone()).unwrap().unwrap();
-        assert_eq!(&*heights, &[5, 10]);
-    }
-
     // ---------------------------------------------------------------------------------------
     // Legacy history migration.
     //

--- a/ledger/store/src/program/finalize.rs
+++ b/ledger/store/src/program/finalize.rs
@@ -372,22 +372,8 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
             #[cfg(feature = "history")]
             {
                 let current_height = self.current_block_height().load(Ordering::SeqCst);
-                let heights_key = (program_id, mapping_name, key.clone());
-
-                // If this key has a legacy heights-map entry it was written before the BE schema
-                // change; continue appending to the heights vec and write with the original LE
-                // encoding so that reads using the heights-map path remain correct.
-                if let Some(heights) = self.mapping_update_heights_map().get_confirmed(&heights_key)? {
-                    let mut heights = heights.into_owned();
-                    self.mapping_update_map()
-                        .insert((program_id, mapping_name, key.clone(), current_height.to_le_bytes()), value.clone())?;
-                    heights.push(current_height);
-                    self.mapping_update_heights_map().insert(heights_key, heights)?;
-                } else {
-                    // New key: use the big-endian encoding so floor seeks work correctly.
-                    self.mapping_update_map()
-                        .insert((program_id, mapping_name, key.clone(), current_height.to_be_bytes()), value.clone())?;
-                }
+                self.mapping_update_map()
+                    .insert((program_id, mapping_name, key.clone(), current_height.to_be_bytes()), value.clone())?;
             }
 
             // Update the key-value map with the new key-value.
@@ -456,24 +442,8 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
                 #[cfg(feature = "history")]
                 {
                     let current_height = self.current_block_height().load(Ordering::SeqCst);
-                    let heights_key = (program_id, mapping_name, key.clone());
-
-                    // Legacy keys (pre-BE schema) continue using LE encoding + heights vec.
-                    if let Some(heights) = self.mapping_update_heights_map().get_confirmed(&heights_key)? {
-                        let mut heights = heights.into_owned();
-                        self.mapping_update_map().insert(
-                            (program_id, mapping_name, key.clone(), current_height.to_le_bytes()),
-                            value.clone(),
-                        )?;
-                        heights.push(current_height);
-                        self.mapping_update_heights_map().insert(heights_key, heights)?;
-                    } else {
-                        // New key: big-endian encoding.
-                        self.mapping_update_map().insert(
-                            (program_id, mapping_name, key.clone(), current_height.to_be_bytes()),
-                            value.clone(),
-                        )?;
-                    }
+                    self.mapping_update_map()
+                        .insert((program_id, mapping_name, key.clone(), current_height.to_be_bytes()), value.clone())?;
                 }
 
                 // Insert the key-value entry.
@@ -859,13 +829,8 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
 
     /// Returns the historical value of a mapping at or before the given block height.
     ///
-    /// **Fast path** (new keys, no `mapping_update_heights_map` entry): single O(log n)
-    /// floor seek on `mapping_update_map`, which uses big-endian height encoding.
-    ///
-    /// **Legacy path** (keys written before the BE schema change, heights-map entry
-    /// present): O(n) binary search over the heights `Vec`, then a point lookup using
-    /// the original little-endian encoding. Correct but slower; these keys stay on this
-    /// path until the node is resynced or an offline migration is performed.
+    /// A single O(log n) floor seek on `mapping_update_map`, whose height keys are big-endian so
+    /// that lexicographic key order matches numeric height order.
     #[cfg(feature = "history")]
     pub fn get_historical_mapping_value(
         &self,
@@ -879,26 +844,7 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
             return Ok(None);
         }
 
-        // Check for a legacy heights-map entry (pre-BE schema change).
-        let heights_key = (program_id, mapping_name, mapping_key.clone());
-        if let Some(heights) = self.storage.mapping_update_heights_map().get_confirmed(&heights_key)? {
-            // Legacy O(n) path: binary search on the heights Vec.
-            let heights = heights.into_owned();
-            let applicable_height = match heights.binary_search(&height) {
-                Ok(_) => height,
-                Err(0) => return Ok(None),
-                Err(idx) => heights[idx - 1],
-            };
-            // Look up with the original little-endian encoding.
-            return self.storage.mapping_update_map().get_confirmed(&(
-                program_id,
-                mapping_name,
-                mapping_key,
-                applicable_height.to_le_bytes(),
-            ));
-        }
-
-        // New fast path: O(log n) floor seek with big-endian encoding.
+        // Find the most recent update at or before the requested height.
         let seek_key = (program_id, mapping_name, mapping_key.clone(), height.to_be_bytes());
         match self.storage.mapping_update_map().get_floor_confirmed(&seek_key)? {
             Some((found_key, found_value)) => {
@@ -911,9 +857,8 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
 
     /// Returns the heights at which past mapping updates occurred, in ascending order.
     ///
-    /// For legacy keys (heights-map entry present) the list is read directly from the
-    /// heights map. For new keys it is reconstructed by scanning `mapping_update_map`.
-    /// Either way this is O(n updates) and is intended for diagnostic / test use only.
+    /// Reconstructed by scanning `mapping_update_map`. This is O(n updates) and is intended for
+    /// diagnostic / test use only.
     #[cfg(feature = "history")]
     pub fn get_mapping_update_heights(
         &self,
@@ -921,13 +866,7 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
         mapping_name: Identifier<N>,
         mapping_key: Plaintext<N>,
     ) -> Result<Option<Cow<'_, Vec<u32>>>, Error> {
-        // Legacy path: heights are stored explicitly in the heights map.
-        let heights_key = (program_id, mapping_name, mapping_key.clone());
-        if let Some(heights) = self.storage.mapping_update_heights_map().get_confirmed(&heights_key)? {
-            return Ok(Some(heights));
-        }
-
-        // New path: reconstruct from mapping_update_map keys (big-endian encoded heights).
+        // Reconstruct from the mapping_update_map keys, whose heights are big-endian encoded.
         let mut heights: Vec<u32> = self
             .storage
             .mapping_update_map()
@@ -2032,5 +1971,284 @@ mod tests {
         let heights =
             finalize_store.get_mapping_update_heights(program_id, mapping_name, key.clone()).unwrap().unwrap();
         assert_eq!(&*heights, &[5, 10]);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Legacy history migration.
+    //
+    // These exercise the raw migration end to end through the real store: legacy data is laid
+    // down exactly as a pre-#3323 node would have left it (little-endian height keys plus a
+    // heights vector), migrated, and then read back through the ordinary public API.
+    // ---------------------------------------------------------------------------------------
+
+    /// Opens a RocksDB-backed finalize store over a fresh temporary directory.
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    fn rocks_store() -> crate::helpers::rocksdb::FinalizeDB<CurrentNetwork> {
+        let temp_dir = std::sync::Arc::new(tempfile::tempdir().expect("Failed to open temporary directory"));
+        crate::helpers::rocksdb::FinalizeDB::open(temp_dir).unwrap()
+    }
+
+    /// Writes `(height, value)` pairs for `key` in the pre-#3323 layout: little-endian height keys
+    /// in the update map, plus the heights vector that marked the key as legacy.
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    fn seed_legacy_key<P: FinalizeStorage<CurrentNetwork>>(
+        storage: &P,
+        program_id: ProgramID<CurrentNetwork>,
+        mapping_name: Identifier<CurrentNetwork>,
+        key: &Plaintext<CurrentNetwork>,
+        updates: &[(u32, Value<CurrentNetwork>)],
+    ) {
+        for (height, value) in updates {
+            storage
+                .mapping_update_map()
+                .insert((program_id, mapping_name, key.clone(), height.to_le_bytes()), value.clone())
+                .unwrap();
+        }
+        let heights = updates.iter().map(|(height, _)| *height).collect::<Vec<_>>();
+        storage.mapping_update_heights_map().insert((program_id, mapping_name, key.clone()), heights).unwrap();
+    }
+
+    /// Runs the migration against a RocksDB-backed store.
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    fn migrate(
+        storage: &crate::helpers::rocksdb::FinalizeDB<CurrentNetwork>,
+    ) -> crate::helpers::rocksdb::MigrationStats {
+        crate::helpers::rocksdb::migrate_finalize_history(
+            storage.mapping_update_heights_map(),
+            storage.mapping_update_map(),
+        )
+        .unwrap()
+    }
+
+    /// The value a correct implementation must return: the most recent update at or before
+    /// `height`, computed directly from the seeded data rather than from the store.
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    fn oracle(updates: &[(u32, Value<CurrentNetwork>)], height: u32) -> Option<Value<CurrentNetwork>> {
+        updates.iter().filter(|(h, _)| *h <= height).max_by_key(|(h, _)| *h).map(|(_, v)| v.clone())
+    }
+
+    /// Verifies that every historical read after migration matches the oracle, at every seeded
+    /// height and at the points either side of it.
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    fn assert_matches_oracle(
+        store: &FinalizeStore<CurrentNetwork, crate::helpers::rocksdb::FinalizeDB<CurrentNetwork>>,
+        program_id: ProgramID<CurrentNetwork>,
+        mapping_name: Identifier<CurrentNetwork>,
+        key: &Plaintext<CurrentNetwork>,
+        updates: &[(u32, Value<CurrentNetwork>)],
+    ) {
+        let mut probes = Vec::new();
+        for (height, _) in updates {
+            probes.extend([height.saturating_sub(1), *height, height.saturating_add(1)]);
+        }
+        for height in probes {
+            let expected = oracle(updates, height);
+            let actual = store
+                .get_historical_mapping_value(program_id, mapping_name, key.clone(), height)
+                .unwrap()
+                .map(|value| value.into_owned());
+            assert_eq!(actual, expected, "mismatch at height {height} for key {key}");
+        }
+    }
+
+    /// Verifies a straightforward migration: the heights map is drained, and every historical
+    /// read returns what it did before.
+    #[test]
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    fn test_migrate_legacy_history() {
+        let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+        let mapping_name = Identifier::from_str("account").unwrap();
+        let key = Plaintext::from_str("1field").unwrap();
+        let updates =
+            (0..64u32).map(|i| (i * 7 + 3, Value::from_str(&format!("{}u64", i * 11)).unwrap())).collect::<Vec<_>>();
+
+        let storage = rocks_store();
+        seed_legacy_key(&storage, program_id, mapping_name, &key, &updates);
+        storage.current_block_height().store(u32::MAX - 1, Ordering::SeqCst);
+
+        let stats = migrate(&storage);
+        assert_eq!(stats.keys, 1);
+        assert_eq!(stats.entries, updates.len() as u64);
+        assert_eq!(stats.resumed, 0);
+
+        // The legacy index is gone, and nothing is left on the old encoding.
+        assert_eq!(storage.mapping_update_heights_map().iter_confirmed().count(), 0);
+        assert_eq!(storage.mapping_update_map().iter_confirmed().count(), updates.len());
+
+        let store = FinalizeStore::from(storage).unwrap();
+        assert_matches_oracle(&store, program_id, mapping_name, &key, &updates);
+    }
+
+    /// Verifies that heights whose two encodings collide survive the migration.
+    ///
+    /// `LE(h)` and `BE(h')` are the same four bytes exactly when `h' == byte_reverse(h)`, so a
+    /// naive per-entry rewrite can delete a value it has already migrated.
+    #[test]
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    fn test_migrate_legacy_history_endian_collisions() {
+        let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+        let mapping_name = Identifier::from_str("bonded").unwrap();
+        let key = Plaintext::from_str("7field").unwrap();
+
+        // A height that is its own partner, a pair that swap with each other, and ordinary
+        // heights interleaved so the colliding set is not the whole key.
+        let self_collision = 65_792u32;
+        assert_eq!(self_collision.to_le_bytes(), self_collision.to_be_bytes());
+        let swap_a = 256u32;
+        let swap_b = 65_536u32;
+        assert_eq!(swap_a.to_le_bytes(), swap_b.to_be_bytes());
+        assert_eq!(swap_b.to_le_bytes(), swap_a.to_be_bytes());
+
+        let mut updates = vec![
+            (swap_a, Value::from_str("2u64").unwrap()),
+            (1_000u32, Value::from_str("9u64").unwrap()),
+            (swap_b, Value::from_str("3u64").unwrap()),
+            (self_collision, Value::from_str("1u64").unwrap()),
+            (70_000u32, Value::from_str("8u64").unwrap()),
+        ];
+        updates.sort_by_key(|(height, _)| *height);
+
+        let storage = rocks_store();
+        seed_legacy_key(&storage, program_id, mapping_name, &key, &updates);
+        storage.current_block_height().store(u32::MAX - 1, Ordering::SeqCst);
+
+        let stats = migrate(&storage);
+        assert_eq!(stats.entries, updates.len() as u64);
+        // The three colliding heights must have been recognised as such.
+        assert_eq!(stats.collisions, 3);
+
+        let store = FinalizeStore::from(storage).unwrap();
+        assert_matches_oracle(&store, program_id, mapping_name, &key, &updates);
+    }
+
+    /// Verifies the migration is idempotent, so an interrupted run can simply be repeated.
+    #[test]
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    fn test_migrate_legacy_history_is_idempotent() {
+        let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+        let mapping_name = Identifier::from_str("account").unwrap();
+        let key = Plaintext::from_str("3field").unwrap();
+        let updates = (0..32u32).map(|i| (i * 3, Value::from_str(&format!("{i}u64")).unwrap())).collect::<Vec<_>>();
+
+        let storage = rocks_store();
+        seed_legacy_key(&storage, program_id, mapping_name, &key, &updates);
+        storage.current_block_height().store(u32::MAX - 1, Ordering::SeqCst);
+
+        assert_eq!(migrate(&storage).entries, updates.len() as u64);
+        // A second run has nothing to do: the heights map is empty, so no key is even visited.
+        let second = migrate(&storage);
+        assert_eq!(second, crate::helpers::rocksdb::MigrationStats::default());
+
+        let store = FinalizeStore::from(storage).unwrap();
+        assert_matches_oracle(&store, program_id, mapping_name, &key, &updates);
+    }
+
+    /// Verifies that a run interrupted partway through a key resumes without loss.
+    ///
+    /// Simulates the crash by migrating a prefix of the key's entries by hand and leaving the
+    /// heights row in place, which is exactly the state an interrupted run leaves behind.
+    #[test]
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    fn test_migrate_legacy_history_resumes_mid_key() {
+        let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+        let mapping_name = Identifier::from_str("account").unwrap();
+        let key = Plaintext::from_str("5field").unwrap();
+        let updates = (0..40u32).map(|i| (i * 5 + 1, Value::from_str(&format!("{i}u64")).unwrap())).collect::<Vec<_>>();
+
+        let storage = rocks_store();
+        seed_legacy_key(&storage, program_id, mapping_name, &key, &updates);
+        storage.current_block_height().store(u32::MAX - 1, Ordering::SeqCst);
+
+        // Move the first 12 entries to the new encoding, as a partial run would have.
+        for (height, value) in updates.iter().take(12) {
+            storage
+                .mapping_update_map()
+                .insert((program_id, mapping_name, key.clone(), height.to_be_bytes()), value.clone())
+                .unwrap();
+            storage
+                .mapping_update_map()
+                .remove(&(program_id, mapping_name, key.clone(), height.to_le_bytes()))
+                .unwrap();
+        }
+
+        let stats = migrate(&storage);
+        // The already-moved entries are recognised rather than treated as missing history.
+        assert_eq!(stats.resumed, 12);
+        assert_eq!(stats.entries, (updates.len() - 12) as u64);
+        assert_eq!(storage.mapping_update_heights_map().iter_confirmed().count(), 0);
+
+        let store = FinalizeStore::from(storage).unwrap();
+        assert_matches_oracle(&store, program_id, mapping_name, &key, &updates);
+    }
+
+    /// Verifies that genuinely missing history is reported rather than silently dropped.
+    #[test]
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    fn test_migrate_legacy_history_rejects_missing_entries() {
+        let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+        let mapping_name = Identifier::from_str("account").unwrap();
+        let key = Plaintext::from_str("11field").unwrap();
+        let updates = (0..8u32).map(|i| (i * 2 + 1, Value::from_str(&format!("{i}u64")).unwrap())).collect::<Vec<_>>();
+
+        let storage = rocks_store();
+        seed_legacy_key(&storage, program_id, mapping_name, &key, &updates);
+
+        // Delete one entry outright, leaving its height listed. Neither encoding holds it now.
+        storage
+            .mapping_update_map()
+            .remove(&(program_id, mapping_name, key.clone(), updates[3].0.to_le_bytes()))
+            .unwrap();
+
+        let result = crate::helpers::rocksdb::migrate_finalize_history(
+            storage.mapping_update_heights_map(),
+            storage.mapping_update_map(),
+        );
+        assert!(result.is_err(), "migration must not silently drop missing history");
+    }
+
+    /// Verifies both populations that share the heights map: many keys with short histories,
+    /// and a few keys with long ones. A design tuned for only one of them fails the other.
+    #[test]
+    #[cfg(all(feature = "rocks", feature = "history"))]
+    fn test_migrate_legacy_history_mixed_population() {
+        let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+        let mapping_name = Identifier::from_str("account").unwrap();
+
+        let storage = rocks_store();
+        storage.current_block_height().store(u32::MAX - 1, Ordering::SeqCst);
+
+        // Many keys, a couple of heights each.
+        let mut shallow = Vec::new();
+        for index in 0..200u32 {
+            let key = Plaintext::from_str(&format!("{index}field")).unwrap();
+            let updates = vec![
+                (index + 1, Value::from_str(&format!("{index}u64")).unwrap()),
+                (index + 500, Value::from_str(&format!("{}u64", index + 1)).unwrap()),
+            ];
+            seed_legacy_key(&storage, program_id, mapping_name, &key, &updates);
+            shallow.push((key, updates));
+        }
+
+        // A few keys with histories long enough to span several write batches.
+        let mut deep = Vec::new();
+        for index in 0..3u32 {
+            // Numerically distinct from the shallow keys above; a field literal must be numeric.
+            let key = Plaintext::from_str(&format!("{}field", 1_000_000 + index)).unwrap();
+            let updates = (0..5_000u32)
+                .map(|i| (i * 2 + 1, Value::from_str(&format!("{}u64", i % 97)).unwrap()))
+                .collect::<Vec<_>>();
+            seed_legacy_key(&storage, program_id, mapping_name, &key, &updates);
+            deep.push((key, updates));
+        }
+
+        let stats = migrate(&storage);
+        assert_eq!(stats.keys, 203);
+        assert_eq!(stats.entries, 200 * 2 + 3 * 5_000);
+        assert_eq!(storage.mapping_update_heights_map().iter_confirmed().count(), 0);
+
+        let store = FinalizeStore::from(storage).unwrap();
+        for (key, updates) in shallow.iter().chain(deep.iter()) {
+            assert_matches_oracle(&store, program_id, mapping_name, key, updates);
+        }
     }
 }


### PR DESCRIPTION
Draft. An alternative to the migration in #3348, working on raw bytes rather than through the typed `Map` API. Opened for discussion alongside the findings write-up.

## Why raw bytes

A `MappingUpdateMap` key is `(ProgramID, Identifier, Plaintext, HeightBytes)` behind a 4-byte `[network_id, map_id]` context. `HeightBytes` is `[u8; 4]`, which bincode writes bare with no length prefix, and it is the last tuple field — so **the height is the final four bytes of the raw key, and the migration is a suffix byte-reversal that leaves the value bytes untouched.**

Going through the typed API instead deserializes a `Plaintext` and a `Value<N>` per entry and re-serializes both to identical bytes. Measured, that round-trip costs ~4.1 KB of peak RSS per entry, linear:

| entries | #3348 peak RSS | this branch | #3348 rate | this branch |
|---:|---:|---:|---:|---:|
| 111,750 | 0.42 GiB | 0.032 GiB | 71k/s | 454k/s |
| 894,000 | 3.45 GiB | 0.055 GiB | 108k/s | 339k/s |
| 1,788,000 | — | 0.076 GiB | — | 253k/s |

Flat rather than linear — 30–90 MB regardless of depth. Extrapolated to a ~7.7-month archive node (2.9B entries): **~3.2 h and ~0.1 GiB**, against ~10.9 TiB for the typed approach. That matters because `credits.aleo`'s `bonded`/`delegated`/`committee` are rewritten in full by `replace_mapping` on every block, so ~507 keys accrue one history entry each per block — and 507 < `MIGRATION_BATCH_SIZE`, so batching never splits them.

Other differences: a forward cursor (so a pass skips one tombstone rather than every tombstone left by previous passes), bounded chunks, and collision handling that preserves the property `38b02d3df` established without needing a key's whole history in memory.

## Review history

An adversarial review of the first commit found two defects, both since fixed in `ab9e5b8df`. Recording them because the second one shaped the design:

1. **Resume transposed byte-reversal pairs (critical).** The colliding write batch and the heights-row deletion were separate writes, so an interruption between them left every entry moved with the row still listing it; the resumed run read each height back through its partner's destination and transposed the pair, silently, for ~109,100 entries on one staking key at today's tip.
2. **The colliding subset was unchunked.** It is not "a few" entries — for a key written every block it is `#{h <= H : byte_reverse(h) <= H}`, growing as `H^2/2^24`: 109,100 at tip 21.6M, 1,048,578 by tip 67M, previously all held in memory at once.

Both are fixed by the same change: each colliding batch shrinks the heights row to the heights it has **not** yet moved, in the same atomic write, and batches pack whole partner groups. The only states a crash can leave are "batch not applied, row unchanged" and "batch applied, row already shortened", so a resumed run is never offered a height it has already migrated.

**One caveat worth a reviewer's attention.** That fix removes the *window*, not the *ambiguity*: a migrated colliding entry is byte-identical to its partner's un-migrated source, so a database placed in the old intermediate state by other means would still be transposed. I argue it is unreachable — `WriteBatch` is atomic, and the only code that could produce that state is the first commit on this branch, which was never released. The repro was updated to exercise the reachable state instead. If that reasoning is too thin, the alternative is a defensive check, and I could not find one that works from the data alone.

## A related finding this PR does not fix

`test_migration_exposes_unlisted_entries_as_wrong_heights` is committed and `#[ignore]`d, because it documents a constraint on **any** heights-row-driven migration rather than a bug in this branch.

snarkOS v4.7.5 and v4.8.0 (snarkVM `a108e8159`..`58a1359ea`) wrote little-endian history entries while writing **no** heights rows. Those entries are invisible to a migration driven by the heights row, and they survive it — where an unlisted entry at height `h` is byte-identical to a migrated entry at `byte_reverse(h)`, a floor seek finds it. A read that was **correct** before the migration returns a value from an unrelated height after it.

A fully correct migration has to enumerate what is actually under each key prefix and classify by encoding, rather than trusting the heights row as an inventory. That is tractable — heights are ≤ ~21.6M < 2^25, so an LE height read as BE almost always exceeds the chain tip — but it is a design change, not a patch.

The same gap causes #3323 to misread that data on v4.8.1+ today, independently of any migration. That is covered in the findings write-up rather than here.

## Verification

`cargo test -p snarkvm-ledger-store --features history,rocks` — **127 passed, 0 failed, 6 ignored.**

`adv_bincode_height_suffix_holds_for_every_plaintext` is deliberately active: it checks the assumption the whole approach rests on, over 396 combinations covering every literal type, nested structs and arrays, and both encodings.

This branch also deletes `test_get_historical_mapping_value_legacy`, since it asserts the legacy read path that this change removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhrVwfiKhGgcRQXUTZfC5p