### PR TITLE
fix(deps): update past the yanked chacha20 and wnaf releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,9 +450,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5108,13 +5108,14 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wnaf"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+checksum = "795ca18b3fdb5e62bf982199278341ddcf7ebf7d32e25e212ad05d496e95f6fa"
 dependencies = [
  "ff",
  "group",
  "hybrid-array",
+ "primefield",
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation

`cargo audit -D warnings` fails on `staging` right now, and has done since these
two releases were yanked from crates.io:

```
Crate:     chacha20     Version: 0.10.1     Warning: yanked
Crate:     wnaf         Version: 0.14.0     Warning: yanked
error: 2 denied warnings found!
```

Neither is a security advisory. The lockfile just pins versions that no longer
exist as far as the registry is concerned, and `check-cargo-audit` runs with
`-D warnings`, which turns a yank into a failure.

Worth being explicit about why this appeared out of nowhere: **a yank is a
registry-side event.** No commit to this repository caused it, and rebasing does
not help, because the yanked versions are what `staging` itself carries. That is
also why it fails every open PR rather than any particular one.

## What changed

`cargo update -p chacha20 -p wnaf`, and nothing else. Both successors are
semver-compatible, so there are no manifest changes and no source changes:

- `chacha20` 0.10.1 → 0.10.2, reached through `rand`
- `wnaf` 0.14.0 → 0.14.1, reached through `k256` → `snarkvm-console-algorithms`

`wnaf` 0.14.1 declares `primefield`, which the lockfile already carries, so the
dependency graph gains no new package. The diff is 5 lines.

## Test Plan

On this branch:

```
$ cargo audit -D warnings
    Scanning Cargo.lock for vulnerabilities (502 crate dependencies)
$ echo $?
0
```

and `cargo check --workspace --all-targets --all-features` still passes, as does
the pre-commit hook (`cargo clippy --workspace --all-targets --all-features --
-D warnings` plus `cargo fmt --check`).

## Notes for reviewers

`chacha20` 0.10.2 is already in use on snarkVM's `testnet` branch and in
snarkOS; this brings `staging` in line with both.

`wnaf` has **not** been updated on any branch yet, and is on its own why
`testnet` and #3404 still fail audit — #3404 already carries the newer
`chacha20` and its audit failure is `wnaf` alone:

```
Crate: wnaf  Version: 0.14.0  Warning: yanked
error: 1 denied warning found!
```

So this unblocks the other open PRs too, once they pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qb8dzi6WAXBSCeyEkpBvrc
