### PR TITLE
fix(program): reject trailing bytes inside length-delimited sub-objects

### DIFF
--- a/console/program/src/data/future/bytes.rs
+++ b/console/program/src/data/future/bytes.rs
@@ -53,8 +53,18 @@ impl<N: Network> Future<N> {
             // Read the argument bytes.
             let mut bytes = Vec::new();
             (&mut reader).take(num_bytes as u64).read_to_end(&mut bytes)?;
+            // Ensure the declared region is entirely present.
+            if bytes.len() != num_bytes as usize {
+                return Err(error("Failed to read future: argument is truncated"));
+            }
             // Recover the argument.
-            let entry = Argument::read_le_internal(&mut bytes.as_slice(), depth)?;
+            let mut slice = bytes.as_slice();
+            let entry = Argument::read_le_internal(&mut slice, depth)?;
+            // Ensure the argument fills its region. Bytes left unread would be dropped
+            // on re-serialization, giving one value a second encoding.
+            if !slice.is_empty() {
+                return Err(error("Failed to read future: argument has trailing bytes"));
+            }
             // Add the argument.
             arguments.push(entry);
         }
@@ -351,5 +361,42 @@ mod tests {
             run_test(i, create_nested_future(i), i > CurrentNetwork::MAX_DATA_DEPTH);
             run_test(i, create_nested_future(i), i > CurrentNetwork::MAX_DATA_DEPTH);
         }
+    }
+
+    /// Builds the encoding of a one-argument future, declaring `padding` more bytes
+    /// for the argument than the argument actually occupies.
+    fn future_with_padded_argument(padding: usize) -> Result<Vec<u8>> {
+        let argument = Argument::<CurrentNetwork>::Plaintext(Plaintext::from_str("7u8")?);
+        let argument_bytes = argument.to_bytes_le()?;
+
+        let mut bytes = Vec::new();
+        ProgramID::<CurrentNetwork>::from_str("credits.aleo")?.write_le(&mut bytes)?;
+        Identifier::<CurrentNetwork>::from_str("transfer")?.write_le(&mut bytes)?;
+        1u8.write_le(&mut bytes)?;
+        u16::try_from(argument_bytes.len() + padding)?.write_le(&mut bytes)?;
+        bytes.extend_from_slice(&argument_bytes);
+        bytes.extend(std::iter::repeat_n(0u8, padding));
+        Ok(bytes)
+    }
+
+    #[test]
+    fn test_future_argument_rejects_trailing_bytes() -> Result<()> {
+        // Unpadded, this is the encoding `to_bytes_le` produces, and it must keep working.
+        let exact = future_with_padded_argument(0)?;
+        let future = Future::<CurrentNetwork>::read_le(&exact[..])?;
+        assert_eq!(exact, future.to_bytes_le()?, "the unpadded encoding must round trip");
+
+        // An argument region larger than the argument fills leaves bytes unread.
+        // Accepting it gives one future -- and so one transaction -- a second
+        // encoding, since re-serializing emits the exact length.
+        for padding in [1, 8, 32] {
+            let padded = future_with_padded_argument(padding)?;
+            assert_ne!(padded, exact);
+            assert!(
+                Future::<CurrentNetwork>::read_le(&padded[..]).is_err(),
+                "a future argument declaring {padding} bytes more than it uses must be rejected"
+            );
+        }
+        Ok(())
     }
 }

--- a/console/program/src/data/plaintext/bytes.rs
+++ b/console/program/src/data/plaintext/bytes.rs
@@ -50,8 +50,18 @@ impl<N: Network> Plaintext<N> {
                     // Read the plaintext bytes.
                     let mut bytes = Vec::new();
                     (&mut reader).take(num_bytes as u64).read_to_end(&mut bytes)?;
+                    // Ensure the declared region is entirely present.
+                    if bytes.len() != num_bytes as usize {
+                        return Err(error("Failed to deserialize plaintext: struct member is truncated"));
+                    }
                     // Recover the plaintext value.
-                    let plaintext = Self::read_le_internal(&mut bytes.as_slice(), depth + 1)?;
+                    let mut slice = bytes.as_slice();
+                    let plaintext = Self::read_le_internal(&mut slice, depth + 1)?;
+                    // Ensure the member fills its region. Bytes left unread would be
+                    // dropped on re-serialization, giving one value a second encoding.
+                    if !slice.is_empty() {
+                        return Err(error("Failed to deserialize plaintext: struct member has trailing bytes"));
+                    }
                     // Add the member.
                     members.insert(identifier, plaintext);
                 }
