### PR TITLE
fix(network): keep default consensus heights network-specific

### DIFF
--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -90,7 +90,8 @@ pub type FiatShamirParameters<N> = <FiatShamir<N> as AlgebraicSponge<Fq<N>, 2>>:
 pub(crate) type VarunaProvingKey<N> = CircuitProvingKey<<N as Environment>::PairingCurve, VarunaHidingMode>;
 pub(crate) type VarunaVerifyingKey<N> = CircuitVerifyingKey<<N as Environment>::PairingCurve>;
 
-/// A list of consensus versions and their corresponding block heights.
+/// Explicitly configured or test consensus version heights, shared across networks.
+#[cfg(any(test, feature = "test", feature = "test_consensus_heights", feature = "wasm"))]
 static CONSENSUS_VERSION_HEIGHTS: OnceLock<[(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS]> = OnceLock::new();
 
 pub trait Network:
@@ -325,8 +326,13 @@ pub trait Network:
     #[allow(non_snake_case)]
     #[cfg(not(any(test, feature = "test", feature = "test_consensus_heights")))]
     fn CONSENSUS_VERSION_HEIGHTS() -> &'static [(ConsensusVersion, u32); NUM_CONSENSUS_VERSIONS] {
-        // Initialize the consensus version heights directly from the constant.
-        CONSENSUS_VERSION_HEIGHTS.get_or_init(|| Self::_CONSENSUS_VERSION_HEIGHTS)
+        // Explicit WebAssembly heights override the network defaults.
+        #[cfg(feature = "wasm")]
+        if let Some(heights) = CONSENSUS_VERSION_HEIGHTS.get() {
+            return heights;
+        }
+        // Default heights belong to this network and must not initialize a shared cache.
+        &Self::_CONSENSUS_VERSION_HEIGHTS
     }
     /// Returns the list of test consensus versions.
     #[allow(non_snake_case)]

--- a/ledger/block/src/helpers/target.rs
+++ b/ledger/block/src/helpers/target.rs
@@ -522,6 +522,22 @@ mod tests {
     const EXPECTED_MAX_STAKING_REWARD: u64 = 142_694_063;
 
     #[test]
+    #[cfg(not(feature = "test"))]
+    fn test_consensus_heights_are_network_specific() -> Result<()> {
+        // The network crate is a dependency here, so its non-test implementation is exercised.
+        for _ in 0..2 {
+            assert_eq!(TestnetV0::CONSENSUS_VERSION_HEIGHTS(), &TestnetV0::_CONSENSUS_VERSION_HEIGHTS);
+            assert_eq!(CanaryV0::CONSENSUS_VERSION_HEIGHTS(), &CanaryV0::_CONSENSUS_VERSION_HEIGHTS);
+            assert_eq!(MainnetV0::CONSENSUS_VERSION_HEIGHTS(), &MainnetV0::_CONSENSUS_VERSION_HEIGHTS);
+
+            for (version, height) in MainnetV0::_CONSENSUS_VERSION_HEIGHTS {
+                assert_eq!(MainnetV0::CONSENSUS_HEIGHT(version)?, height);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
     fn test_anchor_block_reward_v1() {
         // Check the anchor block reward at block 1.
         let reward_at_block_1 = anchor_block_reward_at_height(


### PR DESCRIPTION
## Motivation

Implements the first direction discussed in #3411: return each network's constant height table without initializing a process-global cache. The regression reads Testnet, Canary and Mainnet repeatedly in one process and checks Mainnet consensus-height lookups. It lives in `ledger-block` so the network crate is compiled as a dependency, exercising the non-test path.

The environment/test-height cache is unchanged. With the `wasm` feature, heights explicitly initialized through `get_or_init_consensus_version_heights` still override the defaults.

## Remaining blocker

Keeping this as a draft because correcting the cache exposes a separate supply-cap expectation mismatch. `test_total_supply_cap` now passes its Canary simulation, then fails Testnet at **263,447,171** versus `MAX_SUPPLY_LIMIT_HEIGHT` **263,527,685**. This happens both alone and after `test_block_reward`; it is no longer dependent on which network initialized the cache.

The old standalone pass used Canary's heights for all three simulations. I have not changed supply constants, reward rules or the failing assertion to hide this difference. The intended Testnet supply-limit behavior needs a maintainer decision before this is ready. The separate CI coverage gap in #3411 is also outside this patch.

## Test Plan

Windows x86_64, Rust 1.98.0, based on staging `e9c99afe`:

- New `test_consensus_heights_are_network_specific` fails before the fix (Canary receives Testnet heights) and passes after it.
- `cargo check -p snarkvm-console-network --locked` passes, including separate runs with `--features test_consensus_heights` and `--features wasm`. These are native feature builds, not a wasm runtime test.
- `cargo clippy -p snarkvm-console-network --locked --no-deps -- -D warnings` reports two existing `clippy::useless_borrows_in_formatting` findings in `helpers/id.rs:157` and `helpers/object.rs:131`. Both files are unchanged from staging. Re-running with only `-A clippy::useless_borrows_in_formatting` passes.
- `cargo +nightly-2026-04-02 fmt --all` and `git diff --check` pass.
- `cargo test -p snarkvm-ledger-block --locked --lib -- --test-threads=1 test_block_reward test_total_supply_cap`: 4 pass, supply-cap test fails as detailed above. The supply-cap test also fails alone after Canary passes.

The full workspace suite was not run. Existing parameter-crate warnings are unchanged.

## Documentation

No public API changes. The cache comment now describes its explicit/test-only role.

## Backwards compatibility

Network constants, serialized formats and single-network native lookups are unchanged. Multi-network default lookups now use the selected network instead of whichever network was queried first. No supply-limit adjustment or consensus-version change is included.