### PR TITLE
test(curves): assert every serialized curve point deserializes back

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,6 +3596,7 @@ version = "4.9.0"
 dependencies = [
  "bincode",
  "criterion",
+ "proptest",
  "rand 0.10.2",
  "rustc_version",
  "serde",

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -57,6 +57,9 @@ workspace = true
 [dev-dependencies.criterion]
 workspace = true
 
+[dev-dependencies.proptest]
+workspace = true
+
 [dev-dependencies.rand]
 workspace = true
 

--- a/curves/src/bls12_377/tests.rs
+++ b/curves/src/bls12_377/tests.rs
@@ -647,6 +647,11 @@ fn test_g1_projective_group() {
 }
 
 #[test]
+fn test_g1_serialization_round_trip() {
+    serialization_round_trip_test::<G1Affine>();
+}
+
+#[test]
 fn test_g1_generator() {
     let generator = G1Affine::prime_subgroup_generator();
     assert!(generator.is_on_curve());
@@ -668,6 +673,11 @@ fn test_g2_projective_group() {
     let a: G2Projective = rng.random();
     let b: G2Projective = rng.random();
     projective_test(a, b, &mut rng);
+}
+
+#[test]
+fn test_g2_serialization_round_trip() {
+    serialization_round_trip_test::<G2Affine>();
 }
 
 #[test]

--- a/curves/src/edwards_bls12/tests.rs
+++ b/curves/src/edwards_bls12/tests.rs
@@ -87,6 +87,11 @@ fn test_affine_group() {
 }
 
 #[test]
+fn test_serialization_round_trip() {
+    serialization_round_trip_test::<EdwardsAffine>();
+}
+
+#[test]
 fn test_generator() {
     let generator = EdwardsAffine::prime_subgroup_generator();
     assert!(generator.is_on_curve());

--- a/curves/src/traits/tests_group.rs
+++ b/curves/src/traits/tests_group.rs
@@ -13,9 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use core::fmt::Debug;
+use std::io::Cursor;
+
+use proptest::{prelude::any, test_runner::TestRunner};
+
 use crate::{AffineCurve, ProjectiveCurve};
-use snarkvm_fields::{One, Zero};
-use snarkvm_utilities::rand::{TestRng, Uniform};
+use snarkvm_fields::{One, PrimeField, Zero};
+use snarkvm_utilities::{
+    Compress,
+    Validate,
+    rand::{TestRng, Uniform},
+    serialize::{CanonicalDeserialize, CanonicalSerialize},
+};
 
 #[allow(clippy::eq_op)]
 pub fn affine_test<G: AffineCurve>(a: G) {
@@ -89,4 +99,105 @@ pub fn projective_test<G: ProjectiveCurve>(a: G, mut b: G, rng: &mut TestRng) {
     assert_eq!(a_rand1.mul(fr_rand2), a_rand2.mul(fr_rand1), "(a * r1) * r2 != (a * r2) * r1");
     assert_eq!(a_rand2.mul(fr_rand1), a.mul(fr_rand1 * fr_rand2), "(a * r2) * r1 != a * (r1 * r2)");
     assert_eq!(a_rand1.mul(fr_rand2), a.mul(fr_rand1 * fr_rand2), "(a * r1) * r2 != a * (r1 * r2)");
+}
+
+/// Every combination of `Compress` and `Validate` that a caller can ask for.
+///
+/// Neither enum implements `Debug`, so each mode carries the name it is reported
+/// under when an assertion below fails.
+const SERIALIZATION_MODES: [(Compress, Validate, &str); 4] = [
+    (Compress::Yes, Validate::Yes, "Compress::Yes, Validate::Yes"),
+    (Compress::Yes, Validate::No, "Compress::Yes, Validate::No"),
+    (Compress::No, Validate::Yes, "Compress::No, Validate::Yes"),
+    (Compress::No, Validate::No, "Compress::No, Validate::No"),
+];
+
+/// Asserts that `value` survives serialization followed by deserialization
+/// unchanged, in every mode, and that `serialized_size` agrees with the number
+/// of bytes actually written.
+///
+/// `label` identifies the point in the failure message; a shrunk proptest case
+/// reports a scalar, and the degenerate cases report a name.
+fn assert_round_trips<T>(value: &T, label: &str)
+where
+    T: CanonicalSerialize + CanonicalDeserialize + Eq + Debug,
+{
+    for (compress, validate, mode) in SERIALIZATION_MODES {
+        let claimed_size = value.serialized_size(compress);
+        let mut bytes = Vec::with_capacity(claimed_size);
+        value
+            .serialize_with_mode(&mut bytes, compress)
+            .unwrap_or_else(|e| panic!("{label}: serialization failed ({mode}): {e:?}"));
+
+        assert_eq!(
+            bytes.len(),
+            claimed_size,
+            "{label}: serialized_size reported {claimed_size} bytes ({mode}), but {} were written",
+            bytes.len()
+        );
+
+        let recovered = T::deserialize_with_mode(&mut Cursor::new(&bytes[..]), compress, validate)
+            .unwrap_or_else(|e| panic!("{label}: the deserializer rejected this library's own output ({mode}): {e:?}"));
+
+        assert_eq!(&recovered, value, "{label}: round trip changed the value ({mode})");
+    }
+}
+
+/// Asserts that a point round trips in both its affine and its projective form.
+fn assert_point_round_trips<G: AffineCurve>(point: G, label: &str) {
+    assert_round_trips(&point, &format!("{label} (affine)"));
+    assert_round_trips(&point.to_projective(), &format!("{label} (projective)"));
+}
+
+/// Serializing a curve point and deserializing the result must return that same
+/// point, for every point the serializer accepts and every mode the caller can
+/// ask for.
+///
+/// Every point covered here is in the prime-order subgroup, which is what
+/// `Validate::Yes` admits. On-curve points outside it -- the order-2 and
+/// order-4 points, whose coordinates include a zero -- do not all round trip
+/// today, so extending this harness to cover them fails until the compressed
+/// deserializers stop discarding the sign flag for those coordinates.
+pub fn serialization_round_trip_test<G: AffineCurve>() {
+    degenerate_serialization_round_trip_test::<G>();
+
+    let mut runner = TestRunner::deterministic();
+    runner
+        .run(&any::<[u8; 32]>(), |seed| {
+            let scalar = G::ScalarField::from_bytes_le_mod_order(&seed);
+            assert_point_round_trips((G::prime_subgroup_generator() * scalar).to_affine(), &format!("{scalar}"));
+            Ok(())
+        })
+        .unwrap();
+}
+
+/// The points a random scalar will not produce in any practical number of runs.
+///
+/// The identity is the one that matters most: it is the only point whose
+/// coordinates carry no information, so it is the point whose encoding a
+/// canonicality check is most likely to tighten, and a random scalar reaches it
+/// with probability `1/r`.
+fn degenerate_serialization_round_trip_test<G: AffineCurve>() {
+    let generator = G::prime_subgroup_generator();
+
+    assert_point_round_trips(G::zero(), "identity");
+    assert_point_round_trips(generator, "generator");
+    assert_point_round_trips(-generator, "negated generator");
+
+    // Small multiples, which shrinking drives towards and which a proptest seed
+    // of 32 random bytes will not otherwise produce.
+    let mut multiple = G::Projective::zero();
+    for i in 0..8u8 {
+        assert_point_round_trips(multiple.to_affine(), &format!("generator * {i}"));
+        multiple.add_assign_mixed(&generator);
+    }
+
+    // The largest scalar, reached from the other end of the field.
+    assert_point_round_trips((generator * (-G::ScalarField::one())).to_affine(), "generator * (r - 1)");
+
+    // A projective point that has not been normalized takes a different path
+    // through serialization than one that has.
+    let unnormalized = generator.to_projective().double();
+    assert!(!unnormalized.is_normalized(), "the doubled generator was expected to be unnormalized");
+    assert_round_trips(&unnormalized, "unnormalized projective");
 }


### PR DESCRIPTION
## Motivation

#3397 tightened the compressed Short Weierstrass deserializer so that a set
infinity flag with a non-zero x-coordinate is rejected. While sweeping for the
same problem elsewhere, we came close to merging the analogous tightening of the
*uncompressed* deserializer — and that one would have broken the library's
ability to read back what it had just written.

The uncompressed serializer emits the identity as `x = 0`, `y = 1` with the
infinity flag set:

https://github.com/ProvableHQ/snarkVM/blob/70ac1ff8b/curves/src/templates/macros.rs#L86-L95

So a check requiring both coordinates to be zero when the flag is set rejects
our own output, for the single most common point there is.

Nothing in the test suite would have caught that. There was no assertion
anywhere that the identity survives a serialization round trip, and no
serialization coverage at all for the projective types, which carry their own
`CanonicalSerialize` and `CanonicalDeserialize` impls.

## What this adds

`serialization_round_trip_test` in `curves/src/traits/tests_group.rs`, generic
over `AffineCurve` so one harness covers BLS12-377 G1, BLS12-377 G2 and
Edwards BLS12 rather than a single curve. For each point it asserts:

- serialize followed by deserialize returns an equal value, across all four
  `Compress` × `Validate` combinations;
- the property holds in both affine and projective form;
- `serialized_size` agrees with the number of bytes actually written.

The random half is a `proptest` over a 32-byte scalar seed, run through a
`TestRunner` so it stays generic over the curve.

**The half that does the real work is the explicit degenerate table.** Every bug
of this shape lives on a point that a random scalar reaches with probability
around 2^-250 — the identity above is the clearest case. Random sampling alone
would not have caught the patch we nearly merged, and would not catch the next
one either. The table covers the identity, the small multiples, `r - 1`, and a
projective point that has not been normalized.

## Test Plan

Reapplying the strict-uncompressed patch described above turns G1 and G2 red,
naming the point and the mode:

```
test bls12_377::tests::test_g1_serialization_round_trip ... FAILED
test bls12_377::tests::test_g2_serialization_round_trip ... FAILED

identity (affine): the deserializer rejected this library's own output
  (Compress::No, Validate::Yes): InvalidData
```

Removing the mutation returns the suite to green: 65 passed in
`snarkvm-curves`, with `cargo clippy -p snarkvm-curves --all-targets --
-D warnings` and `cargo +nightly fmt --check` clean.

## Scope

The harness is deliberately restricted to prime-order-subgroup points, which is
what `Validate::Yes` admits. On-curve points *outside* the subgroup — the
order-2 and order-4 points, whose coordinates include a zero — do not all round
trip today, so widening the harness to cover them fails on the current tree. A
doc comment on the entry point records this so the next person does not walk
into it. Those cases, and the canonicality gaps they expose, are a separate
follow-up.

## Backwards compatibility

Test-only. No runtime code changes, so no consensus impact. The single
non-test change is a `proptest` dev-dependency on `snarkvm-curves`, taken from
the existing workspace pin (`=1.6`, already in `Cargo.lock` via
`ledger/committee`); `Cargo.lock` gains one line and no new transitive crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qb8dzi6WAXBSCeyEkpBvrc