@@ -72,8 +82,18 @@ impl<N: Network> Plaintext<N> {
                     // Read the plaintext bytes.
                     let mut bytes = Vec::new();
                     (&mut reader).take(num_bytes as u64).read_to_end(&mut bytes)?;
+                    // Ensure the declared region is entirely present.
+                    if bytes.len() != num_bytes as usize {
+                        return Err(error("Failed to deserialize plaintext: array element is truncated"));
+                    }
                     // Recover the plaintext value.
-                    let plaintext = Self::read_le_internal(&mut bytes.as_slice(), depth + 1)?;
+                    let mut slice = bytes.as_slice();
+                    let plaintext = Self::read_le_internal(&mut slice, depth + 1)?;
+                    // Ensure the element fills its region. Bytes left unread would be
+                    // dropped on re-serialization, giving one value a second encoding.
+                    if !slice.is_empty() {
+                        return Err(error("Failed to deserialize plaintext: array element has trailing bytes"));
+                    }
                     // Add the element.
                     elements.push(plaintext);
                 }
@@ -408,5 +428,74 @@ mod tests {
             run_test(i, create_alternated_nested(i, "0u128"), i > CurrentNetwork::MAX_DATA_DEPTH);
             run_test(i, create_alternated_nested(i, "10field"), i > CurrentNetwork::MAX_DATA_DEPTH);
         }
