### PR TITLE
hardening(curve): consult the sign flag when deserializing x = 0 on Edwards

### DIFF
--- a/curves/src/templates/macros.rs
+++ b/curves/src/templates/macros.rs
@@ -248,11 +248,12 @@ macro_rules! impl_edwards_curve_serializer {
                 let point = if let Compress::Yes = compress {
                     let (x, flags): (P::BaseField, EdwardsFlags) = P::BaseField::deserialize_with_flags(&mut reader)?;
 
-                    if x == P::BaseField::zero() {
-                        Self::zero()
-                    } else {
-                        Affine::<P>::from_x_coordinate(x, flags.is_positive()).ok_or(SerializationError::InvalidData)?
-                    }
+                    // The flag names the sign of y, and it is consulted at every
+                    // x. At x = 0 it is the only thing separating the identity
+                    // (0, 1) from the order-two point (0, -1); reading the
+                    // identity out of x = 0 without looking at the flag would
+                    // give the identity a second encoding.
+                    Affine::<P>::from_x_coordinate(x, flags.is_positive()).ok_or(SerializationError::InvalidData)?
                 } else {
                     let x = P::BaseField::deserialize_uncompressed(&mut reader)?;
                     let y = P::BaseField::deserialize_uncompressed(&mut reader)?;

--- a/curves/src/templates/twisted_edwards_extended/tests.rs
+++ b/curves/src/templates/twisted_edwards_extended/tests.rs
@@ -53,6 +53,88 @@ where
     edwards_curve_serialization_test::<P>(rng);
     edwards_from_random_bytes::<P>(rng);
     edwards_from_x_and_y_coordinates::<P>(rng);
+    edwards_non_canonical_identity_is_rejected::<P>();
+    edwards_order_two_point_round_trips::<P>();
+}
+
+/// Returns `(0, -1)`, the order-two point.
+///
+/// `x = 0` gives `y^2 = 1` on every twisted Edwards curve, so this point and the
+/// identity `(0, 1)` are the two solutions there, and both are on the curve.
+fn order_two_point<P: TwistedEdwardsParameters>() -> Affine<P> {
+    Affine::<P>::new(P::BaseField::zero(), -P::BaseField::one(), P::BaseField::zero())
+}
+
+/// The identity must have exactly one compressed encoding.
+///
+/// A compressed encoding carries `x` plus a flag naming the sign of `y`. At
+/// `x = 0` the flag is the only thing separating the identity from
+/// [`order_two_point`], so a deserializer that ignores it there gives the
+/// identity two spellings, and anything that hashes those bytes disagrees with
+/// anything that hashes a re-serialization.
+///
+/// This is the twisted Edwards counterpart of
+/// `sw_non_canonical_infinity_is_rejected`.
+pub fn edwards_non_canonical_identity_is_rejected<P: TwistedEdwardsParameters>() {
+    // The canonical identity encoding: x = 0 carrying the default flag.
+    let mut canonical = Vec::new();
+    Affine::<P>::zero().serialize_with_mode(&mut canonical, Compress::Yes).unwrap();
+
+    // The same x with the opposite flag, which lives in the high bit of the
+    // last byte. This names (0, -1), not the identity.
+    let mut non_canonical = canonical.clone();
+    let last = non_canonical.len() - 1;
+    non_canonical[last] ^= 1 << 7;
+    assert_ne!(non_canonical, canonical);
+
+    // Validate does not implement Debug, and the mode matters to the report:
+    // the identity is in the prime-order subgroup, so this must be settled by
+    // the encoding rather than by the subgroup check.
+    for (validate, mode) in [(Validate::Yes, "Validate::Yes"), (Validate::No, "Validate::No")] {
+        // The canonical encoding must keep working. A fix that rejected both
+        // would break every serialized identity in existence, and that should
+        // fail loudly rather than pass quietly.
+        let point = Affine::<P>::deserialize_with_mode(Cursor::new(&canonical[..]), Compress::Yes, validate).unwrap();
+        assert!(point.is_zero(), "the canonical identity encoding must still deserialize ({mode})");
+
+        // The flag-set encoding may be rejected, or may decode to (0, -1). What
+        // it must never be is a second way to write the identity.
+        if let Ok(point) = Affine::<P>::deserialize_with_mode(Cursor::new(&non_canonical[..]), Compress::Yes, validate)
+        {
+            assert!(
+                !point.is_zero(),
+                "a non-canonical identity encoding was accepted ({mode}).\n\
+                 The encodings differ only in the flag byte, {:#04x} against the canonical {:#04x},\n\
+                 so those are two ways to write one value.",
+                non_canonical[last],
+                canonical[last],
+            );
+        }
+    }
+}
+
+/// The serializer accepts [`order_two_point`], so the deserializer must return
+/// it unchanged.
+///
+/// It sits outside the prime-order subgroup, so `Validate::Yes` rejects it by
+/// design; the round trip is asserted under `Validate::No`, where the subgroup
+/// check is not what is being measured.
+pub fn edwards_order_two_point_round_trips<P: TwistedEdwardsParameters>() {
+    let order_two = order_two_point::<P>();
+    assert!(order_two.is_on_curve(), "(0, -1) must be on the curve");
+    assert!(!order_two.is_zero(), "(0, -1) must be distinct from the identity");
+    assert!(
+        !order_two.is_in_correct_subgroup_assuming_on_curve(),
+        "(0, -1) has order two, so it must be outside the prime-order subgroup"
+    );
+
+    for (compress, mode) in [(Compress::Yes, "Compress::Yes"), (Compress::No, "Compress::No")] {
+        let mut bytes = Vec::new();
+        order_two.serialize_with_mode(&mut bytes, compress).unwrap();
+
+        let recovered = Affine::<P>::deserialize_with_mode(Cursor::new(&bytes[..]), compress, Validate::No).unwrap();
+        assert_eq!(recovered, order_two, "(0, -1) did not survive a round trip ({mode})");
+    }
 }
 
 pub fn edwards_curve_serialization_test<P: TwistedEdwardsParameters>(rng: &mut TestRng) {

--- a/curves/src/traits/tests_group.rs
+++ b/curves/src/traits/tests_group.rs
@@ -153,11 +153,11 @@ fn assert_point_round_trips<G: AffineCurve>(point: G, label: &str) {
 /// point, for every point the serializer accepts and every mode the caller can
 /// ask for.
 ///
-/// Every point covered here is in the prime-order subgroup, which is what
-/// `Validate::Yes` admits. On-curve points outside it -- the order-2 and
-/// order-4 points, whose coordinates include a zero -- do not all round trip
-/// today, so extending this harness to cover them fails until the compressed
-/// deserializers stop discarding the sign flag for those coordinates.
+/// Every point covered here is in the prime-order subgroup. Each round trip is
+/// asserted under `Validate::Yes` as well as `Validate::No`, and `Validate::Yes`
+/// rejects anything outside the subgroup, so the order-2 and order-4 points
+/// cannot be driven through this harness. The per-curve-family harnesses cover
+/// them instead, under `Validate::No`.
 pub fn serialization_round_trip_test<G: AffineCurve>() {
     degenerate_serialization_round_trip_test::<G>();
 


### PR DESCRIPTION
Split out of #3407, which bundled this with a Short Weierstrass fix that needs its own backwards-compatibility argument. That half is #3422.

## The bug

A compressed twisted Edwards encoding is `x` plus a flag naming the sign of `y`. At `x = 0`, `y^2 = 1` has two solutions: the identity `(0, 1)` and the order-two point `(0, -1)`. The deserializer special-cased `x = 0` and returned the identity without ever reading the flag.

So the identity had two accepted encodings, and `(0, -1)` deserialized to the identity instead of to itself — a silently wrong value rather than an error. `Validate::Yes` catches neither: the identity is in the prime-order subgroup, and `(0, -1)` had already been replaced by the time the subgroup check ran.

## The fix

Delete the special case. `from_x_coordinate(0, greatest)` already returns `(0, 1)` for a clear flag and `(0, -1)` for a set one, so it was redundant as well as wrong. There is no `x` for which this newly returns `None`.

## Backwards compatibility

**No consensus object is encoded with this macro, so no historical bytes change meaning.** Aleo `group` values — every `Address`, record `nonce` and `group` literal — are encoded as the bare affine x-coordinate via `Group`'s `ToBytes`, with no flag byte, and decoded via `Group::from_x_coordinate`, which subgroup-checks the two candidates. `Group` has no `CanonicalSerialize` impl, no type deriving `CanonicalSerialize` holds a twisted Edwards point, and every `deserialize_compressed` call site in the repo is a Varuna or KZG structure over the pairing curve.

Within the library the encoder is unchanged and only ever emitted the clear flag at `x = 0`, so everything it has produced still decodes to the same point. Only the flag-set spelling changes meaning, and it was never emitted.

@Antonio95 asked for that last claim to be checked rather than asserted:

```sh
git log --oneline -S 'mask |= 1 << 7' -- utilities/src/serialize/flags.rs
git log --oneline -S 'if x == P::BaseField::zero()' -- curves/src/templates/macros.rs
git log --oneline -S 'EdwardsFlags::from_y_sign' -- curves/src/templates/macros.rs
```

Each returns exactly one commit: `2e1312c12`, the initial commit. Bit layout, special case and writer are unchanged since the repository began.

The only commit that ever changed decoder behaviour is `e8ef1d2db` (May 2022), which narrowed `SWFlags::from_u8` from `(_, true) => Infinity` to `(true, true) => None`, commented *"we only want **one** way to serialize the point at infinity"*. Decoder narrowed, encoder untouched — the same move as this PR and as #3397.

## Tests

Two tests in the generic `edwards_test<P>` harness, so they cover every twisted Edwards curve. Both written first, both fail on an unfixed tree.

- `edwards_non_canonical_identity_is_rejected` — asserts the canonical encoding still deserializes *first*, so a fix that rejected both would fail loudly rather than pass quietly; then that the flag-set encoding is not a second spelling of the identity. Runs under `Validate::No` as well, since the rejection must come from the encoding rather than the subgroup check.
- `edwards_order_two_point_round_trips` — the round-trip failure directly, both compression modes, under `Validate::No`.

Also corrects a doc comment from #3405 that this fix makes false.

`cargo test -p snarkvm-curves`: 65 passed, 0 failed.

## Left alone

The order-four points `(±i, 0)` accept either flag for the same reason. Not consensus-reachable, and `Validate::Yes` rejects them anyway for being outside the prime-order subgroup.
