### PR TITLE
fix(narwhal): reject repeated entries in count-prefixed collections

### DIFF
--- a/ledger/narwhal/batch-certificate/src/bytes.rs
+++ b/ledger/narwhal/batch-certificate/src/bytes.rs
@@ -31,9 +31,15 @@ impl<N: Network> BatchCertificate<N> {
         let mut signature_bytes = vec![0u8; num_signatures as usize * Signature::<N>::size_in_bytes()];
         reader.read_exact(&mut signature_bytes)?;
         // Read the signatures.
-        cfg_chunks!(signature_bytes, Signature::<N>::size_in_bytes())
+        let signatures = cfg_chunks!(signature_bytes, Signature::<N>::size_in_bytes())
             .map(|data| Signature::read_le_with_unchecked(data, unchecked))
-            .collect::<Result<IndexSet<_>, _>>()
+            .collect::<Result<IndexSet<_>, _>>()?;
+        // Ensure no signature was repeated. The set absorbs a repeat, so it would
+        // otherwise give one certificate a second encoding.
+        if signatures.len() != num_signatures as usize {
+            return Err(error("Duplicate signature in batch certificate"));
+        }
+        Ok(signatures)
     }
 }
 impl<N: Network> FromBytes for BatchCertificate<N> {
@@ -104,5 +110,36 @@ mod tests {
             assert_eq!(expected, BatchCertificate::read_le(&expected_bytes[..]).unwrap());
             assert_eq!(expected, BatchCertificate::read_le_unchecked(&expected_bytes[..]).unwrap());
         }
+    }
+
+    #[test]
+    fn test_duplicate_signature_is_rejected() {
+        let rng = &mut TestRng::default();
+        let certificate = crate::test_helpers::sample_batch_certificate(rng);
+        let exact = certificate.to_bytes_le().unwrap();
+
+        // The honest encoding must keep working.
+        assert_eq!(certificate, BatchCertificate::read_le(&exact[..]).unwrap());
+
+        // version, then the batch header, then the signature count.
+        let count_at = 1 + certificate.batch_header().to_bytes_le().unwrap().len();
+        let count = u16::from_le_bytes([exact[count_at], exact[count_at + 1]]) as usize;
+        assert_eq!(count, certificate.signatures().count(), "offset arithmetic is wrong if this fails");
+        assert!(count > 0, "a sampled certificate carries signatures");
+
+        let width = certificate.signatures().next().unwrap().to_bytes_le().unwrap().len();
+        let signatures_at = count_at + 2;
+        let mut padded = exact.clone();
+        padded[count_at..count_at + 2].copy_from_slice(&(u16::try_from(count).unwrap() + 1).to_le_bytes());
+        let first = exact[signatures_at..signatures_at + width].to_vec();
+        padded.splice(signatures_at + width..signatures_at + width, first);
+        assert_ne!(padded, exact);
+
+        // The set absorbs the repeat, so the certificate is unchanged and only
+        // its bytes differ.
+        assert!(
+            BatchCertificate::<console::network::MainnetV0>::read_le(&padded[..]).is_err(),
+            "a certificate repeating a signature must be rejected"
+        );
     }
 }

--- a/ledger/narwhal/batch-header/src/bytes.rs
+++ b/ledger/narwhal/batch-header/src/bytes.rs
@@ -51,6 +51,13 @@ impl<N: Network> FromBytes for BatchHeader<N> {
             // Insert the transmission ID.
             transmission_ids.insert(TransmissionID::read_le(&mut reader)?);
         }
+        // Ensure no transmission ID was repeated. A repeat is absorbed by the set
+        // before the batch ID is computed over it, so it leaves the batch ID and
+        // the signature intact while changing the bytes -- a second encoding of
+        // one batch header.
+        if transmission_ids.len() != num_transmission_ids as usize {
+            return Err(error("Duplicate transmission ID in batch header"));
+        }
 
         // Read the number of previous certificate IDs.
         let num_previous_certificate_ids = u16::read_le(&mut reader)?;