+    }
+
+    /// Builds the encoding of a one-member struct, declaring `padding` more bytes
+    /// for the member than the member actually occupies.
+    fn struct_with_padded_member(padding: usize) -> Result<Vec<u8>> {
+        let member = Plaintext::<CurrentNetwork>::Literal(Literal::U8(U8::new(7)), Default::default());
+        let member_bytes = member.to_bytes_le()?;
+
+        let mut bytes = Vec::new();
+        1u8.write_le(&mut bytes)?;
+        1u8.write_le(&mut bytes)?;
+        Identifier::<CurrentNetwork>::from_str("a")?.write_le(&mut bytes)?;
+        u16::try_from(member_bytes.len() + padding)?.write_le(&mut bytes)?;
+        bytes.extend_from_slice(&member_bytes);
+        bytes.extend(std::iter::repeat_n(0u8, padding));
+        Ok(bytes)
+    }
+
+    /// Builds the encoding of a one-element array, declaring `padding` more bytes
+    /// for the element than the element actually occupies.
+    fn array_with_padded_element(padding: usize) -> Result<Vec<u8>> {
+        let element = Plaintext::<CurrentNetwork>::Literal(Literal::U8(U8::new(7)), Default::default());
+        let element_bytes = element.to_bytes_le()?;
+
+        let mut bytes = Vec::new();
+        2u8.write_le(&mut bytes)?;
+        1u32.write_le(&mut bytes)?;
+        u16::try_from(element_bytes.len() + padding)?.write_le(&mut bytes)?;
+        bytes.extend_from_slice(&element_bytes);
+        bytes.extend(std::iter::repeat_n(0u8, padding));
+        Ok(bytes)
+    }
+
+    #[test]
+    fn test_struct_member_rejects_trailing_bytes() -> Result<()> {
+        // Unpadded, this is the encoding `to_bytes_le` produces, and it must keep working.
+        let exact = struct_with_padded_member(0)?;
+        let plaintext = Plaintext::<CurrentNetwork>::read_le(&exact[..])?;
+        assert_eq!(exact, plaintext.to_bytes_le()?, "the unpadded encoding must round trip");
+
+        // A member region larger than the member fills leaves bytes unread. Accepting
+        // it gives one value a second encoding, since re-serializing emits the exact
+        // length -- and two encodings of one transaction are two TransmissionIDs.
+        for padding in [1, 8, 32] {
+            let padded = struct_with_padded_member(padding)?;
+            assert_ne!(padded, exact);
+            assert!(
+                Plaintext::<CurrentNetwork>::read_le(&padded[..]).is_err(),
+                "a struct member declaring {padding} bytes more than it uses must be rejected"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_element_rejects_trailing_bytes() -> Result<()> {
+        let exact = array_with_padded_element(0)?;
+        let plaintext = Plaintext::<CurrentNetwork>::read_le(&exact[..])?;
+        assert_eq!(exact, plaintext.to_bytes_le()?, "the unpadded encoding must round trip");
+
+        for padding in [1, 8, 32] {
+            let padded = array_with_padded_element(padding)?;
+            assert_ne!(padded, exact);
+            assert!(
+                Plaintext::<CurrentNetwork>::read_le(&padded[..]).is_err(),
+                "an array element declaring {padding} bytes more than it uses must be rejected"
+            );
+        }
+        Ok(())
     }
 }

--- a/console/program/src/data/record/bytes.rs
+++ b/console/program/src/data/record/bytes.rs
@@ -47,8 +47,18 @@ impl<N: Network, Private: Visibility> FromBytes for Record<N, Private> {
             // Read the entry bytes.
             let mut bytes = Vec::new();
             (&mut reader).take(num_bytes as u64).read_to_end(&mut bytes)?;
+            // Ensure the declared region is entirely present.
+            if bytes.len() != num_bytes as usize {
+                return Err(error("Failed to read record: entry is truncated"));
+            }
             // Recover the entry value.
-            let entry = Entry::read_le(&mut bytes.as_slice())?;
+            let mut slice = bytes.as_slice();
+            let entry = Entry::read_le(&mut slice)?;
+            // Ensure the entry fills its region. Bytes left unread would be dropped on
+            // re-serialization, giving one value a second encoding.
+            if !slice.is_empty() {
+                return Err(error("Failed to read record: entry has trailing bytes"));
+            }
             // Add the entry.
             data.insert(identifier, entry);
         }
@@ -165,6 +175,40 @@ mod tests {
         // Check the byte representation.
         let expected_bytes = expected.to_bytes_le()?;
         assert_eq!(expected, Record::read_le(&expected_bytes[..])?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_record_entry_rejects_trailing_bytes() -> Result<()> {
+        let record = Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::from_str(
+            "{ owner: aleo1d5hg2z3ma00382pngntdp68e74zv54jdxy249qhaujhks9c72yrs33ddah.private, token_amount: 100u64.private, _nonce: 0group.public }",
+        )?;
+        let exact = record.to_bytes_le()?;
+        assert_eq!(record, Record::read_le(&exact[..])?);
+
+        // Locate the sole data entry by its own encoding: the two bytes in front of it
+        // are the `u16` that delimits its region.
+        let identifier = Identifier::<CurrentNetwork>::from_str("token_amount")?;
+        let entry_bytes = record.data().get(&identifier).expect("the record has this entry").to_bytes_le()?;
+        let at = exact
+            .windows(entry_bytes.len())
+            .position(|window| window == entry_bytes.as_slice())
+            .expect("the entry's bytes appear in the record's bytes");
+        assert!(at >= 2);
+        assert_eq!(u16::from_le_bytes([exact[at - 2], exact[at - 1]]) as usize, entry_bytes.len());
+
+        // Declaring more bytes for the entry than it occupies leaves bytes unread.
+        for padding in [1usize, 8, 32] {
+            let mut padded = exact.clone();
+            let declared = u16::try_from(entry_bytes.len() + padding)?;
+            padded[at - 2..at].copy_from_slice(&declared.to_le_bytes());
+            padded.splice(at + entry_bytes.len()..at + entry_bytes.len(), std::iter::repeat_n(0u8, padding));
+            assert_ne!(padded, exact);
+            assert!(
+                Record::<CurrentNetwork, Plaintext<CurrentNetwork>>::read_le(&padded[..]).is_err(),
+                "a record entry declaring {padding} bytes more than it uses must be rejected"
+            );
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

`Future`, `Plaintext` and `Record` all embed a sub-object in a `u16`-delimited
region. Every one of them reads the length, takes that many bytes, and parses the
sub-object out of them — without checking that the sub-object consumed the whole
region:

```rust
let num_bytes = u16::read_le(&mut reader)?;
let mut bytes = Vec::new();
(&mut reader).take(num_bytes as u64).read_to_end(&mut bytes)?;
let entry = Argument::read_le_internal(&mut bytes.as_slice(), depth)?;
```

Anything left over in that region is silently dropped. The writer emits the true
length:

```rust
let bytes = argument.to_bytes_le()?;
u16::try_from(bytes.len())?.write_le(&mut writer)?;
```

So a region can be inflated by up to 65,535 bytes of arbitrary padding and the
value still parses — to **the same value**, which then re-serializes shorter.

**One transaction, many byte encodings, one transaction ID.** Since a
`TransmissionID` is a hash of the transmitted bytes, that is two TransmissionIDs
for one transaction. Struct members and array elements nest, so the number of
encodings of a single transaction is combinatorial rather than merely large.

snarkVM already guards this at the top level — `deserialize_transaction_strict`
rejects trailing bytes after a transaction. The same guard is simply missing on
these inner regions.

## The four sites

| File | Region |
|---|---|
| `console/program/src/data/future/bytes.rs:55` | future argument |
| `console/program/src/data/plaintext/bytes.rs:52` | struct member |
| `console/program/src/data/plaintext/bytes.rs:74` | array element |
| `console/program/src/data/record/bytes.rs:49` | record entry |

Each gains two checks: the declared region must be entirely present, and the
sub-object must consume all of it.

The truncation check matters for the same reason as the trailing check. Without
it, a region declared longer than the remaining stream yields a short read, and
the value re-serializes with the true smaller length — the same divergence from
the other direction.

## How this was found

A fuzzing campaign on the re-encoding oracle: parse, re-encode, require byte
identity. Five artifacts, all at the future-argument site:

| artifact | declared | actual | delta |
|---|---|---|---|
| `04194fa1a3` | 35 | 3 | −32 |
| `3daf94a166` | 36 | 5 | −31 |
| `69ebd5da88` | 36 | 6 | −30 |
| `81a2b3ed9f` | 36 | 5 | −31 |
| `ad256562ac` | 36 | 3 | −33 |

Every delta is exactly `declared - actual`. Each artifact reports
`the re-encoded bytes parse again; same transaction id: true`.

The other three sites were then confirmed by construction rather than assumed —
each has a regression test that fails on an unpatched tree.

## Test plan

Four tests, one per site, each asserting the unpadded encoding still round trips
*before* asserting padded ones are rejected — so a fix that rejected both would
fail loudly rather than pass quietly.

On an unpatched tree all four fail:

```
a future argument declaring 1 bytes more than it uses must be rejected
a struct member declaring 1 bytes more than it uses must be rejected
an array element declaring 1 bytes more than it uses must be rejected
a record entry declaring 1 bytes more than it uses must be rejected
```

With the patch: 4 pass, and `snarkvm-console-program`'s full suite is 303
passed / 0 failed. Applied to the vendored tree, all five artifacts are rejected.

## Impact: a reachable commit stall, not only malleability

The padding survives `deserialize_transaction_strict`, because that check catches
trailing bytes only at the outermost level and this padding sits *inside* the
`u16` regions. That makes a second valid `(transaction_id, checksum)` pair
constructible, and a `TransmissionID` is exactly that pair — the checksum is
SHA3 over the raw transmitted bytes
(`ledger/narwhal/data/src/lib.rs:53-65`).

The consequence is worse than duplicate IDs. A byzantine validator can author a
batch header committing to `(id, padded_checksum)`:

1. Honest validators fetch the padded bytes and validate them. The transaction ID
   matches, and the checksum is computed on the still-padded buffer, so it
   matches too. They sign and certify the batch.
2. The transmission is then canonicalized — the padding is dropped *after* the
   checksum check.
3. At commit, `decouple_transmissions` asserts the canonical checksum equals the
   committed one. It does not. `prepare_advance_to_next_quorum_block` bails, and
   the leader cannot build the block.

This patch turns it into a clean rejection at parse time.

*(Traced by reading the path, not by executing it. A test driving a padded batch
header through to commit would confirm it, and is worth writing.)*

## Backwards compatibility

Compatible. Both sides were audited rather than assumed.

**Nothing on disk carries padding.** In snarkVM every persistence path
re-serializes from the parsed object: block storage decomposes into typed maps
(`FutureMap = Option<Future<N>>` and friends,
`ledger/store/src/transition/output.rs:38-53`), and RocksDB writes bincode over
`to_bytes_le()` (`ledger/store/src/helpers/rocksdb/internal/map.rs:87`). The one
place raw bytes are retained, `Data::Buffer`, is confined to narwhal
transmissions and never persisted. On the snarkOS side every producer
canonicalizes before writing; even the proposal cache, which genuinely round
trips bytes through a file, can only ever receive canonical ones.

**A padded encoding cannot already be on chain.** Block verification recomputes
the transmission checksum from the canonical re-serialization
(`ledger/block/src/verify.rs:631-640`), so a block including a padded
transmission fails verification on every node today. A syncing mainnet is
evidence none has been committed. The genesis block parses unchanged with this
patch applied.

**What does change is what a node accepts from a peer.** An old node would sign a
batch carrying a padded transmission where a new node would not. That
disagreement is only reachable by an adversary — no honest client emits padding,
since `to_bytes_le` cannot produce it — and under that same attack today the
batch is certified and then stalls at commit. Refusing it earlier is the better
failure, and it degrades toward the current behaviour rather than away from it.

