### PR TITLE
fix(utilities): correct array serialized size and cover containers

### DIFF
--- a/utilities/src/serialize/impls.rs
+++ b/utilities/src/serialize/impls.rs
@@ -503,7 +503,7 @@ impl<T: CanonicalSerialize> CanonicalSerialize for [T; 32] {
 
     #[inline]
     fn serialized_size(&self, compress: Compress) -> usize {
-        8 + self.iter().map(|item| item.serialized_size(compress)).sum::<usize>()
+        self.iter().map(|item| item.serialized_size(compress)).sum()
     }
 }
 
@@ -686,7 +686,9 @@ mod test {
 
     #[test]
     fn test_string() {
+        test_serialize(String::new());
         test_serialize("asdf".to_owned());
+        test_serialize("Aleo 🦀".to_owned());
     }
 
     #[test]
@@ -703,7 +705,9 @@ mod test {
 
     #[test]
     fn test_tuple() {
+        test_serialize((0u8, u64::MAX));
         test_serialize((123u64, 234u32, 999u16));
+        test_serialize((Some(123u64), String::new(), vec![1u16, 2], false));
     }
 
     #[test]
@@ -720,5 +724,73 @@ mod test {
     #[test]
     fn test_phantomdata() {
         test_serialize(std::marker::PhantomData::<u64>);
+    }
+
+    #[test]
+    fn test_array() {
+        test_serialize([0u8; 32]);
+        test_serialize([u64::MAX; 32]);
+        let data: [Option<String>; 32] =
+            std::array::from_fn(|index| if index % 2 == 0 { None } else { Some("a".repeat(index)) });
+        test_serialize(data.clone());
+        test_serialize(Some(data.clone()));
+        test_serialize(vec![data]);
+    }
+
+    #[test]
+    fn test_arc() {
+        test_serialize(Arc::new(Vec::<u64>::new()));
+        test_serialize(Arc::new(vec![None, Some(String::new()), Some("Aleo 🦀".to_owned())]));
+    }
+
+    #[test]
+    fn test_btree_map() {
+        test_serialize(BTreeMap::<u64, String>::new());
+        test_serialize(BTreeMap::from([(2u64, Some("Aleo 🦀".to_owned())), (0, None), (1, Some(String::new()))]));
+    }
+
+    #[test]
+    fn test_serialization_wrappers() -> Result<(), SerializationError> {
+        for data in [Vec::<Option<String>>::new(), vec![None, Some(String::new()), Some("Aleo 🦀".to_owned())]] {
+            let rc = Rc::new(data.clone());
+            let slice = data.as_slice();
+            for compress in [Compress::No, Compress::Yes] {
+                let mut expected = Vec::new();
+                data.serialize_with_mode(&mut expected, compress)?;
+
+                let mut serialized = Vec::new();
+                rc.serialize_with_mode(&mut serialized, compress)?;
+                assert_eq!(serialized, expected);
+                assert_eq!(rc.serialized_size(compress), serialized.len());
+
+                serialized.clear();
+                <[Option<String>]>::serialize_with_mode(slice, &mut serialized, compress)?;
+                assert_eq!(serialized, expected);
+                assert_eq!(<[Option<String>]>::serialized_size(slice, compress), serialized.len());
+
+                serialized.clear();
+                <&[Option<String>]>::serialize_with_mode(&slice, &mut serialized, compress)?;
+                assert_eq!(serialized, expected);
+                assert_eq!(<&[Option<String>]>::serialized_size(&slice, compress), serialized.len());
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_cow_serialization() -> Result<(), SerializationError> {
+        for data in [(None, String::new()), (Some(u64::MAX), "Aleo 🦀".to_owned())] {
+            for compress in [Compress::No, Compress::Yes] {
+                let mut expected = Vec::new();
+                data.serialize_with_mode(&mut expected, compress)?;
+                for wrapper in [Cow::Borrowed(&data), Cow::Owned(data.clone())] {
+                    let mut serialized = Vec::new();
+                    wrapper.serialize_with_mode(&mut serialized, compress)?;
+                    assert_eq!(serialized, expected);
+                    assert_eq!(wrapper.serialized_size(compress), serialized.len());
+                }
+            }
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

Addresses the utility-container coverage in #2956, independently of the curve tests in #3405.

The new array test exposed a size mismatch: `[0u8; 32]` writes 32 bytes but reports 40. Fixed arrays do not write a length prefix, so their size must be the sum of their elements. The one-line fix also corrects size reporting when arrays are nested in `Option` or `Vec`.

Adds coverage for arrays, `Arc`, `BTreeMap`, empty and Unicode strings, two-/four-element tuples, and serialization-only wrappers (`Rc`, borrowed/owned `Cow`, slices and slice references). Round-trip cases exercise both compression modes and both validation modes; wrappers check bytes and reported sizes against their underlying values.

## Test Plan

On Windows x86_64, Rust 1.98.0:

- Before the fix, the new array regression fails with reported size 40 versus actual size 32.
- `cargo check -p snarkvm-utilities --locked`
- `cargo clippy -p snarkvm-utilities --locked --all-targets --no-deps -- -D warnings`
- `cargo +nightly-2026-04-02 fmt --all`
- `cargo test -p snarkvm-utilities --locked`: 40 unit tests and 2 doctests pass.
- `git diff --check`

The full workspace suite was not run.

## Documentation

No API or documentation changes. This covers the utility portion of #2956, not its remaining field/curve coverage.

## Backwards compatibility

No serialized bytes, deserialization behavior, dependencies or consensus rules change. Only the fixed-array size calculation changes.