@@ -69,6 +76,10 @@ impl<N: Network> FromBytes for BatchHeader<N> {
         let previous_certificate_ids = cfg_chunks!(previous_certificate_id_bytes, Field::<N>::size_in_bytes())
             .map(Field::read_le)
             .collect::<Result<IndexSet<_>, _>>()?;
+        // Ensure no previous certificate ID was repeated, for the same reason.
+        if previous_certificate_ids.len() != num_previous_certificate_ids as usize {
+            return Err(error("Duplicate previous certificate ID in batch header"));
+        }
 
         // Read the signature.
 
@@ -158,5 +169,84 @@ mod tests {
             assert_eq!(expected, BatchHeader::read_le(&expected_bytes[..]).unwrap());
             assert_eq!(expected, BatchHeader::read_le_unchecked(&expected_bytes[..]).unwrap());
         }
+    }
+
+    type CurrentNetwork = console::network::MainnetV0;
+
+    /// Offset of the transmission-ID count: version, batch ID, author, round,
+    /// timestamp, committee ID.
+    fn transmission_count_offset() -> usize {
+        1 + Field::<CurrentNetwork>::size_in_bytes()
+            + Address::<CurrentNetwork>::size_in_bytes()
+            + 8
+            + 8
+            + Field::<CurrentNetwork>::size_in_bytes()
+    }
+
+    /// Repeats `entry` inside a count-prefixed run, bumping the count to match.
+    fn repeat_entry(bytes: &[u8], count_at: usize, count_width: usize, entry_at: usize, entry_len: usize) -> Vec<u8> {
+        let mut out = bytes.to_vec();
+        let count = match count_width {
+            2 => u16::from_le_bytes([bytes[count_at], bytes[count_at + 1]]) as u64,
+            _ => u32::from_le_bytes([bytes[count_at], bytes[count_at + 1], bytes[count_at + 2], bytes[count_at + 3]])
+                as u64,
+        };
+        match count_width {
+            2 => out[count_at..count_at + 2].copy_from_slice(&(u16::try_from(count).unwrap() + 1).to_le_bytes()),
+            _ => out[count_at..count_at + 4].copy_from_slice(&(u32::try_from(count).unwrap() + 1).to_le_bytes()),
+        }
+        let entry = bytes[entry_at..entry_at + entry_len].to_vec();
+        out.splice(entry_at + entry_len..entry_at + entry_len, entry);
+        out
+    }
+
+    #[test]
+    fn test_duplicate_transmission_id_is_rejected() {
+        let rng = &mut TestRng::default();
+        let header = crate::test_helpers::sample_batch_header(rng);
+        let exact = header.to_bytes_le().unwrap();
+
+        // The honest encoding must keep working, or the rejection below would be
+        // refusing our own output.
+        assert_eq!(header, BatchHeader::read_le(&exact[..]).unwrap());
+
+        let first = header.transmission_ids().iter().next().expect("a sampled header has transmission IDs");
+        let first_len = first.to_bytes_le().unwrap().len();
+        let padded = repeat_entry(&exact, transmission_count_offset(), 4, transmission_count_offset() + 4, first_len);
+        assert_ne!(padded, exact);
+
+        // A repeat is absorbed by the set before the batch ID is computed, so it
+        // leaves the batch ID and the signature intact. Only the bytes differ.
+        assert!(
+            BatchHeader::<CurrentNetwork>::read_le(&padded[..]).is_err(),
+            "a batch header repeating a transmission ID must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_duplicate_previous_certificate_id_is_rejected() {
+        let rng = &mut TestRng::default();
+        let header = crate::test_helpers::sample_batch_header_for_round(2, rng);
+        let exact = header.to_bytes_le().unwrap();
+        assert_eq!(header, BatchHeader::read_le(&exact[..]).unwrap());
+        assert!(!header.previous_certificate_ids().is_empty(), "round 2 must carry previous certificates");
+
+        // The previous-certificate count follows the transmission IDs, which are
+        // variable width, so its offset is measured rather than assumed.
+        let transmissions_len: usize = header.transmission_ids().iter().map(|id| id.to_bytes_le().unwrap().len()).sum();
+        let count_at = transmission_count_offset() + 4 + transmissions_len;
+        let field_len = Field::<CurrentNetwork>::size_in_bytes();
+        assert_eq!(
+            u16::from_le_bytes([exact[count_at], exact[count_at + 1]]) as usize,
+            header.previous_certificate_ids().len(),
+            "offset arithmetic is wrong if this fails"
+        );
+
+        let padded = repeat_entry(&exact, count_at, 2, count_at + 2, field_len);
+        assert_ne!(padded, exact);
+        assert!(
+            BatchHeader::<CurrentNetwork>::read_le(&padded[..]).is_err(),
+            "a batch header repeating a previous certificate ID must be rejected"
+        );
     }
 }

