### PR TITLE
Run GitHub CI benchmarks only on canary, testnet, and mainnet

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,8 +3,9 @@ name: Run snarkVM Benchmarks
 on:
   push:
     branches:
-      - 'staging'
-      - 'fix/benchmark-ci'
+      - 'canary'
+      - 'testnet'
+      - 'mainnet'
   workflow_dispatch:
 
 jobs:
@@ -131,7 +132,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./cache
-          key: ${{ runner.os }}-benchmark
+          key: ${{ runner.os }}-benchmark-${{ github.ref_name }}
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
@@ -140,6 +141,8 @@ jobs:
           tool: 'cargo'
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Keep canary/testnet/mainnet histories independent on gh-pages.
+          benchmark-data-dir-path: dev/bench/${{ github.ref_name }}
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true

--- a/CI.md
+++ b/CI.md
@@ -11,9 +11,11 @@ are targeting a 15 minute max runtime.
 - `ledger-workflow`
 - `synthesizer-workflow`
 
-When a PR is merged, `merge-workflow` runs additional expensive or slow tests,
-e.g. those marked as `ignore` or which download paramters. Moreover, benchmarks
-are run from github actions.s
+When a PR is merged into `staging`, `canary`, `testnet`, or `mainnet`,
+`merge-workflow` runs additional expensive or slow tests, e.g. those marked as
+`ignore` or which download parameters.
+
+GitHub Actions benchmarks run on merges to `canary`, `testnet`, and `mainnet`.
 
 When a PR is opened from a release branch (`canary`,`testnet`,`mainnet`), the
 `release-workflow` is ran which tests windows.


### PR DESCRIPTION
## Summary
- Restrict `.github/workflows/benchmarks.yml` to pushes on `canary`, `testnet`, and `mainnet` (drop `staging` and the leftover `fix/benchmark-ci` trigger).
- Store benchmark history per branch (`dev/bench/<branch>` and a branch-scoped cache key) so release lines do not share a baseline.
- Update `CI.md` to match.

## Test plan
- After merge, verify a push to `staging` does **not** start `Run snarkVM Benchmarks`.
- After merge, verify the next merge to `canary`, `testnet`, or `mainnet` starts the workflow and writes to `dev/bench/<branch>` on `gh-pages`.