--- a/ledger/narwhal/subdag/src/bytes.rs
+++ b/ledger/narwhal/subdag/src/bytes.rs
@@ -33,9 +33,19 @@ impl<N: Network> Subdag<N> {
         }
         // Read the round certificates.
         let mut subdag = BTreeMap::new();
+        // The writer emits rounds in `BTreeMap` order, so an encoding whose rounds
+        // are not strictly ascending is a second encoding of the same subdag: the
+        // map would sort and deduplicate it back into the canonical one.
+        let mut previous_round: Option<u64> = None;
         for _ in 0..num_rounds {
             // Read the round.
             let round = u64::read_le(&mut reader)?;
+            if let Some(previous) = previous_round
+                && round <= previous
+            {
+                return Err(error(format!("Subdag round {round} does not follow {previous} in ascending order")));
+            }
+            previous_round = Some(round);
             // Read the number of certificates.
             let num_certificates = u16::read_le(&mut reader)?;
             // Ensure the number of certificates is within bounds.
@@ -47,6 +57,10 @@ impl<N: Network> Subdag<N> {
             for _ in 0..num_certificates {
                 let cert = BatchCertificate::read_le_with_unchecked(&mut reader, unchecked)?;
                 certificates.insert(cert);
+            }
+            // Ensure no certificate was repeated within the round.
+            if certificates.len() != num_certificates as usize {
+                return Err(error(format!("Duplicate certificate in subdag round {round}")));
             }
             // Insert the round and certificates.
             subdag.insert(round, certificates);
@@ -105,5 +119,66 @@ mod tests {
             assert_eq!(expected, Subdag::read_le(&expected_bytes[..]).unwrap());
             assert_eq!(expected, Subdag::read_le_unchecked(&expected_bytes[..]).unwrap());
         }
+    }
+
+    /// Encodes a subdag from its parts, so a test can control the round order
+    /// and repeat a certificate -- neither of which `to_bytes_le` will produce.
+    fn encode(rounds: &[(u64, Vec<BatchCertificate<console::network::MainnetV0>>)]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        1u8.write_le(&mut bytes).unwrap();
+        u32::try_from(rounds.len()).unwrap().write_le(&mut bytes).unwrap();
+        for (round, certificates) in rounds {
+            round.write_le(&mut bytes).unwrap();
+            u16::try_from(certificates.len()).unwrap().write_le(&mut bytes).unwrap();
+            for certificate in certificates {
+                certificate.write_le(&mut bytes).unwrap();
+            }
+        }
+        bytes
+    }
+
+    #[test]
+    fn test_descending_rounds_are_rejected() {
+        let rng = &mut TestRng::default();
+        let subdag = crate::test_helpers::sample_subdag(rng);
+        let rounds: Vec<(u64, Vec<_>)> =
+            subdag.iter().map(|(round, certs)| (*round, certs.iter().cloned().collect())).collect();
+        assert!(rounds.len() >= 2, "need at least two rounds to reverse");
+
+        // Ascending is what `to_bytes_le` emits, and it must keep working.
+        let ascending = encode(&rounds);
+        assert_eq!(ascending, subdag.to_bytes_le().unwrap());
+        assert_eq!(subdag, Subdag::read_le(&ascending[..]).unwrap());
+
+        // The map would sort this back into the encoding above, so accepting it
+        // would give one subdag two encodings.
+        let mut reversed = rounds.clone();
+        reversed.reverse();
+        let descending = encode(&reversed);
+        assert_ne!(descending, ascending);
+        assert!(
+            Subdag::<console::network::MainnetV0>::read_le(&descending[..]).is_err(),
+            "a subdag whose rounds are not ascending must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_duplicate_certificate_in_a_round_is_rejected() {
+        let rng = &mut TestRng::default();
+        let subdag = crate::test_helpers::sample_subdag(rng);
+        let mut rounds: Vec<(u64, Vec<_>)> =
+            subdag.iter().map(|(round, certs)| (*round, certs.iter().cloned().collect())).collect();
+
+        // Repeat the first certificate of the first round. The set absorbs it, so
+        // the subdag is unchanged and only its bytes differ.
+        let first = rounds[0].1.first().expect("a sampled round carries certificates").clone();
+        rounds[0].1.push(first);
+
+        let padded = encode(&rounds);
+        assert_ne!(padded, subdag.to_bytes_le().unwrap());
+        assert!(
+            Subdag::<console::network::MainnetV0>::read_le(&padded[..]).is_err(),
+            "a subdag repeating a certificate within a round must be rejected"
+        );
     }
 }


### PR DESCRIPTION
During deserialization, `BatchHeader`, `BatchCertificate` and `Subdag` each read a count and then insert
that many entries into an `IndexSet` or a `BTreeMap`:

```rust
let mut transmission_ids = IndexSet::new();
for _ in 0..num_transmission_ids {
    transmission_ids.insert(TransmissionID::read_le(&mut reader)?);   // return value discarded
}
```

The collection absorbs a repeat silently — `insert`'s return value is discarded,
and `collect` into a set has nowhere to report one. So an encoding carrying a
duplicate parses to the same object and re-serializes shorter: **one value, two
encodings.**

Measured on a sampled batch header:

```
962 bytes in  ->  ACCEPTED  ->  re-encodes to 937 bytes, same batch ID
```

## Why nothing downstream catches it

A batch header's ID is recomputed on read and compared against the wire value
(`bytes.rs`), and the signature is verified over that recomputation. **Both
pass.** The batch ID is computed over the *deduplicated* set, so the duplicate
never reaches the preimage. Every guard operates on the parsed object, and the
duplicate only ever existed in the bytes.

## The five sites

| File | Collection |
|---|---|
| `batch-header/src/bytes.rs` | `transmission_ids` |
| `batch-header/src/bytes.rs` | `previous_certificate_ids` |
| `batch-certificate/src/bytes.rs` | `signatures` |
| `subdag/src/bytes.rs` | `certificates` per round |
| `subdag/src/bytes.rs` | rounds (`BTreeMap`) |

Each now checks the collection's length against the declared count.

## Order is deliberately left alone

Sorting on write was considered and rejected: it would rewrite every historical
batch ID. `compute_batch_id` hashes the transmission IDs **in insertion order**
(`to_id.rs`), and the signature covers the result.

That order is arbitrary — a proposal drains its worker FIFO, so it reflects
arrival order at one validator — but it is *authenticated*, which is what
matters. Reordering is already rejected today; only duplication slipped through,
because dedup happens before the ID is computed.

**The exception is `Subdag`'s rounds.** The writer iterates a `BTreeMap`, so it
already emits ascending order; the reader now requires it. That rejects nothing
an honest node produces and closes reordering as well as repetition.

## Test plan

Five regression tests, one per site, each asserting the honest encoding still
round trips *before* asserting the tampered one is refused — so a fix that
rejected both would fail loudly rather than pass quietly.

All five fail on an unpatched tree:

```
a batch header repeating a transmission ID must be rejected
a batch header repeating a previous certificate ID must be rejected
a certificate repeating a signature must be rejected
a subdag repeating a certificate within a round must be rejected
a subdag whose rounds are not ascending must be rejected
```

With the patch: batch-header 5 passed, batch-certificate 8 passed, subdag 19
passed. Full pre-commit hook green (`clippy --workspace --all-targets
--all-features -D warnings` plus fmt).

## Backwards compatibility

No honest encoding is affected. `to_bytes_le` writes `collection.len()` and
iterates that same collection, so it can never emit a duplicate, and the subdag
writer already emits ascending rounds. Nothing already on chain can carry one.

Related to #3409, which fixes the same class — a non-canonical encoding accepted
— in `Future`/`Plaintext`/`Record`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qb8dzi6WAXBSCeyEkpBvrc