### PR TITLE
Rebuild the history by replaying blocks, instead of re-encoding it

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -99,8 +99,7 @@ locktick = [
 metrics = [ "snarkvm-ledger-committee/metrics", "snarkvm-ledger-store/metrics" ]
 prop-tests = [ "snarkvm-ledger-committee/prop-tests" ]
 rocks = [ "snarkvm-ledger-store/rocks" ]
-# The offline finalize-state rebuild, and the tool that drives it. Opt-in and separate from `rocks`
-# so that enabling RocksDB storage does not also change `add_next_block`'s atomic-batch path for
+# Separate from `rocks`: pairing them there would change `add_next_block`'s atomic-batch path for
 # anyone building this crate on its own.
 rebuild = [ "rocks", "snarkvm-synthesizer/rocks", "dep:tracing-subscriber" ]
 serial = [

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -16,10 +16,10 @@ categories = [ "cryptography", "web-programming" ]
 license = "Apache-2.0"
 edition = "2024"
 
-[[example]]
+[[bin]]
 name = "rebuild_db"
-path = "examples/rebuild_db.rs"
-required-features = [ "rocks" ]
+path = "src/bin/rebuild_db.rs"
+required-features = [ "rebuild" ]
 
 [[test]]
 name = "block-cache"
@@ -99,6 +99,10 @@ locktick = [
 metrics = [ "snarkvm-ledger-committee/metrics", "snarkvm-ledger-store/metrics" ]
 prop-tests = [ "snarkvm-ledger-committee/prop-tests" ]
 rocks = [ "snarkvm-ledger-store/rocks" ]
+# The offline finalize-state rebuild, and the tool that drives it. Opt-in and separate from `rocks`
+# so that enabling RocksDB storage does not also change `add_next_block`'s atomic-batch path for
+# anyone building this crate on its own.
+rebuild = [ "rocks", "snarkvm-synthesizer/rocks", "dep:tracing-subscriber" ]
 serial = [
   "snarkvm-console/serial",
   "snarkvm-ledger-authority/serial",
@@ -248,6 +252,11 @@ workspace = true
 [dev-dependencies.snarkvm-synthesizer]
 workspace = true
 features = [ "rocks", "test" ]
+
+[dependencies.tracing-subscriber]
+version = "0.3"
+features = [ "env-filter", "std" ]
+optional = true
 
 [dev-dependencies.tracing-subscriber]
 version = "0.3"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -29,7 +29,7 @@ required-features = [ "rocks" ]
 [[test]]
 name = "history-rebuild"
 path = "tests/history_rebuild.rs"
-required-features = [ "rocks", "history", "test" ]
+required-features = [ "rebuild", "history", "test" ]
 
 [[bench]]
 name = "block"
@@ -251,7 +251,7 @@ workspace = true
 
 [dev-dependencies.snarkvm-synthesizer]
 workspace = true
-features = [ "rocks", "test" ]
+features = [ "test" ]
 
 [dependencies.tracing-subscriber]
 version = "0.3"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -16,10 +16,20 @@ categories = [ "cryptography", "web-programming" ]
 license = "Apache-2.0"
 edition = "2024"
 
+[[example]]
+name = "rebuild_db"
+path = "examples/rebuild_db.rs"
+required-features = [ "rocks" ]
+
 [[test]]
 name = "block-cache"
 path = "tests/block_cache.rs"
 required-features = [ "rocks" ]
+
+[[test]]
+name = "history-rebuild"
+path = "tests/history_rebuild.rs"
+required-features = [ "rocks", "history", "test" ]
 
 [[bench]]
 name = "block"
@@ -237,7 +247,7 @@ workspace = true
 
 [dev-dependencies.snarkvm-synthesizer]
 workspace = true
-features = [ "test" ]
+features = [ "rocks", "test" ]
 
 [dev-dependencies.tracing-subscriber]
 version = "0.3"

--- a/ledger/examples/rebuild_db.rs
+++ b/ledger/examples/rebuild_db.rs
@@ -1,0 +1,99 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Rebuilds a ledger's finalize state by replaying its blocks.
+//!
+//! ```text
+//! cargo build --release --example rebuild_db --features rocks,history
+//! ./target/release/examples/rebuild_db ~/.aleo/storage/ledger-0
+//! ```
+//!
+//! An example rather than a binary so that it can borrow the crate's existing
+//! `tracing-subscriber` dev-dependency instead of adding one, and because it is temporary: the
+//! operator-facing form of this is `snarkos developer rebuild-history`, which calls the same
+//! `VM::rebuild_finalize_state`. Nothing here is more than argument parsing and a log subscriber.
+//!
+//! The node must be stopped. RocksDB permits a single writer, so this refuses to open a ledger a
+//! node still holds, and the rebuild rewrites the state a running node would be reading.
+
+use snarkvm_console::network::{CanaryV0, MainnetV0, Network, TestnetV0};
+use snarkvm_ledger_store::{
+    ConsensusStore,
+    helpers::rocksdb::{ConsensusDB, allow_downlevel_open},
+};
+use snarkvm_synthesizer::vm::VM;
+
+use aleo_std::StorageMode;
+use anyhow::{Result, bail};
+use std::path::PathBuf;
+
+const USAGE: &str = "\
+usage: rebuild_db <ledger-dir> [network-id]
+
+Discards the ledger's finalize state and rebuilds it by replaying every block already in
+storage. The network is inferred from a directory name ending in `-<id>` (0 = mainnet,
+1 = testnet, 2 = canary), or given as the final argument.
+
+Stop the node first. Progress is reported as it runs, and it can be interrupted and resumed.";
+
+/// Returns the network id encoded in a ledger directory name, if it has one.
+///
+/// Production ledgers are `ledger-{network}`; development ones are `.ledger-{network}-{id}`, so a
+/// naive split from the right yields the dev id instead. An id outside the known range is refused
+/// rather than assumed, because guessing it wrong would rebuild under the wrong prefix.
+fn network_from_name(path: &std::path::Path) -> Option<u16> {
+    let name = path.file_name()?.to_str()?;
+    let rest = name.strip_prefix('.').unwrap_or(name).strip_prefix("ledger-")?;
+    let network = rest.split('-').next()?.parse().ok()?;
+    // 0 = mainnet, 1 = testnet, 2 = canary. Anything else is a misread name.
+    (network <= 2).then_some(network)
+}
+
+/// Opens the ledger at `path` and rebuilds its finalize state.
+fn rebuild<N: Network>(path: PathBuf) -> Result<()> {
+    // Said before opening: the schema gate exists to keep a node out of exactly this database.
+    allow_downlevel_open();
+
+    let store = ConsensusStore::<N, ConsensusDB<N>>::open(StorageMode::Custom(path))?;
+    VM::from(store)?.rebuild_finalize_state()
+}
+
+fn main() -> Result<()> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.is_empty() || args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        println!("{USAGE}");
+        return Ok(());
+    }
+
+    let path = PathBuf::from(&args[0]);
+    let network_id = match args.get(1) {
+        Some(explicit) => explicit.parse()?,
+        None => match network_from_name(&path) {
+            Some(id) => id,
+            None => bail!("Could not infer the network from {path:?}.\n\n{USAGE}"),
+        },
+    };
+
+    // The rebuild reports progress through `tracing`; without a subscriber a multi-hour run would
+    // print nothing at all.
+    tracing_subscriber::fmt().with_env_filter("info").with_target(false).init();
+
+    match network_id {
+        0 => rebuild::<MainnetV0>(path),
+        1 => rebuild::<TestnetV0>(path),
+        2 => rebuild::<CanaryV0>(path),
+        other => bail!("Unknown network id {other}.\n\n{USAGE}"),
+    }
+}

--- a/ledger/src/bin/rebuild_db.rs
+++ b/ledger/src/bin/rebuild_db.rs
@@ -16,14 +16,16 @@
 //! Rebuilds a ledger's finalize state by replaying its blocks.
 //!
 //! ```text
-//! cargo build --release --example rebuild_db --features rocks,history
-//! ./target/release/examples/rebuild_db ~/.aleo/storage/ledger-0
+//! cargo build --release --bin rebuild_db --features rebuild,history
+//! ./target/release/rebuild_db ~/.aleo/storage/ledger-0
 //! ```
 //!
-//! An example rather than a binary so that it can borrow the crate's existing
-//! `tracing-subscriber` dev-dependency instead of adding one, and because it is temporary: the
-//! operator-facing form of this is `snarkos developer rebuild-history`, which calls the same
-//! `VM::rebuild_finalize_state`. Nothing here is more than argument parsing and a log subscriber.
+//! Deliberately a binary rather than an example: an example is built with the crate's
+//! dev-dependencies unified into the graph, which would hand an operator a tool compiled with
+//! `snarkvm-synthesizer/test` -- one that loads the wrong `Process` and caps confirmed transactions
+//! at eight. Temporary either way; the operator-facing form is `snarkos developer rebuild-history`,
+//! which calls the same `VM::rebuild_finalize_state`. Nothing here is more than argument parsing
+//! and a log subscriber.
 //!
 //! The node must be stopped. RocksDB permits a single writer, so this refuses to open a ledger a
 //! node still holds, and the rebuild rewrites the state a running node would be reading.

--- a/ledger/src/bin/rebuild_db.rs
+++ b/ledger/src/bin/rebuild_db.rs
@@ -39,11 +39,15 @@ use anyhow::{Result, bail};
 use std::path::PathBuf;
 
 const USAGE: &str = "\
-usage: rebuild_db [--check] <ledger-dir> [network-id]
+usage: rebuild_db [--check] [--force] <ledger-dir> [network-id]
 
 Discards the ledger's finalize state and rebuilds it by replaying every block already in
 storage. The network is inferred from a directory name ending in `-<id>` (0 = mainnet,
 1 = testnet, 2 = canary), or given as the final argument.
+
+--force rebuilds a ledger that already records this schema version, discarding a finalize
+state nothing has reported as wrong. Only for a ledger whose history is suspect for some
+other reason.
 
 --check runs every pre-flight the rebuild runs and stops before the first write, reporting
 whether this ledger is a candidate and how much of it there is to replay. It still needs the
@@ -65,7 +69,7 @@ fn network_from_name(path: &std::path::Path) -> Option<u16> {
 }
 
 /// Opens the ledger at `path` and rebuilds its finalize state.
-fn rebuild<N: Network>(path: PathBuf, check: bool) -> Result<()> {
+fn rebuild<N: Network>(path: PathBuf, check: bool, force: bool) -> Result<()> {
     // Said before opening: the schema gate exists to keep a node out of exactly this database.
     allow_downlevel_open();
 
@@ -73,9 +77,10 @@ fn rebuild<N: Network>(path: PathBuf, check: bool) -> Result<()> {
     // Without preloaded deployments: the replay adds each program as it reaches its deployment, so
     // a program revised later is checked against the edition the block carries.
     let vm = VM::from_without_deployments(store)?;
-    match check {
-        true => vm.check_rebuild(),
-        false => vm.rebuild_finalize_state(),
+    match (check, force) {
+        (true, _) => vm.check_rebuild(),
+        (false, true) => vm.force_rebuild_finalize_state(),
+        (false, false) => vm.rebuild_finalize_state(),
     }
 }
 
@@ -86,6 +91,7 @@ fn main() -> Result<()> {
         return Ok(());
     }
     let check = all.iter().any(|arg| arg == "--check" || arg == "-c");
+    let force = all.iter().any(|arg| arg == "--force");
     let args = all.into_iter().filter(|arg| !arg.starts_with('-')).collect::<Vec<_>>();
     if args.is_empty() {
         bail!("No ledger directory given.\n\n{USAGE}");
@@ -107,9 +113,9 @@ fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter(filter).with_target(false).init();
 
     match network_id {
-        0 => rebuild::<MainnetV0>(path, check),
-        1 => rebuild::<TestnetV0>(path, check),
-        2 => rebuild::<CanaryV0>(path, check),
+        0 => rebuild::<MainnetV0>(path, check, force),
+        1 => rebuild::<TestnetV0>(path, check, force),
+        2 => rebuild::<CanaryV0>(path, check, force),
         other => bail!("Unknown network id {other}.\n\n{USAGE}"),
     }
 }

--- a/ledger/src/bin/rebuild_db.rs
+++ b/ledger/src/bin/rebuild_db.rs
@@ -70,7 +70,9 @@ fn rebuild<N: Network>(path: PathBuf, check: bool) -> Result<()> {
     allow_downlevel_open();
 
     let store = ConsensusStore::<N, ConsensusDB<N>>::open(StorageMode::Custom(path))?;
-    let vm = VM::from(store)?;
+    // Without preloaded deployments: the replay adds each program as it reaches its deployment, so
+    // a program revised later is checked against the edition the block carries.
+    let vm = VM::from_without_deployments(store)?;
     match check {
         true => vm.check_rebuild(),
         false => vm.rebuild_finalize_state(),

--- a/ledger/src/bin/rebuild_db.rs
+++ b/ledger/src/bin/rebuild_db.rs
@@ -20,12 +20,9 @@
 //! ./target/release/rebuild_db ~/.aleo/storage/ledger-0
 //! ```
 //!
-//! Deliberately a binary rather than an example: an example is built with the crate's
-//! dev-dependencies unified into the graph, which would hand an operator a tool compiled with
-//! `snarkvm-synthesizer/test` -- one that loads the wrong `Process` and caps confirmed transactions
-//! at eight. Temporary either way; the operator-facing form is `snarkos developer rebuild-history`,
-//! which calls the same `VM::rebuild_finalize_state`. Nothing here is more than argument parsing
-//! and a log subscriber.
+//! Must stay a binary, not an example: an example is built with this crate's dev-dependencies
+//! unified into the graph, which compiles it with `snarkvm-synthesizer/test` -- the wrong `Process`
+//! for the tip height, and confirmed transactions capped at eight.
 //!
 //! The node must be stopped. RocksDB permits a single writer, so this refuses to open a ledger a
 //! node still holds, and the rebuild rewrites the state a running node would be reading.
@@ -102,8 +99,10 @@ fn main() -> Result<()> {
     };
 
     // The rebuild reports progress through `tracing`; without a subscriber a multi-hour run would
-    // print nothing at all.
-    tracing_subscriber::fmt().with_env_filter("info").with_target(false).init();
+    // print nothing at all. `RUST_LOG` overrides the default, so a stalled run can be turned up.
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::fmt().with_env_filter(filter).with_target(false).init();
 
     match network_id {
         0 => rebuild::<MainnetV0>(path, check),

--- a/ledger/src/bin/rebuild_db.rs
+++ b/ledger/src/bin/rebuild_db.rs
@@ -42,11 +42,15 @@ use anyhow::{Result, bail};
 use std::path::PathBuf;
 
 const USAGE: &str = "\
-usage: rebuild_db <ledger-dir> [network-id]
+usage: rebuild_db [--check] <ledger-dir> [network-id]
 
 Discards the ledger's finalize state and rebuilds it by replaying every block already in
 storage. The network is inferred from a directory name ending in `-<id>` (0 = mainnet,
 1 = testnet, 2 = canary), or given as the final argument.
+
+--check runs every pre-flight the rebuild runs and stops before the first write, reporting
+whether this ledger is a candidate and how much of it there is to replay. It still needs the
+node stopped, since opening the ledger takes RocksDB's single writer lock.
 
 Stop the node first. Progress is reported as it runs, and it can be interrupted and resumed.";
 
@@ -64,19 +68,28 @@ fn network_from_name(path: &std::path::Path) -> Option<u16> {
 }
 
 /// Opens the ledger at `path` and rebuilds its finalize state.
-fn rebuild<N: Network>(path: PathBuf) -> Result<()> {
+fn rebuild<N: Network>(path: PathBuf, check: bool) -> Result<()> {
     // Said before opening: the schema gate exists to keep a node out of exactly this database.
     allow_downlevel_open();
 
     let store = ConsensusStore::<N, ConsensusDB<N>>::open(StorageMode::Custom(path))?;
-    VM::from(store)?.rebuild_finalize_state()
+    let vm = VM::from(store)?;
+    match check {
+        true => vm.check_rebuild(),
+        false => vm.rebuild_finalize_state(),
+    }
 }
 
 fn main() -> Result<()> {
-    let args = std::env::args().skip(1).collect::<Vec<_>>();
-    if args.is_empty() || args.iter().any(|arg| arg == "-h" || arg == "--help") {
+    let all = std::env::args().skip(1).collect::<Vec<_>>();
+    if all.is_empty() || all.iter().any(|arg| arg == "-h" || arg == "--help") {
         println!("{USAGE}");
         return Ok(());
+    }
+    let check = all.iter().any(|arg| arg == "--check" || arg == "-c");
+    let args = all.into_iter().filter(|arg| !arg.starts_with('-')).collect::<Vec<_>>();
+    if args.is_empty() {
+        bail!("No ledger directory given.\n\n{USAGE}");
     }
 
     let path = PathBuf::from(&args[0]);
@@ -93,9 +106,9 @@ fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter("info").with_target(false).init();
 
     match network_id {
-        0 => rebuild::<MainnetV0>(path),
-        1 => rebuild::<TestnetV0>(path),
-        2 => rebuild::<CanaryV0>(path),
+        0 => rebuild::<MainnetV0>(path, check),
+        1 => rebuild::<TestnetV0>(path, check),
+        2 => rebuild::<CanaryV0>(path, check),
         other => bail!("Unknown network id {other}.\n\n{USAGE}"),
     }
 }

--- a/ledger/store/src/helpers/memory/program.rs
+++ b/ledger/store/src/helpers/memory/program.rs
@@ -52,9 +52,6 @@ pub struct FinalizeMemory<N: Network> {
     /// The historical mapping value map (keyed by big-endian block height).
     #[cfg(feature = "history")]
     mapping_update_map: MemoryMap<(ProgramID<N>, Identifier<N>, Plaintext<N>, HeightBytes), Value<N>>,
-    /// The legacy heights index; present only for keys written before the BE schema change.
-    #[cfg(feature = "history")]
-    mapping_update_heights_map: MemoryMap<(ProgramID<N>, Identifier<N>, Plaintext<N>), Vec<u32>>,
     /// The current block height.
     #[cfg(feature = "history")]
     block_height: Arc<AtomicU32>,
@@ -73,8 +70,6 @@ impl<N: Network> FinalizeStorage<N> for FinalizeMemory<N> {
     type RejectedReasonMap = MemoryMap<Field<N>, RejectedReason<N>>;
     #[cfg(feature = "history")]
     type MappingUpdateMap = MemoryMap<(ProgramID<N>, Identifier<N>, Plaintext<N>, HeightBytes), Value<N>>;
-    #[cfg(feature = "history")]
-    type MappingUpdateHeightsMap = MemoryMap<(ProgramID<N>, Identifier<N>, Plaintext<N>), Vec<u32>>;
     #[cfg(feature = "history-staking-rewards")]
     type StakingRewardsMap = MemoryMap<(Address<N>, u32), (Address<N>, u64, u64)>;
 
@@ -95,8 +90,6 @@ impl<N: Network> FinalizeStorage<N> for FinalizeMemory<N> {
             rejected_reason_map: MemoryMap::default(),
             #[cfg(feature = "history")]
             mapping_update_map: MemoryMap::default(),
-            #[cfg(feature = "history")]
-            mapping_update_heights_map: MemoryMap::default(),
             #[cfg(feature = "history")]
             block_height: Arc::new(AtomicU32::new(initial_height)),
             #[cfg(feature = "history-staking-rewards")]
@@ -129,11 +122,6 @@ impl<N: Network> FinalizeStorage<N> for FinalizeMemory<N> {
     #[cfg(feature = "history")]
     fn mapping_update_map(&self) -> &Self::MappingUpdateMap {
         &self.mapping_update_map
-    }
-
-    #[cfg(feature = "history")]
-    fn mapping_update_heights_map(&self) -> &Self::MappingUpdateHeightsMap {
-        &self.mapping_update_heights_map
     }
 
     /// Returns the historical staking rewards map.

--- a/ledger/store/src/helpers/rocksdb/internal/history_rebuild.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/history_rebuild.rs
@@ -1,0 +1,271 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Storage migration v0 -> v1: discard the finalize state and rebuild it by replaying blocks.
+//!
+//! # What is being repaired
+//!
+//! Three incompatible layouts of `MappingUpdateMap` shipped in quick succession, and nothing on
+//! disk records which one wrote a given entry:
+//!
+//! | snarkOS | height encoding | `MappingUpdateHeightsMap` |
+//! |---|---|---|
+//! | <= v4.7.4 | little-endian | written, and lists every entry |
+//! | v4.7.5, v4.8.0 | little-endian | **not written** |
+//! | v4.8.1+ | big-endian for keys with no heights row, little-endian for keys with one | frozen or appended |
+//!
+//! # Why the entries cannot be repaired in place
+//!
+//! `HeightBytes` is the final field of the raw key, so re-encoding an entry is a suffix
+//! byte-reversal -- which makes it tempting to classify each entry and move the little-endian ones.
+//! That cannot be made complete, because the two encodings collide and the collision already
+//! destroyed data on the running node.
+//!
+//! `LE(256)` and `BE(65_536)` are the same four bytes. A key written at height 256 while the node
+//! ran a little-endian build, and again at height 65,536 after it upgraded, produced *one* raw key:
+//! the second write overwrote the first, and height 256's value is gone. Nothing on disk can bring
+//! it back. The collision needs `byte_reverse(h)` to also be a real height, which for a ~20.8M tip
+//! bounds it at roughly 0.6% of the little-endian window -- and `credits.aleo/{committee, delegated,
+//! bonded}` reach that bound exactly, because `replace_mapping` rewrites every key in the mapping on
+//! every reward block.
+//!
+//! So any repair that relocates existing entries inherits those holes. Rebuilding the values is the
+//! only way to fill them, and the values are recoverable: the blocks are still on disk, and
+//! replaying their finalize operations reproduces every mapping update at the height it happened.
+//!
+//! # What is discarded
+//!
+//! Everything the finalize and committee stores own. The mapping state is discarded along with the
+//! history because a replay must run forward from genesis: reproducing the update at height `h`
+//! requires the state as it stood at `h - 1`, and the only state on disk is the one at the tip.
+//!
+//! Blocks, transactions, transitions and deployments are never touched. They are the source the
+//! rebuild reads from.
+//!
+//! # Why this is raw
+//!
+//! Clearing a map through the typed API would deserialize every key and value only to drop them.
+//! Working on raw prefixes also means the clear runs whatever cargo features are enabled: a build
+//! that never opens the typed history map can still discard it.
+
+use aleo_std_storage::StorageMode;
+use anyhow::Result;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use super::{
+    CommitteeMap,
+    Database as _,
+    MapID,
+    MetadataKey,
+    ProgramMap,
+    RocksDB,
+    get_metadata,
+    map_context,
+    put_metadata,
+};
+
+/// Whether this process may open a ledger whose storage schema predates this build.
+///
+/// The version gate exists to keep a node out of a database it would misread. The rebuild is the
+/// one caller that must open exactly such a database, so it says so explicitly rather than the gate
+/// guessing at intent from the storage mode or the calling crate.
+static DOWNLEVEL_OPEN_ALLOWED: AtomicBool = AtomicBool::new(false);
+
+/// Permits this process to open a ledger whose storage schema predates this build.
+///
+/// Intended for the rebuild alone. A node must never call it: the gate is what stops a build from
+/// reading little-endian history entries as big-endian.
+pub fn allow_downlevel_open() {
+    DOWNLEVEL_OPEN_ALLOWED.store(true, Ordering::SeqCst);
+}
+
+/// Returns whether [`allow_downlevel_open`] has been called.
+pub(crate) fn downlevel_open_allowed() -> bool {
+    DOWNLEVEL_OPEN_ALLOWED.load(Ordering::SeqCst)
+}
+
+/// The maps the rebuild discards and replays.
+///
+/// The committee maps are here because the committee store is written by ratification, inside the
+/// same atomic batch as the mapping updates, and a replay reproduces it. Leaving it would also
+/// leave the rebuild without a resume point: `CommitteeStorage::insert` requires each height to
+/// follow the last, so a cleared committee store is what makes a resumed replay verify its own
+/// position instead of trusting a recorded cursor.
+const REBUILT_MAPS: &[MapID] = &[
+    MapID::Program(ProgramMap::ProgramID),
+    MapID::Program(ProgramMap::KeyValueID),
+    MapID::Program(ProgramMap::MappingUpdate),
+    MapID::Program(ProgramMap::MappingUpdateHeights),
+    MapID::Program(ProgramMap::StakingRewards),
+    MapID::Program(ProgramMap::RejectedReason),
+    MapID::Committee(CommitteeMap::CurrentRound),
+    MapID::Committee(CommitteeMap::RoundToHeight),
+    MapID::Committee(CommitteeMap::Committee),
+];
+
+/// The maps holding historical mapping updates.
+///
+/// Both are consulted when deciding whether a ledger has history to rebuild: a node that ran only
+/// <= v4.7.4 has a heights row for every key, and one that ran only v4.7.5+ has none.
+const HISTORY_MAPS: &[MapID] =
+    &[MapID::Program(ProgramMap::MappingUpdate), MapID::Program(ProgramMap::MappingUpdateHeights)];
+
+/// Returns the exclusive upper bound of the key range a prefix covers.
+///
+/// `None` when the prefix is all `0xFF` and so has no successor, meaning the range runs to the end
+/// of the keyspace. A map prefix is `[network_id, map_id]` and neither is `0xFFFF` today, but the
+/// bound is handled rather than assumed away, since getting it wrong deletes an unrelated map.
+fn prefix_end(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut end = prefix.to_vec();
+    while let Some(byte) = end.last_mut() {
+        if *byte == u8::MAX {
+            end.pop();
+        } else {
+            *byte += 1;
+            return Some(end);
+        }
+    }
+    None
+}
+
+/// Returns whether any key exists under the given prefix.
+fn prefix_is_occupied(database: &rocksdb::DB, prefix: &[u8]) -> bool {
+    database.prefix_iterator(prefix).next().is_some()
+}
+
+/// Opens the ledger at `storage`, bypassing the storage schema gate for the rest of the process.
+///
+/// The handle is the one the node's stores already share, so a caller that has a store open gets
+/// that same database back rather than a second connection to it.
+pub fn open_for_rebuild<S: Into<StorageMode>>(network_id: u16, storage: S) -> Result<RocksDB> {
+    allow_downlevel_open();
+    RocksDB::open(network_id, storage)
+}
+
+/// Returns the storage schema version the database was last written under.
+pub fn schema_version(database: &rocksdb::DB, network_id: u16) -> Result<u32> {
+    super::get_metadata_u32(database, network_id, MetadataKey::StorageVersion)
+}
+
+/// Records the storage schema version the database is now in.
+pub fn set_schema_version(database: &rocksdb::DB, network_id: u16, version: u32) -> Result<()> {
+    put_metadata(database, network_id, MetadataKey::StorageVersion, &version.to_le_bytes())
+}
+
+/// Returns whether the ledger holds historical mapping updates.
+///
+/// A ledger with none has nothing to rebuild, so the version is stamped in passing and a node that
+/// never enabled the `history` feature never sees a rebuild prompt for work that does not exist.
+pub fn has_history(database: &rocksdb::DB, network_id: u16) -> Result<bool> {
+    Ok(HISTORY_MAPS.iter().any(|map_id| prefix_is_occupied(database, &map_context(network_id, *map_id))))
+}
+
+/// Returns whether the ledger holds historical staking rewards.
+///
+/// Asked separately from the history because it is written under a separate cargo feature, and a
+/// build without that feature would discard these entries and rebuild nothing in their place.
+pub fn has_staking_rewards(database: &rocksdb::DB, network_id: u16) -> Result<bool> {
+    Ok(prefix_is_occupied(database, &map_context(network_id, MapID::Program(ProgramMap::StakingRewards))))
+}
+
+/// Returns whether the finalize state has been discarded and is awaiting replay.
+///
+/// Recorded rather than inferred from an empty finalize store, which cannot distinguish a ledger
+/// mid-rebuild from a fresh one: both are empty, but only the first must refuse to serve reads.
+pub fn is_rebuilding(database: &rocksdb::DB, network_id: u16) -> Result<bool> {
+    Ok(get_metadata(database, network_id, MetadataKey::RebuildInProgress)?.is_some_and(|flag| flag == [1]))
+}
+
+/// Records that the finalize state has been discarded, or that the replay has finished.
+pub fn set_rebuilding(database: &rocksdb::DB, network_id: u16, rebuilding: bool) -> Result<()> {
+    put_metadata(database, network_id, MetadataKey::RebuildInProgress, &[u8::from(rebuilding)])
+}
+
+/// Records which optional maps the discarded data occupied, as `(history, staking rewards)`.
+///
+/// Written by the clear, because after it nothing on disk says what was there. A resumed run cannot
+/// re-derive this -- an emptied history map and one that never existed look identical -- and
+/// without the record a rebuild begun by a `history` build could be finished by one without it,
+/// which would stamp the schema version over a history that had been discarded and never rewritten.
+fn record_required_features(database: &rocksdb::DB, network_id: u16, history: bool, rewards: bool) -> Result<()> {
+    let mask = u8::from(history) | (u8::from(rewards) << 1);
+    put_metadata(database, network_id, MetadataKey::RebuildRequiredFeatures, &[mask])
+}
+
+/// Returns which optional maps the discarded data occupied, as `(history, staking rewards)`.
+///
+/// An absent record reads as neither, which is what a ledger clear of both would have written.
+pub fn required_features(database: &rocksdb::DB, network_id: u16) -> Result<(bool, bool)> {
+    let mask = get_metadata(database, network_id, MetadataKey::RebuildRequiredFeatures)?
+        .and_then(|bytes| bytes.first().copied())
+        .unwrap_or(0);
+    Ok((mask & 1 != 0, mask & 2 != 0))
+}
+
+/// Discards every map the replay reproduces, and compacts the space back.
+///
+/// Marks the rebuild in progress *before* deleting anything. A crash between the two would
+/// otherwise leave a partly emptied finalize store that reports itself intact, which is the one
+/// state worse than the corruption being repaired. Ordered the other way the failure is benign: a
+/// flag set over an untouched store just makes the next run clear it again, which it would do
+/// anyway since this is idempotent.
+///
+/// The compaction is deliberate. `delete_range` only writes tombstones, and a replay that then
+/// seeks through hundreds of millions of them pays for every one on every read.
+pub fn clear_rebuilt_state(database: &rocksdb::DB, network_id: u16) -> Result<()> {
+    let (history, rewards) = (has_history(database, network_id)?, has_staking_rewards(database, network_id)?);
+    record_required_features(database, network_id, history, rewards)?;
+    set_rebuilding(database, network_id, true)?;
+
+    for map_id in REBUILT_MAPS {
+        let start = map_context(network_id, *map_id);
+        let Some(end) = prefix_end(&start) else { continue };
+
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.delete_range(&start, &end);
+        database.write(batch)?;
+
+        database.compact_range(Some(&start), Some(&end));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prefix_end_carries() {
+        assert_eq!(prefix_end(&[0, 0]), Some(vec![0, 1]));
+        assert_eq!(prefix_end(&[0, 0xFF]), Some(vec![1]));
+        assert_eq!(prefix_end(&[0xFF, 0xFF]), None);
+    }
+
+    /// The bound must cover every key of the map, and nothing outside it.
+    #[test]
+    fn test_prefix_end_bounds_one_map() {
+        let start = map_context(3, MapID::Program(ProgramMap::MappingUpdate));
+        let end = prefix_end(&start).unwrap();
+
+        // A key of this map, however long its body, sorts below the bound.
+        let mut longest = start.clone();
+        longest.extend_from_slice(&[0xFF; 64]);
+        assert!(longest.as_slice() < end.as_slice());
+
+        // Nothing at or above the bound carries this map's prefix, so no other map is in range.
+        assert!(!end.starts_with(&start));
+    }
+}

--- a/ledger/store/src/helpers/rocksdb/internal/history_rebuild.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/history_rebuild.rs
@@ -91,6 +91,15 @@ pub fn allow_downlevel_open() {
     DOWNLEVEL_OPEN_ALLOWED.store(true, Ordering::SeqCst);
 }
 
+/// Restores the storage schema gate, undoing [`allow_downlevel_open`].
+///
+/// The bypass is a process-wide latch, so leaving it set outlives the rebuild that needed it: a
+/// rebuild that fails partway would otherwise let the same process go on to open the half-emptied
+/// finalize state it just refused to leave behind.
+pub fn disallow_downlevel_open() {
+    DOWNLEVEL_OPEN_ALLOWED.store(false, Ordering::SeqCst);
+}
+
 /// Returns whether [`allow_downlevel_open`] has been called.
 pub(crate) fn downlevel_open_allowed() -> bool {
     DOWNLEVEL_OPEN_ALLOWED.load(Ordering::SeqCst)
@@ -103,13 +112,17 @@ pub(crate) fn downlevel_open_allowed() -> bool {
 /// leave the rebuild without a resume point: `CommitteeStorage::insert` requires each height to
 /// follow the last, so a cleared committee store is what makes a resumed replay verify its own
 /// position instead of trusting a recorded cursor.
+/// `RejectedReason` is deliberately absent. Its rows are keyed by transaction id rather than by
+/// height, so the encoding fault never touched them -- and a replay could not put them back. They
+/// are written from `atomic_finalize` only for transaction ids present in `VM::pending_rejected_reasons`,
+/// which is populated exclusively by speculation, a step a replay does not perform. Clearing them
+/// would empty the map for good.
 const REBUILT_MAPS: &[MapID] = &[
     MapID::Program(ProgramMap::ProgramID),
     MapID::Program(ProgramMap::KeyValueID),
     MapID::Program(ProgramMap::MappingUpdate),
     MapID::Program(ProgramMap::MappingUpdateHeights),
     MapID::Program(ProgramMap::StakingRewards),
-    MapID::Program(ProgramMap::RejectedReason),
     MapID::Committee(CommitteeMap::CurrentRound),
     MapID::Committee(CommitteeMap::RoundToHeight),
     MapID::Committee(CommitteeMap::Committee),

--- a/ledger/store/src/helpers/rocksdb/internal/history_rebuild.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/history_rebuild.rs
@@ -61,7 +61,7 @@
 //! that never opens the typed history map can still discard it.
 
 use aleo_std_storage::StorageMode;
-use anyhow::Result;
+use anyhow::{Result, bail};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::{
@@ -73,6 +73,7 @@ use super::{
     RocksDB,
     get_metadata,
     map_context,
+    metadata_key,
     put_metadata,
 };
 
@@ -223,9 +224,8 @@ pub fn set_rebuilding(database: &rocksdb::DB, network_id: u16, rebuilding: bool)
 /// re-derive this -- an emptied history map and one that never existed look identical -- and
 /// without the record a rebuild begun by a `history` build could be finished by one without it,
 /// which would stamp the schema version over a history that had been discarded and never rewritten.
-fn record_required_features(database: &rocksdb::DB, network_id: u16, history: bool, rewards: bool) -> Result<()> {
-    let mask = u8::from(history) | (u8::from(rewards) << 1);
-    put_metadata(database, network_id, MetadataKey::RebuildRequiredFeatures, &[mask])
+fn required_features_mask(history: bool, rewards: bool) -> [u8; 1] {
+    [u8::from(history) | (u8::from(rewards) << 1)]
 }
 
 /// Returns which optional maps the discarded data occupied, as `(history, staking rewards)`.
@@ -250,18 +250,37 @@ pub fn required_features(database: &rocksdb::DB, network_id: u16) -> Result<(boo
 /// seeks through hundreds of millions of them pays for every one on every read.
 pub fn clear_rebuilt_state(database: &rocksdb::DB, network_id: u16) -> Result<()> {
     let (history, rewards) = (has_history(database, network_id)?, has_staking_rewards(database, network_id)?);
-    record_required_features(database, network_id, history, rewards)?;
-    set_rebuilding(database, network_id, true)?;
 
+    // One batch for the flag, the record and every range. A batch is applied atomically, so the
+    // ledger is either untouched or fully cleared, and never the state in between.
+    //
+    // That state is unrecoverable, not merely untidy: the resume path skips the clear whenever the
+    // rebuild flag is set, so a half-cleared store is never cleared again. With the committee maps
+    // emptied but the mapping maps intact, a resumed run would replay from genesis on top of
+    // tip-era key-values and the original little-endian history, and could finish and stamp the
+    // schema version over entries it never touched.
+    let mut batch = rocksdb::WriteBatch::default();
+    batch.put(metadata_key(network_id, MetadataKey::RebuildInProgress), [1]);
+    batch.put(metadata_key(network_id, MetadataKey::RebuildRequiredFeatures), required_features_mask(history, rewards));
+
+    let mut ranges = Vec::with_capacity(REBUILT_MAPS.len());
     for map_id in REBUILT_MAPS {
         let start = map_context(network_id, *map_id);
-        let Some(end) = prefix_end(&start) else { continue };
-
-        let mut batch = rocksdb::WriteBatch::default();
+        // Fail closed. Skipping a map here would leave its pre-rebuild contents in place while the
+        // run went on to stamp the ledger as repaired.
+        let Some(end) = prefix_end(&start) else {
+            bail!("The key range of {map_id:?} cannot be bounded, so it cannot be discarded safely")
+        };
         batch.delete_range(&start, &end);
-        database.write(batch)?;
+        ranges.push((start, end));
+    }
+    database.write(batch)?;
 
-        database.compact_range(Some(&start), Some(&end));
+    // Compaction only reclaims space, so it is outside the batch. It is also the longest blocking
+    // step in the whole run, hence a line per map rather than silence for hours.
+    for (index, (start, end)) in ranges.iter().enumerate() {
+        tracing::info!("Compacting discarded map {} of {}", index + 1, ranges.len());
+        database.compact_range(Some(start), Some(end));
     }
 
     Ok(())

--- a/ledger/store/src/helpers/rocksdb/internal/history_rebuild.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/history_rebuild.rs
@@ -13,52 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Storage migration v0 -> v1: discard the finalize state and rebuild it by replaying blocks.
+//! Storage migration v0 -> v1: discard the finalize state so it can be rebuilt by replaying blocks.
 //!
-//! # What is being repaired
+//! # Hazard: the two height encodings collide
 //!
-//! Three incompatible layouts of `MappingUpdateMap` shipped in quick succession, and nothing on
-//! disk records which one wrote a given entry:
+//! `HeightBytes` is the last field of a `MappingUpdateMap` key, so `LE(256)` and `BE(65_536)` are
+//! the same raw key. A key written at both heights kept only the later value; the other is gone and
+//! cannot be recovered from this database. Any repair that relocates surviving entries inherits
+//! those holes, which is why the state is discarded and recomputed rather than re-encoded.
 //!
-//! | snarkOS | height encoding | `MappingUpdateHeightsMap` |
-//! |---|---|---|
-//! | <= v4.7.4 | little-endian | written, and lists every entry |
-//! | v4.7.5, v4.8.0 | little-endian | **not written** |
-//! | v4.8.1+ | big-endian for keys with no heights row, little-endian for keys with one | frozen or appended |
+//! # Hazard: the mapping state must go with the history
 //!
-//! # Why the entries cannot be repaired in place
-//!
-//! `HeightBytes` is the final field of the raw key, so re-encoding an entry is a suffix
-//! byte-reversal -- which makes it tempting to classify each entry and move the little-endian ones.
-//! That cannot be made complete, because the two encodings collide and the collision already
-//! destroyed data on the running node.
-//!
-//! `LE(256)` and `BE(65_536)` are the same four bytes. A key written at height 256 while the node
-//! ran a little-endian build, and again at height 65,536 after it upgraded, produced *one* raw key:
-//! the second write overwrote the first, and height 256's value is gone. Nothing on disk can bring
-//! it back. The collision needs `byte_reverse(h)` to also be a real height, which for a ~20.8M tip
-//! bounds it at roughly 0.6% of the little-endian window -- and `credits.aleo/{committee, delegated,
-//! bonded}` reach that bound exactly, because `replace_mapping` rewrites every key in the mapping on
-//! every reward block.
-//!
-//! So any repair that relocates existing entries inherits those holes. Rebuilding the values is the
-//! only way to fill them, and the values are recoverable: the blocks are still on disk, and
-//! replaying their finalize operations reproduces every mapping update at the height it happened.
-//!
-//! # What is discarded
-//!
-//! Everything the finalize and committee stores own. The mapping state is discarded along with the
-//! history because a replay must run forward from genesis: reproducing the update at height `h`
-//! requires the state as it stood at `h - 1`, and the only state on disk is the one at the tip.
-//!
-//! Blocks, transactions, transitions and deployments are never touched. They are the source the
-//! rebuild reads from.
-//!
-//! # Why this is raw
-//!
-//! Clearing a map through the typed API would deserialize every key and value only to drop them.
-//! Working on raw prefixes also means the clear runs whatever cargo features are enabled: a build
-//! that never opens the typed history map can still discard it.
+//! Reproducing the update at height `h` needs the state as it stood at `h - 1`, and the only state
+//! on disk is the one at the tip. Blocks, transactions, transitions and deployments are never
+//! touched; they are the source the rebuild reads from.
 
 use aleo_std_storage::StorageMode;
 use anyhow::{Result, bail};
@@ -163,8 +131,16 @@ fn prefix_end(prefix: &[u8]) -> Option<Vec<u8>> {
 }
 
 /// Returns whether any key exists under the given prefix.
-fn prefix_is_occupied(database: &rocksdb::DB, prefix: &[u8]) -> bool {
-    database.prefix_iterator(prefix).next().is_some()
+///
+/// A read failure is propagated rather than counted as occupied. Reporting it as occupied would
+/// record staking rewards as present on a ledger that may hold none, pinning every resumed run to a
+/// build with that feature.
+fn prefix_is_occupied(database: &rocksdb::DB, prefix: &[u8]) -> Result<bool> {
+    match database.prefix_iterator(prefix).next() {
+        Some(Ok(_)) => Ok(true),
+        Some(Err(error)) => Err(error.into()),
+        None => Ok(false),
+    }
 }
 
 /// Opens the ledger at `storage`, bypassing the storage schema gate for the rest of the process.
@@ -194,7 +170,12 @@ pub fn set_schema_version(database: &rocksdb::DB, network_id: u16, version: u32)
 /// A ledger with none has nothing to rebuild, so the version is stamped in passing and a node that
 /// never enabled the `history` feature never sees a rebuild prompt for work that does not exist.
 pub fn has_history(database: &rocksdb::DB, network_id: u16) -> Result<bool> {
-    Ok(HISTORY_MAPS.iter().any(|map_id| prefix_is_occupied(database, &map_context(network_id, *map_id))))
+    for map_id in HISTORY_MAPS {
+        if prefix_is_occupied(database, &map_context(network_id, *map_id))? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Returns whether the ledger holds historical staking rewards.
@@ -202,7 +183,7 @@ pub fn has_history(database: &rocksdb::DB, network_id: u16) -> Result<bool> {
 /// Asked separately from the history because it is written under a separate cargo feature, and a
 /// build without that feature would discard these entries and rebuild nothing in their place.
 pub fn has_staking_rewards(database: &rocksdb::DB, network_id: u16) -> Result<bool> {
-    Ok(prefix_is_occupied(database, &map_context(network_id, MapID::Program(ProgramMap::StakingRewards))))
+    prefix_is_occupied(database, &map_context(network_id, MapID::Program(ProgramMap::StakingRewards)))
 }
 
 /// Returns whether the finalize state has been discarded and is awaiting replay.

--- a/ledger/store/src/helpers/rocksdb/internal/history_rebuild.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/history_rebuild.rs
@@ -112,20 +112,28 @@ pub(crate) fn downlevel_open_allowed() -> bool {
 /// leave the rebuild without a resume point: `CommitteeStorage::insert` requires each height to
 /// follow the last, so a cleared committee store is what makes a resumed replay verify its own
 /// position instead of trusting a recorded cursor.
+///
+/// **The committee maps must stay first.** The resume point is the committee store's height, so
+/// clearing them last would mean an interruption partway -- most likely during `MappingUpdate`,
+/// which holds hundreds of millions of rows and is followed by a synchronous compaction -- left the
+/// mapping state gone while the committee still read as the tip. The next run would then resume at
+/// `tip + 1`, replay nothing, satisfy its completeness check vacuously, and stamp the schema
+/// version over a destroyed ledger. Clearing them first makes any interruption resume from
+/// genesis.
 /// `RejectedReason` is deliberately absent. Its rows are keyed by transaction id rather than by
 /// height, so the encoding fault never touched them -- and a replay could not put them back. They
 /// are written from `atomic_finalize` only for transaction ids present in `VM::pending_rejected_reasons`,
 /// which is populated exclusively by speculation, a step a replay does not perform. Clearing them
 /// would empty the map for good.
 const REBUILT_MAPS: &[MapID] = &[
+    MapID::Committee(CommitteeMap::CurrentRound),
+    MapID::Committee(CommitteeMap::RoundToHeight),
+    MapID::Committee(CommitteeMap::Committee),
     MapID::Program(ProgramMap::ProgramID),
     MapID::Program(ProgramMap::KeyValueID),
     MapID::Program(ProgramMap::MappingUpdate),
     MapID::Program(ProgramMap::MappingUpdateHeights),
     MapID::Program(ProgramMap::StakingRewards),
-    MapID::Committee(CommitteeMap::CurrentRound),
-    MapID::Committee(CommitteeMap::RoundToHeight),
-    MapID::Committee(CommitteeMap::Committee),
 ];
 
 /// The maps holding historical mapping updates.
@@ -164,7 +172,10 @@ fn prefix_is_occupied(database: &rocksdb::DB, prefix: &[u8]) -> bool {
 /// that same database back rather than a second connection to it.
 pub fn open_for_rebuild<S: Into<StorageMode>>(network_id: u16, storage: S) -> Result<RocksDB> {
     allow_downlevel_open();
-    RocksDB::open(network_id, storage)
+    // Restore the gate if the open fails -- a wrong path, or a node still holding the lock. There is
+    // no rebuild to keep it open for in that case, and leaving a process-wide latch set is exactly
+    // what `disallow_downlevel_open` exists to prevent.
+    RocksDB::open(network_id, storage).inspect_err(|_| disallow_downlevel_open())
 }
 
 /// Returns the storage schema version the database was last written under.

--- a/ledger/store/src/helpers/rocksdb/internal/id.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/id.rs
@@ -29,6 +29,7 @@ pub enum MapID {
     TransitionInput(TransitionInputMap),
     TransitionOutput(TransitionOutputMap),
     Program(ProgramMap),
+    Metadata(MetadataMap),
     #[cfg(test)]
     Test(TestMap),
 }
@@ -47,6 +48,7 @@ impl From<MapID> for u16 {
             MapID::TransitionInput(id) => id as u16,
             MapID::TransitionOutput(id) => id as u16,
             MapID::Program(id) => id as u16,
+            MapID::Metadata(id) => id as u16,
             #[cfg(test)]
             MapID::Test(id) => id as u16,
         }
@@ -218,6 +220,16 @@ pub enum ProgramMap {
     RejectedReason = DataID::RejectedReasonMap as u16,
 }
 
+/// The RocksDB map prefix for storage metadata.
+///
+/// A single map holding a handful of well-known keys rather than one map per item, so that future
+/// metadata needs no further `DataID` variants (which can never be removed once written).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum MetadataMap {
+    Metadata = DataID::StorageMetadataMap as u16,
+}
+
 /// The RocksDB map prefix for test-related entries.
 // Note: the order of these variants can be changed at any point in time.
 #[cfg(test)]
@@ -344,6 +356,9 @@ enum DataID {
 
     // Track rejection reasons for rejected transactions
     RejectedReasonMap,
+
+    // Storage metadata: schema versions and migration progress.
+    StorageMetadataMap,
 
     // Testing
     #[cfg(test)]

--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -17,6 +17,7 @@ mod history_rebuild;
 pub use history_rebuild::{
     allow_downlevel_open,
     clear_rebuilt_state,
+    disallow_downlevel_open,
     has_history,
     has_staking_rewards,
     is_rebuilding,

--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -205,12 +205,14 @@ fn check_storage_version(database: &rocksdb::DB, network_id: u16) -> Result<()> 
     // Asked per outstanding migration rather than as one hardcoded probe: a future v1 -> v2
     // migration concerning some other map would otherwise be skipped on any ledger without
     // history, stamping a database as being in a layout it is not in.
-    if !(found..STORAGE_VERSION)
-        .map(|v| has_work(database, network_id, v))
-        .collect::<Result<Vec<_>>>()?
-        .iter()
-        .any(|has| *has)
-    {
+    let mut outstanding = false;
+    for version in found..STORAGE_VERSION {
+        if has_work(database, network_id, version)? {
+            outstanding = true;
+            break;
+        }
+    }
+    if !outstanding {
         put_metadata(database, network_id, MetadataKey::StorageVersion, &STORAGE_VERSION.to_le_bytes())?;
         return Ok(());
     }

--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -147,11 +147,11 @@ fn has_work(database: &rocksdb::DB, network_id: u16, version: u32) -> Result<boo
 /// The remedy printed when a ledger needs rebuilding.
 const REBUILD_REMEDY: &str = "Stop the node and rebuild its finalize state with snarkVM's \
                               `rebuild_db` tool, built from this release:\n\n    cargo build \
-                              --release --bin rebuild_db --features rebuild,history\n    \
+                              --release --bin rebuild_db --features rebuild,history[,history-staking-rewards]\n    \
                               rebuild_db <ledger-dir>\n\nIt replays every block from local \
                               storage and can take hours on an archive node. It reports progress, \
                               and can be interrupted and resumed. Pass --check first to see what it \
-                              would do.";
+                              would do. Build it with the same history features the node runs with.";
 
 /// Verifies the ledger's storage schema is one this build understands.
 ///

--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -145,10 +145,13 @@ fn has_work(database: &rocksdb::DB, network_id: u16, version: u32) -> Result<boo
 }
 
 /// The remedy printed when a ledger needs rebuilding.
-const REBUILD_REMEDY: &str = "Stop the node and rebuild its finalize state:\n\n    snarkos \
-                              developer rebuild-history <ledger-dir>\n\nThe rebuild replays every \
-                              block from local storage and can take hours on an archive node. It \
-                              reports progress, and can be interrupted and resumed.";
+const REBUILD_REMEDY: &str = "Stop the node and rebuild its finalize state with snarkVM's \
+                              `rebuild_db` tool, built from this release:\n\n    cargo build \
+                              --release --bin rebuild_db --features rebuild,history\n    \
+                              rebuild_db <ledger-dir>\n\nIt replays every block from local \
+                              storage and can take hours on an archive node. It reports progress, \
+                              and can be interrupted and resumed. Pass --check first to see what it \
+                              would do.";
 
 /// Verifies the ledger's storage schema is one this build understands.
 ///

--- a/ledger/store/src/helpers/rocksdb/internal/mod.rs
+++ b/ledger/store/src/helpers/rocksdb/internal/mod.rs
@@ -13,6 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod history_rebuild;
+pub use history_rebuild::{
+    allow_downlevel_open,
+    clear_rebuilt_state,
+    has_history,
+    has_staking_rewards,
+    is_rebuilding,
+    open_for_rebuild,
+    required_features,
+    schema_version,
+    set_rebuilding,
+    set_schema_version,
+};
+
 mod id;
 pub use id::*;
 
@@ -26,7 +40,7 @@ pub use nested_map::*;
 mod tests;
 
 use aleo_std_storage::StorageMode;
-use anyhow::{Result, bail, ensure};
+use anyhow::{Result, anyhow, bail, ensure};
 #[cfg(feature = "locktick")]
 use locktick::parking_lot::Mutex;
 #[cfg(not(feature = "locktick"))]
@@ -47,6 +61,158 @@ use std::{
 };
 
 pub const PREFIX_LEN: usize = 4; // N::ID (u16) + DataID (u16)
+
+/// The storage schema version this build writes and understands.
+///
+/// Bump this whenever the on-disk layout changes in a way that a build expecting the previous
+/// version would read incorrectly. A database records the version it was last written under, so a
+/// build can refuse a database from the future instead of silently misreading it.
+///
+/// Note this only protects forward from the release that introduced it: builds older than that do
+/// not consult the record at all. Three incompatible historical-mapping layouts shipped within
+/// three weeks with nothing on disk to distinguish them, which is the situation this exists to
+/// prevent recurring.
+pub const STORAGE_VERSION: u32 = 1;
+
+/// The well-known keys of the storage metadata map.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum MetadataKey {
+    /// The storage schema version the database was last written under.
+    StorageVersion = 0,
+    /// Whether the finalize state has been discarded and is awaiting replay.
+    ///
+    /// Distinct from the version, which only advances once a rebuild completes. This says the
+    /// ledger is mid-rebuild, and an empty finalize store cannot say that for itself: a fresh
+    /// ledger looks identical, and only one of the two must refuse to serve reads.
+    RebuildInProgress = 1,
+    /// Which optional maps the discarded data occupied, so a resumed rebuild can still tell.
+    RebuildRequiredFeatures = 2,
+}
+
+/// Returns the 4-byte `[network_id, map_id]` prefix a map's keys sit behind.
+///
+/// The layout is a persisted on-disk invariant, so it is built in one place rather than repeated
+/// wherever a raw key is needed.
+pub(crate) fn map_context(network_id: u16, map_id: MapID) -> Vec<u8> {
+    let mut raw = Vec::with_capacity(PREFIX_LEN);
+    raw.extend_from_slice(&network_id.to_le_bytes());
+    raw.extend_from_slice(&u16::from(map_id).to_le_bytes());
+    raw
+}
+
+/// Returns the raw database key for a metadata entry.
+pub(crate) fn metadata_key(network_id: u16, key: MetadataKey) -> Vec<u8> {
+    let mut raw = map_context(network_id, MapID::Metadata(MetadataMap::Metadata));
+    raw.push(key as u8);
+    raw
+}
+
+/// Reads a metadata entry, or `None` if the database has never recorded it.
+pub(crate) fn get_metadata(database: &rocksdb::DB, network_id: u16, key: MetadataKey) -> Result<Option<Vec<u8>>> {
+    Ok(database.get(metadata_key(network_id, key))?)
+}
+
+/// Writes a metadata entry.
+pub(crate) fn put_metadata(database: &rocksdb::DB, network_id: u16, key: MetadataKey, value: &[u8]) -> Result<()> {
+    Ok(database.put(metadata_key(network_id, key), value)?)
+}
+
+/// Reads a `u32` metadata entry, treating an absent record as zero.
+///
+/// Zero is the right default: every database written before this record existed is, by definition,
+/// at the version that preceded it.
+pub(crate) fn get_metadata_u32(database: &rocksdb::DB, network_id: u16, key: MetadataKey) -> Result<u32> {
+    match get_metadata(database, network_id, key)? {
+        Some(bytes) => {
+            let bytes: [u8; 4] = bytes.as_slice().try_into().map_err(|_| anyhow!("Malformed metadata for {key:?}"))?;
+            Ok(u32::from_le_bytes(bytes))
+        }
+        None => Ok(0),
+    }
+}
+
+/// Returns whether the migration from `version` to `version + 1` has anything to do here.
+///
+/// Lets the version be stamped in passing when every outstanding migration is a no-op, without that
+/// shortcut being tied to what any one of them happens to be about.
+fn has_work(database: &rocksdb::DB, network_id: u16, version: u32) -> Result<bool> {
+    match version {
+        0 => history_rebuild::has_history(database, network_id),
+        other => bail!("No storage migration is defined for schema v{other}"),
+    }
+}
+
+/// The remedy printed when a ledger needs rebuilding.
+const REBUILD_REMEDY: &str = "Stop the node and rebuild its finalize state:\n\n    snarkos \
+                              developer rebuild-history <ledger-dir>\n\nThe rebuild replays every \
+                              block from local storage and can take hours on an archive node. It \
+                              reports progress, and can be interrupted and resumed.";
+
+/// Verifies the ledger's storage schema is one this build understands.
+///
+/// Deliberately does **not** rebuild. A rebuild replays the whole chain and can take hours, which
+/// is not something a node should do as a side effect of starting: an operator wants to run it when
+/// they choose, watching it, able to stop it. So this is a point lookup that refuses to proceed and
+/// says what to run, in the manner of every other system that separates schema migration from
+/// application startup.
+///
+/// A database with no history to rebuild is stamped in passing, so a fresh node -- or one that never
+/// enabled the `history` feature -- never sees a rebuild prompt for work that does not exist.
+fn check_storage_version(database: &rocksdb::DB, network_id: u16) -> Result<()> {
+    // The rebuild must open the very database this gate exists to keep a node out of.
+    if history_rebuild::downlevel_open_allowed() {
+        return Ok(());
+    }
+
+    // Checked before the version, which is still at the old one throughout a rebuild and so cannot
+    // distinguish "not started" from "half done". It matters because the finalize state has already
+    // been discarded by this point: were this ordered after the stamp-in-passing shortcut below,
+    // that shortcut would find no history, conclude there was nothing to do, and start a node on an
+    // empty finalize store.
+    ensure!(
+        !history_rebuild::is_rebuilding(database, network_id)?,
+        "This ledger's finalize state was discarded by a rebuild that has not finished. It cannot \
+         be read until the rebuild completes.\n\n{REBUILD_REMEDY}"
+    );
+
+    let found = get_metadata_u32(database, network_id, MetadataKey::StorageVersion)?;
+
+    // A database from the future cannot be read safely, and the failure would otherwise be silent
+    // and data-dependent rather than immediate.
+    ensure!(
+        found <= STORAGE_VERSION,
+        "This ledger was written by a newer version of snarkVM (storage schema v{found}; this \
+         build understands v{STORAGE_VERSION}). Upgrade snarkVM, or resync from genesis."
+    );
+    if found == STORAGE_VERSION {
+        return Ok(());
+    }
+
+    // Nothing recorded, and nothing to record: stamp it and carry on.
+    //
+    // The gate is on the *data*, not on which features this build was compiled with, and that is a
+    // correctness requirement rather than a convenience. A build that does not read history could
+    // stamp the version without rebuilding, since it would never notice the difference -- but the
+    // stamp is what a later history-enabled build consults, and it would then skip the rebuild and
+    // read little-endian entries as big-endian. Blocking a non-history node that carries unrebuilt
+    // history is the price of the version meaning what it says.
+    //
+    // Asked per outstanding migration rather than as one hardcoded probe: a future v1 -> v2
+    // migration concerning some other map would otherwise be skipped on any ledger without
+    // history, stamping a database as being in a layout it is not in.
+    if !(found..STORAGE_VERSION)
+        .map(|v| has_work(database, network_id, v))
+        .collect::<Result<Vec<_>>>()?
+        .iter()
+        .any(|has| *has)
+    {
+        put_metadata(database, network_id, MetadataKey::StorageVersion, &STORAGE_VERSION.to_le_bytes())?;
+        return Ok(());
+    }
+
+    bail!("This ledger is at storage schema v{found}, and this build requires v{STORAGE_VERSION}.\n\n{REBUILD_REMEDY}");
+}
 
 // A static map of database paths to their objects; it's needed in order to facilitate concurrent
 // tests involving persistent storage, but it only ever has a single member outside of them.
@@ -181,6 +347,9 @@ impl Database for RocksDB {
         } else {
             ensure!(databases.len() == 1, "There can only be one active rocksDB database when not in test mode.");
         }
+
+        // Refuse a schema this build does not understand, before anything reads it.
+        check_storage_version(&database.rocksdb, network_id)?;
 
         // Ensure the database network ID and storage mode match.
         match database.network_id == network_id && database.storage_mode == storage {

--- a/ledger/store/src/helpers/rocksdb/program.rs
+++ b/ledger/store/src/helpers/rocksdb/program.rs
@@ -52,9 +52,6 @@ pub struct FinalizeDB<N: Network> {
     /// The historical mapping value map (keyed by big-endian block height).
     #[cfg(feature = "history")]
     mapping_update_map: DataMap<(ProgramID<N>, Identifier<N>, Plaintext<N>, HeightBytes), Value<N>>,
-    /// The legacy heights index; present only for keys written before the BE schema change.
-    #[cfg(feature = "history")]
-    mapping_update_heights_map: DataMap<(ProgramID<N>, Identifier<N>, Plaintext<N>), Vec<u32>>,
     /// The current block height.
     #[cfg(feature = "history")]
     block_height: Arc<AtomicU32>,
@@ -73,8 +70,6 @@ impl<N: Network> FinalizeStorage<N> for FinalizeDB<N> {
     type RejectedReasonMap = DataMap<Field<N>, RejectedReason<N>>;
     #[cfg(feature = "history")]
     type MappingUpdateMap = DataMap<(ProgramID<N>, Identifier<N>, Plaintext<N>, HeightBytes), Value<N>>;
-    #[cfg(feature = "history")]
-    type MappingUpdateHeightsMap = DataMap<(ProgramID<N>, Identifier<N>, Plaintext<N>), Vec<u32>>;
     #[cfg(feature = "history-staking-rewards")]
     type StakingRewardsMap = DataMap<(Address<N>, u32), (Address<N>, u64, u64)>;
 
@@ -97,8 +92,6 @@ impl<N: Network> FinalizeStorage<N> for FinalizeDB<N> {
             rejected_reason_map: rocksdb::RocksDB::open_map(N::ID, storage.clone(), MapID::Program(ProgramMap::RejectedReason))?,
             #[cfg(feature = "history")]
             mapping_update_map: rocksdb::RocksDB::open_map(N::ID, storage.clone(), MapID::Program(ProgramMap::MappingUpdate))?,
-            #[cfg(feature = "history")]
-            mapping_update_heights_map: rocksdb::RocksDB::open_map(N::ID, storage.clone(), MapID::Program(ProgramMap::MappingUpdateHeights))?,
             #[cfg(feature = "history")]
             block_height: Arc::new(AtomicU32::new(initial_height)),
             #[cfg(feature = "history-staking-rewards")]
@@ -131,11 +124,6 @@ impl<N: Network> FinalizeStorage<N> for FinalizeDB<N> {
     #[cfg(feature = "history")]
     fn mapping_update_map(&self) -> &Self::MappingUpdateMap {
         &self.mapping_update_map
-    }
-
-    #[cfg(feature = "history")]
-    fn mapping_update_heights_map(&self) -> &Self::MappingUpdateHeightsMap {
-        &self.mapping_update_heights_map
     }
 
     /// Returns the historical staking rewards map.

--- a/ledger/store/src/program/finalize.rs
+++ b/ledger/store/src/program/finalize.rs
@@ -26,7 +26,7 @@ use console::{
     types::Field,
 };
 use snarkvm_ledger_block::RejectedReason;
-use snarkvm_synthesizer_program::{FinalizeOperation, FinalizeStoreTrait};
+use snarkvm_synthesizer_program::{FinalizeOperation, FinalizeStoreTrait, Program};
 
 use aleo_std_storage::StorageMode;
 use anyhow::Result;
@@ -805,6 +805,20 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
                 });
             }
         }
+    }
+
+    /// Initializes any `credits.aleo` mapping that is not already present.
+    ///
+    /// Called when a store is opened and again after a rebuild discards it, since genesis
+    /// ratification replaces these mappings wholesale and refuses one that does not yet exist.
+    pub fn initialize_credits_mappings(&self, credits: &Program<N>) -> Result<()> {
+        let initialized = self.get_mapping_names_confirmed(credits.id())?.unwrap_or_default();
+        for mapping in credits.mappings().values() {
+            if !initialized.contains(mapping.name()) {
+                self.initialize_mapping(*credits.id(), *mapping.name())?;
+            }
+        }
+        Ok(())
     }
 
     /// Returns the historical value of a mapping at or before the given block height.

--- a/ledger/store/src/program/finalize.rs
+++ b/ledger/store/src/program/finalize.rs
@@ -57,9 +57,9 @@ struct SerializedMappingEntries {
 /// New entries encode the height in **big-endian** order so that lexicographic key order matches
 /// numeric height order, enabling O(log n) floor seeks via `get_floor_confirmed`.
 ///
-/// Legacy entries (written before this schema change) use **little-endian** order (the `bincode`
-/// default for `u32`).  They are distinguished at read time by the presence of an entry in
-/// `mapping_update_heights_map`; see `get_historical_mapping_value` for details.
+/// Databases written under the earlier little-endian layout are discarded and rebuilt by the
+/// v0 -> v1 storage migration before the store is opened, so only this encoding is ever present
+/// here.
 #[cfg(feature = "history")]
 pub(crate) type HeightBytes = [u8; 4];
 
@@ -113,20 +113,11 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
     type RejectedReasonMap: for<'a> Map<'a, Field<N>, RejectedReason<N>>;
     /// The mapping of `(program ID, mapping name, key, height)` to `value`.
     ///
-    /// The height component is a [`HeightBytes`]: big-endian for new entries, little-endian
-    /// for legacy entries (detected via `mapping_update_heights_map`).
-    ///
-    /// Big-endian encoding lets lexicographic key order match numeric height order, enabling
+    /// The height component is a [`HeightBytes`], always big-endian, which lets lexicographic key
+    /// order match numeric height order, enabling
     /// O(log n) floor lookups via `get_floor_confirmed`.
     #[cfg(feature = "history")]
     type MappingUpdateMap: for<'a> Map<'a, (ProgramID<N>, Identifier<N>, Plaintext<N>, HeightBytes), Value<N>>;
-    /// The mapping of `(program ID, mapping name, key)` to `[height]`.
-    ///
-    /// Present only for keys written before the big-endian schema change. Acts as a
-    /// "legacy sentinel": if an entry exists here the key still uses the old LE encoding,
-    /// and `get_historical_mapping_value` falls back to the O(n) binary-search path.
-    #[cfg(feature = "history")]
-    type MappingUpdateHeightsMap: for<'a> Map<'a, (ProgramID<N>, Identifier<N>, Plaintext<N>), Vec<u32>>;
     /// The mapping of `(staker address, height)` to `(validator address, block reward, new stake)`.
     #[cfg(feature = "history-staking-rewards")]
     type StakingRewardsMap: for<'a> Map<'a, (Address<N>, u32), (Address<N>, u64, u64)>;
@@ -145,9 +136,6 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
     /// Returns the historical mapping value map.
     #[cfg(feature = "history")]
     fn mapping_update_map(&self) -> &Self::MappingUpdateMap;
-    /// Returns the historical mapping update heights map (legacy: present only for pre-schema-change keys).
-    #[cfg(feature = "history")]
-    fn mapping_update_heights_map(&self) -> &Self::MappingUpdateHeightsMap;
     /// Returns the historical staking rewards map.
     #[cfg(feature = "history-staking-rewards")]
     fn staking_rewards_map(&self) -> &Self::StakingRewardsMap;
@@ -164,7 +152,6 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
         #[cfg(feature = "history")]
         {
             self.mapping_update_map().start_atomic();
-            self.mapping_update_heights_map().start_atomic();
         }
         #[cfg(feature = "history-staking-rewards")]
         self.staking_rewards_map().start_atomic();
@@ -177,9 +164,7 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
             || self.key_value_map().is_atomic_in_progress()
             || self.rejected_reason_map().is_atomic_in_progress();
         #[cfg(feature = "history")]
-        let ret = ret
-            || self.mapping_update_map().is_atomic_in_progress()
-            || self.mapping_update_heights_map().is_atomic_in_progress();
+        let ret = ret || self.mapping_update_map().is_atomic_in_progress();
         #[cfg(feature = "history-staking-rewards")]
         let ret = ret || self.staking_rewards_map().is_atomic_in_progress();
 
@@ -195,7 +180,6 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
         #[cfg(feature = "history")]
         {
             self.mapping_update_map().atomic_checkpoint();
-            self.mapping_update_heights_map().atomic_checkpoint();
         }
         #[cfg(feature = "history-staking-rewards")]
         self.staking_rewards_map().atomic_checkpoint();
@@ -210,7 +194,6 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
         #[cfg(feature = "history")]
         {
             self.mapping_update_map().clear_latest_checkpoint();
-            self.mapping_update_heights_map().clear_latest_checkpoint();
         }
         #[cfg(feature = "history-staking-rewards")]
         self.staking_rewards_map().clear_latest_checkpoint();
@@ -225,7 +208,6 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
         #[cfg(feature = "history")]
         {
             self.mapping_update_map().atomic_rewind();
-            self.mapping_update_heights_map().atomic_rewind();
         }
         #[cfg(feature = "history-staking-rewards")]
         self.staking_rewards_map().atomic_rewind();
@@ -240,7 +222,6 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
         #[cfg(feature = "history")]
         {
             self.mapping_update_map().abort_atomic();
-            self.mapping_update_heights_map().abort_atomic();
         }
         #[cfg(feature = "history-staking-rewards")]
         self.staking_rewards_map().abort_atomic();
@@ -255,7 +236,6 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
         #[cfg(feature = "history")]
         {
             self.mapping_update_map().finish_atomic()?;
-            self.mapping_update_heights_map().finish_atomic()?;
         }
         #[cfg(feature = "history-staking-rewards")]
         self.staking_rewards_map().finish_atomic()?;
@@ -372,22 +352,8 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
             #[cfg(feature = "history")]
             {
                 let current_height = self.current_block_height().load(Ordering::SeqCst);
-                let heights_key = (program_id, mapping_name, key.clone());
-
-                // If this key has a legacy heights-map entry it was written before the BE schema
-                // change; continue appending to the heights vec and write with the original LE
-                // encoding so that reads using the heights-map path remain correct.
-                if let Some(heights) = self.mapping_update_heights_map().get_confirmed(&heights_key)? {
-                    let mut heights = heights.into_owned();
-                    self.mapping_update_map()
-                        .insert((program_id, mapping_name, key.clone(), current_height.to_le_bytes()), value.clone())?;
-                    heights.push(current_height);
-                    self.mapping_update_heights_map().insert(heights_key, heights)?;
-                } else {
-                    // New key: use the big-endian encoding so floor seeks work correctly.
-                    self.mapping_update_map()
-                        .insert((program_id, mapping_name, key.clone(), current_height.to_be_bytes()), value.clone())?;
-                }
+                self.mapping_update_map()
+                    .insert((program_id, mapping_name, key.clone(), current_height.to_be_bytes()), value.clone())?;
             }
 
             // Update the key-value map with the new key-value.
@@ -456,24 +422,8 @@ pub trait FinalizeStorage<N: Network>: 'static + Clone + Send + Sync {
                 #[cfg(feature = "history")]
                 {
                     let current_height = self.current_block_height().load(Ordering::SeqCst);
-                    let heights_key = (program_id, mapping_name, key.clone());
-
-                    // Legacy keys (pre-BE schema) continue using LE encoding + heights vec.
-                    if let Some(heights) = self.mapping_update_heights_map().get_confirmed(&heights_key)? {
-                        let mut heights = heights.into_owned();
-                        self.mapping_update_map().insert(
-                            (program_id, mapping_name, key.clone(), current_height.to_le_bytes()),
-                            value.clone(),
-                        )?;
-                        heights.push(current_height);
-                        self.mapping_update_heights_map().insert(heights_key, heights)?;
-                    } else {
-                        // New key: big-endian encoding.
-                        self.mapping_update_map().insert(
-                            (program_id, mapping_name, key.clone(), current_height.to_be_bytes()),
-                            value.clone(),
-                        )?;
-                    }
+                    self.mapping_update_map()
+                        .insert((program_id, mapping_name, key.clone(), current_height.to_be_bytes()), value.clone())?;
                 }
 
                 // Insert the key-value entry.
@@ -859,13 +809,10 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
 
     /// Returns the historical value of a mapping at or before the given block height.
     ///
-    /// **Fast path** (new keys, no `mapping_update_heights_map` entry): single O(log n)
-    /// floor seek on `mapping_update_map`, which uses big-endian height encoding.
-    ///
-    /// **Legacy path** (keys written before the BE schema change, heights-map entry
-    /// present): O(n) binary search over the heights `Vec`, then a point lookup using
-    /// the original little-endian encoding. Correct but slower; these keys stay on this
-    /// path until the node is resynced or an offline migration is performed.
+    /// A single O(log n) floor seek on `mapping_update_map`, whose height keys are big-endian so
+    /// that lexicographic key order matches numeric height order. Databases written under the
+    /// earlier little-endian layout are discarded and rebuilt by the v0 -> v1 storage migration
+    /// before the store is opened, so only one encoding is ever present here.
     #[cfg(feature = "history")]
     pub fn get_historical_mapping_value(
         &self,
@@ -879,26 +826,7 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
             return Ok(None);
         }
 
-        // Check for a legacy heights-map entry (pre-BE schema change).
-        let heights_key = (program_id, mapping_name, mapping_key.clone());
-        if let Some(heights) = self.storage.mapping_update_heights_map().get_confirmed(&heights_key)? {
-            // Legacy O(n) path: binary search on the heights Vec.
-            let heights = heights.into_owned();
-            let applicable_height = match heights.binary_search(&height) {
-                Ok(_) => height,
-                Err(0) => return Ok(None),
-                Err(idx) => heights[idx - 1],
-            };
-            // Look up with the original little-endian encoding.
-            return self.storage.mapping_update_map().get_confirmed(&(
-                program_id,
-                mapping_name,
-                mapping_key,
-                applicable_height.to_le_bytes(),
-            ));
-        }
-
-        // New fast path: O(log n) floor seek with big-endian encoding.
+        // Find the most recent update at or before the requested height.
         let seek_key = (program_id, mapping_name, mapping_key.clone(), height.to_be_bytes());
         match self.storage.mapping_update_map().get_floor_confirmed(&seek_key)? {
             Some((found_key, found_value)) => {
@@ -911,9 +839,8 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
 
     /// Returns the heights at which past mapping updates occurred, in ascending order.
     ///
-    /// For legacy keys (heights-map entry present) the list is read directly from the
-    /// heights map. For new keys it is reconstructed by scanning `mapping_update_map`.
-    /// Either way this is O(n updates) and is intended for diagnostic / test use only.
+    /// Reconstructed by scanning `mapping_update_map`. This is O(n updates) and is intended for
+    /// diagnostic / test use only.
     #[cfg(feature = "history")]
     pub fn get_mapping_update_heights(
         &self,
@@ -921,13 +848,7 @@ impl<N: Network, P: FinalizeStorage<N>> FinalizeStore<N, P> {
         mapping_name: Identifier<N>,
         mapping_key: Plaintext<N>,
     ) -> Result<Option<Cow<'_, Vec<u32>>>, Error> {
-        // Legacy path: heights are stored explicitly in the heights map.
-        let heights_key = (program_id, mapping_name, mapping_key.clone());
-        if let Some(heights) = self.storage.mapping_update_heights_map().get_confirmed(&heights_key)? {
-            return Ok(Some(heights));
-        }
-
-        // New path: reconstruct from mapping_update_map keys (big-endian encoded heights).
+        // Reconstruct from the mapping_update_map keys, whose heights are big-endian encoded.
         let mut heights: Vec<u32> = self
             .storage
             .mapping_update_map()
@@ -1970,67 +1891,5 @@ mod tests {
         let heights =
             finalize_store.get_mapping_update_heights(program_id, mapping_name, key.clone()).unwrap().unwrap();
         assert_eq!(&*heights, &[10, 20, 50, 100]);
-    }
-
-    /// Verifies the legacy (pre-BE schema) read path: keys whose heights are stored in
-    /// `mapping_update_heights_map` continue to be found correctly via binary search.
-    #[test]
-    #[cfg(feature = "history")]
-    fn test_get_historical_mapping_value_legacy() {
-        use std::sync::atomic::Ordering;
-
-        let program_id = ProgramID::<CurrentNetwork>::from_str("hello.aleo").unwrap();
-        let mapping_name = Identifier::from_str("account").unwrap();
-        let key = Plaintext::from_str("1field").unwrap();
-
-        let program_memory = FinalizeMemory::open(StorageMode::Test(None)).unwrap();
-        let finalize_store = FinalizeStore::from(program_memory).unwrap();
-
-        finalize_store.initialize_mapping(program_id, mapping_name).unwrap();
-
-        // Simulate legacy writes: insert directly into the LE-keyed update map AND into the heights map,
-        // exactly as the old code did.
-        let v5 = Value::from_str("5u64").unwrap();
-        let v10 = Value::from_str("10u64").unwrap();
-        finalize_store
-            .storage
-            .mapping_update_map()
-            .insert((program_id, mapping_name, key.clone(), 5u32.to_le_bytes()), v5.clone())
-            .unwrap();
-        finalize_store
-            .storage
-            .mapping_update_map()
-            .insert((program_id, mapping_name, key.clone(), 10u32.to_le_bytes()), v10.clone())
-            .unwrap();
-        finalize_store
-            .storage
-            .mapping_update_heights_map()
-            .insert((program_id, mapping_name, key.clone()), vec![5, 10])
-            .unwrap();
-        finalize_store.storage.current_block_height().store(20, Ordering::SeqCst);
-
-        // Height before first update → None.
-        assert!(
-            finalize_store.get_historical_mapping_value(program_id, mapping_name, key.clone(), 4).unwrap().is_none()
-        );
-        // Height 5 (exact) → v5.
-        let v = finalize_store.get_historical_mapping_value(program_id, mapping_name, key.clone(), 5).unwrap().unwrap();
-        assert_eq!(*v, v5);
-        // Height 7 (floor → 5) → v5.
-        let v = finalize_store.get_historical_mapping_value(program_id, mapping_name, key.clone(), 7).unwrap().unwrap();
-        assert_eq!(*v, v5);
-        // Height 10 (exact) → v10.
-        let v =
-            finalize_store.get_historical_mapping_value(program_id, mapping_name, key.clone(), 10).unwrap().unwrap();
-        assert_eq!(*v, v10);
-        // Height 15 (floor → 10) → v10.
-        let v =
-            finalize_store.get_historical_mapping_value(program_id, mapping_name, key.clone(), 15).unwrap().unwrap();
-        assert_eq!(*v, v10);
-
-        // Heights list comes from the heights map.
-        let heights =
-            finalize_store.get_mapping_update_heights(program_id, mapping_name, key.clone()).unwrap().unwrap();
-        assert_eq!(&*heights, &[5, 10]);
     }
 }

--- a/ledger/tests/history_rebuild.rs
+++ b/ledger/tests/history_rebuild.rs
@@ -26,6 +26,20 @@ use snarkvm_console::{
 use snarkvm_ledger_store::helpers::rocksdb;
 use snarkvm_synthesizer::vm::VM;
 
+use std::sync::{Mutex, MutexGuard};
+
+/// Serialises the tests in this file.
+///
+/// The schema-gate bypass these tests rely on is a single process-wide latch over a shared database
+/// registry, so two tests running at once decide for each other whether a freshly created ledger
+/// gets its schema version stamped. Left parallel, whether a rebuild actually runs depends on
+/// thread interleaving.
+static SERIAL: Mutex<()> = Mutex::new(());
+
+fn serial() -> MutexGuard<'static, ()> {
+    SERIAL.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// The number of blocks each test replays.
 ///
 /// Every block ratifies a block reward, which rewrites `credits.aleo/{committee, delegated, bonded}`
@@ -98,7 +112,39 @@ fn sample_ledger(rng: &mut TestRng) -> (CurrentLedger, StorageMode) {
     }
     assert_eq!(ledger.latest_height(), NUM_BLOCKS);
 
+    // A ledger built here is stamped at the current schema version the moment it is created: it has
+    // no history yet, so the startup gate records the version in passing. Left that way, every
+    // rebuild below would take the "already rebuilt, nothing to do" path and each assertion would
+    // hold trivially over a chain nothing had touched. Winding the version back is what makes these
+    // tests exercise a replay at all -- and the sentinel each test plants is what proves they did,
+    // rather than this being trusted to stay true.
+    let database = rocksdb::open_for_rebuild(CurrentNetwork::ID, storage_mode.clone()).unwrap();
+    rocksdb::set_schema_version(&database, CurrentNetwork::ID, 0).unwrap();
+
     (ledger, storage_mode)
+}
+
+/// Leaves a mapping behind that no replay would recreate, so a caller can tell whether the finalize
+/// state was actually discarded.
+fn plant_sentinel(ledger: &CurrentLedger) -> (ProgramID<CurrentNetwork>, Identifier<CurrentNetwork>) {
+    let program = ProgramID::<CurrentNetwork>::from_str("not_on_chain.aleo").unwrap();
+    let mapping = Identifier::<CurrentNetwork>::from_str("sentinel").unwrap();
+    ledger.vm().finalize_store().initialize_mapping(program, mapping).unwrap();
+    (program, mapping)
+}
+
+/// Returns whether the sentinel planted by [`plant_sentinel`] is still present.
+fn sentinel_survives(
+    ledger: &CurrentLedger,
+    program: ProgramID<CurrentNetwork>,
+    mapping: Identifier<CurrentNetwork>,
+) -> bool {
+    ledger
+        .vm()
+        .finalize_store()
+        .get_mapping_names_confirmed(&program)
+        .unwrap()
+        .is_some_and(|names| names.contains(&mapping))
 }
 
 /// Re-initializes the `credits.aleo` mappings a clear removes.
@@ -119,12 +165,17 @@ fn initialize_credits_mappings(ledger: &CurrentLedger) {
 /// A rebuild must reproduce the history the chain originally wrote, entry for entry.
 #[test]
 fn test_rebuild_reproduces_history() {
+    let _guard = serial();
     let rng = &mut TestRng::default();
     let (ledger, storage_mode) = sample_ledger(rng);
 
     let expected = snapshot_history(&ledger);
+    let (program, mapping) = plant_sentinel(&ledger);
 
     ledger.vm().rebuild_finalize_state().unwrap();
+
+    // Without this the comparison below would pass on a rebuild that never ran.
+    assert!(!sentinel_survives(&ledger, program, mapping), "the rebuild did not discard the finalize state");
 
     assert_eq!(snapshot_history(&ledger), expected, "the rebuilt history differs from the one the chain wrote");
     assert_eq!(ledger.vm().block_store().current_block_height(), NUM_BLOCKS, "the rebuild changed the block store");
@@ -139,6 +190,7 @@ fn test_rebuild_reproduces_history() {
 /// A rebuild interrupted partway must resume where it stopped, not start over or skip ahead.
 #[test]
 fn test_rebuild_resumes_after_interruption() {
+    let _guard = serial();
     let rng = &mut TestRng::default();
     let (ledger, storage_mode) = sample_ledger(rng);
 
@@ -172,21 +224,21 @@ fn test_rebuild_resumes_after_interruption() {
 /// no replay would recreate: if it survives, the second call returned without touching anything.
 #[test]
 fn test_rebuild_is_idempotent() {
+    let _guard = serial();
     let rng = &mut TestRng::default();
     let (ledger, _storage_mode) = sample_ledger(rng);
 
+    // The first call must genuinely rebuild, or the second one proves nothing.
+    let (program, mapping) = plant_sentinel(&ledger);
     ledger.vm().rebuild_finalize_state().unwrap();
+    assert!(!sentinel_survives(&ledger, program, mapping), "the first rebuild did not discard the finalize state");
     let once = snapshot_history(&ledger);
 
-    let sentinel_program = ProgramID::<CurrentNetwork>::from_str("not_on_chain.aleo").unwrap();
-    let sentinel_mapping = Identifier::<CurrentNetwork>::from_str("sentinel").unwrap();
-    ledger.vm().finalize_store().initialize_mapping(sentinel_program, sentinel_mapping).unwrap();
-
+    let (program, mapping) = plant_sentinel(&ledger);
     ledger.vm().rebuild_finalize_state().unwrap();
 
-    let names = ledger.vm().finalize_store().get_mapping_names_confirmed(&sentinel_program).unwrap();
     assert!(
-        names.is_some_and(|names| names.contains(&sentinel_mapping)),
+        sentinel_survives(&ledger, program, mapping),
         "the second rebuild discarded the finalize state instead of returning early"
     );
     assert_eq!(snapshot_history(&ledger), once);

--- a/ledger/tests/history_rebuild.rs
+++ b/ledger/tests/history_rebuild.rs
@@ -167,6 +167,93 @@ fn initialize_credits_mappings(ledger: &CurrentLedger) {
     ledger.vm().finalize_store().initialize_credits_mappings(&credits).unwrap();
 }
 
+/// A rebuild must replay a program's own deployment and the mapping updates its execution made.
+///
+/// The beacon-only chains above hold no programs, so they never exercise the process being built as
+/// the replay proceeds -- the whole reason the rebuild constructs its VM without preloaded
+/// deployments. Here the program's stack exists only because its deployment was replayed first.
+#[test]
+fn test_rebuild_replays_a_deployed_program() {
+    let _guard = serial();
+    let rng = &mut TestRng::default();
+    let storage_mode = StorageMode::new_test(None);
+
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let store = CurrentConsensusStore::open(storage_mode.clone()).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+    let ledger = CurrentLedger::load(genesis, storage_mode.clone()).unwrap();
+
+    let program = snarkvm_synthesizer::program::Program::<CurrentNetwork>::from_str(
+        r"
+program rebuild_probe.aleo;
+
+mapping counter:
+    key as field.public;
+    value as u64.public;
+
+function bump:
+    input r0 as field.public;
+    async bump r0 into r1;
+    output r1 as rebuild_probe.aleo/bump.future;
+
+finalize bump:
+    input r0 as field.public;
+    get.or_use counter[r0] 0u64 into r1;
+    add r1 1u64 into r2;
+    set r2 into counter[r0];
+",
+    )
+    .unwrap();
+
+    let deployment = ledger.vm().deploy(&private_key, &program, None, 0, None, rng).unwrap();
+    let block =
+        ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![deployment], rng).unwrap();
+    ledger.advance_to_next_block(&block).unwrap();
+
+    // Two executions, so the mapping has a history rather than a single entry.
+    for _ in 0..2 {
+        let inputs = vec![snarkvm_console::program::Value::from_str("1field").unwrap()];
+        let execution = ledger
+            .vm()
+            .execute(&private_key, ("rebuild_probe.aleo", "bump"), inputs.iter(), None, 0, None, rng)
+            .unwrap();
+        let block =
+            ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![execution], rng).unwrap();
+        ledger.advance_to_next_block(&block).unwrap();
+    }
+
+    let program_id = ProgramID::<CurrentNetwork>::from_str("rebuild_probe.aleo").unwrap();
+    let mapping_name = Identifier::<CurrentNetwork>::from_str("counter").unwrap();
+    let key = Plaintext::<CurrentNetwork>::from_str("1field").unwrap();
+    let expected = ledger
+        .vm()
+        .finalize_store()
+        .get_mapping_update_heights(program_id, mapping_name, key.clone())
+        .unwrap()
+        .map(|heights| heights.into_owned());
+    assert!(expected.as_ref().is_some_and(|heights| heights.len() == 2), "the chain should have written two updates");
+
+    // Release the ledger's VM, which preloaded the program, and rebuild through one that did not --
+    // the arrangement the tool uses, and the only one that can replay a deployment correctly.
+    drop(ledger);
+
+    let database = open_db(storage_mode.clone());
+    rocksdb::set_schema_version(&database, CurrentNetwork::ID, 0).unwrap();
+
+    // As the tool does: the schema gate exists to keep a node out of exactly this database.
+    rocksdb::allow_downlevel_open();
+    let store = CurrentConsensusStore::open(storage_mode).unwrap();
+    let vm = VM::from_without_deployments(store).unwrap();
+    vm.rebuild_finalize_state().unwrap();
+
+    let rebuilt = vm
+        .finalize_store()
+        .get_mapping_update_heights(program_id, mapping_name, key)
+        .unwrap()
+        .map(|heights| heights.into_owned());
+    assert_eq!(rebuilt, expected, "the replayed program's mapping history differs from the chain's");
+}
+
 /// A rebuild must reproduce the history the chain originally wrote, entry for entry.
 #[test]
 fn test_rebuild_reproduces_history() {

--- a/ledger/tests/history_rebuild.rs
+++ b/ledger/tests/history_rebuild.rs
@@ -24,6 +24,17 @@ use snarkvm_console::{
     program::{Identifier, Plaintext, ProgramID, Value},
 };
 use snarkvm_ledger_store::helpers::rocksdb;
+
+/// Opens the ledger's database and restores the schema gate afterwards.
+///
+/// `open_for_rebuild` latches the bypass on for the whole process. Left set, it disables
+/// `check_storage_version` for every later open in this test binary -- which is how two of these
+/// tests came to pass without exercising a rebuild at all.
+fn open_db(storage_mode: StorageMode) -> rocksdb::RocksDB {
+    let database = rocksdb::open_for_rebuild(CurrentNetwork::ID, storage_mode).unwrap();
+    rocksdb::disallow_downlevel_open();
+    database
+}
 use snarkvm_synthesizer::vm::VM;
 
 use std::sync::{Mutex, MutexGuard};
@@ -118,7 +129,7 @@ fn sample_ledger(rng: &mut TestRng) -> (CurrentLedger, StorageMode) {
     // hold trivially over a chain nothing had touched. Winding the version back is what makes these
     // tests exercise a replay at all -- and the sentinel each test plants is what proves they did,
     // rather than this being trusted to stay true.
-    let database = rocksdb::open_for_rebuild(CurrentNetwork::ID, storage_mode.clone()).unwrap();
+    let database = open_db(storage_mode.clone());
     rocksdb::set_schema_version(&database, CurrentNetwork::ID, 0).unwrap();
 
     (ledger, storage_mode)
@@ -153,13 +164,7 @@ fn sentinel_survives(
 /// because genesis ratification replaces those mappings wholesale and refuses one that is absent.
 fn initialize_credits_mappings(ledger: &CurrentLedger) {
     let credits = snarkvm_synthesizer::program::Program::<CurrentNetwork>::credits().unwrap();
-    let store = ledger.vm().finalize_store();
-    let initialized = store.get_mapping_names_confirmed(credits.id()).unwrap().unwrap_or_default();
-    for mapping in credits.mappings().values() {
-        if !initialized.contains(mapping.name()) {
-            store.initialize_mapping(*credits.id(), *mapping.name()).unwrap();
-        }
-    }
+    ledger.vm().finalize_store().initialize_credits_mappings(&credits).unwrap();
 }
 
 /// A rebuild must reproduce the history the chain originally wrote, entry for entry.
@@ -182,7 +187,7 @@ fn test_rebuild_reproduces_history() {
 
     // A completed rebuild stamps the schema version and clears the in-progress flag, which is what
     // lets a node start again.
-    let database = rocksdb::open_for_rebuild(CurrentNetwork::ID, storage_mode).unwrap();
+    let database = open_db(storage_mode);
     assert_eq!(rocksdb::schema_version(&database, CurrentNetwork::ID).unwrap(), rocksdb::STORAGE_VERSION);
     assert!(!rocksdb::is_rebuilding(&database, CurrentNetwork::ID).unwrap());
 }
@@ -197,14 +202,14 @@ fn test_rebuild_resumes_after_interruption() {
     let expected = snapshot_history(&ledger);
 
     // Interrupt a rebuild by hand: discard the state, then replay only part of the chain.
-    let database = rocksdb::open_for_rebuild(CurrentNetwork::ID, storage_mode).unwrap();
+    let database = open_db(storage_mode);
     rocksdb::clear_rebuilt_state(&database, CurrentNetwork::ID).unwrap();
     initialize_credits_mappings(&ledger);
 
     let stopped_at = NUM_BLOCKS / 2;
     for height in 0..=stopped_at {
         let block = ledger.get_block(height).unwrap();
-        ledger.vm().replay_block(&block).unwrap();
+        ledger.vm().replay_block(block).unwrap();
     }
     assert_eq!(ledger.vm().finalize_store().committee_store().current_height().unwrap(), stopped_at);
 

--- a/ledger/tests/history_rebuild.rs
+++ b/ledger/tests/history_rebuild.rs
@@ -1,0 +1,179 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for rebuilding the finalize state by replaying blocks.
+
+use snarkvm_ledger::test_helpers::{CurrentConsensusStore, CurrentLedger, CurrentNetwork};
+
+use aleo_std::StorageMode;
+use snarkvm_console::{
+    account::PrivateKey,
+    prelude::*,
+    program::{Identifier, Plaintext, ProgramID, Value},
+};
+use snarkvm_ledger_store::helpers::rocksdb;
+use snarkvm_synthesizer::vm::VM;
+
+/// The number of blocks each test replays.
+///
+/// Every block ratifies a block reward, which rewrites `credits.aleo/{committee, delegated, bonded}`
+/// in full -- so a chain with no transactions at all still exercises the mappings that carry the
+/// overwhelming majority of a real archive node's history.
+const NUM_BLOCKS: u32 = 8;
+
+/// The `credits.aleo` mappings a rebuild must reproduce, and the history of each.
+const REBUILT_MAPPINGS: &[&str] = &["committee", "delegated", "bonded", "account", "withdraw"];
+
+/// The full history of every key of the given mappings: each key, the heights it changed at, and
+/// its value at each of those heights.
+type HistorySnapshot = Vec<(String, String, Vec<(u32, String)>)>;
+
+/// Reads back the entire history of the `credits.aleo` mappings a rebuild is expected to reproduce.
+///
+/// Goes through the public read path rather than the raw map, so the comparison is over what a node
+/// would actually serve. Rendered as strings so a mismatch names the key and value that differ.
+fn snapshot_history(ledger: &CurrentLedger) -> HistorySnapshot {
+    let program_id = ProgramID::<CurrentNetwork>::from_str("credits.aleo").unwrap();
+    let store = ledger.vm().finalize_store();
+
+    let mut snapshot = HistorySnapshot::new();
+    for name in REBUILT_MAPPINGS {
+        let mapping_name = Identifier::<CurrentNetwork>::from_str(name).unwrap();
+        let entries = store.get_mapping_confirmed(program_id, mapping_name).unwrap();
+
+        let mut keys = entries.into_iter().map(|(key, _)| key).collect::<Vec<Plaintext<CurrentNetwork>>>();
+        keys.sort_by_key(ToString::to_string);
+
+        for key in keys {
+            let heights = store
+                .get_mapping_update_heights(program_id, mapping_name, key.clone())
+                .unwrap()
+                .map(|heights| heights.into_owned())
+                .unwrap_or_default();
+
+            let values = heights
+                .into_iter()
+                .map(|height| {
+                    let value: Value<CurrentNetwork> = store
+                        .get_historical_mapping_value(program_id, mapping_name, key.clone(), height)
+                        .unwrap()
+                        .unwrap_or_else(|| panic!("{name}/{key} reports an update at {height} but has no value there"))
+                        .into_owned();
+                    (height, value.to_string())
+                })
+                .collect();
+
+            snapshot.push((name.to_string(), key.to_string(), values));
+        }
+    }
+
+    assert!(!snapshot.is_empty(), "the chain wrote no history, so a rebuild of it would prove nothing");
+    snapshot
+}
+
+/// Returns a ledger of [`NUM_BLOCKS`] beacon blocks, and the key it was built with.
+fn sample_ledger(rng: &mut TestRng) -> (CurrentLedger, StorageMode) {
+    let storage_mode = StorageMode::new_test(None);
+
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    let store = CurrentConsensusStore::open(storage_mode.clone()).unwrap();
+    let genesis = VM::from(store).unwrap().genesis_beacon(&private_key, rng).unwrap();
+
+    let ledger = CurrentLedger::load(genesis, storage_mode.clone()).unwrap();
+    for _ in 1..=NUM_BLOCKS {
+        let block = ledger.prepare_advance_to_next_beacon_block(&private_key, vec![], vec![], vec![], rng).unwrap();
+        ledger.advance_to_next_block(&block).unwrap();
+    }
+    assert_eq!(ledger.latest_height(), NUM_BLOCKS);
+
+    (ledger, storage_mode)
+}
+
+/// Re-initializes the `credits.aleo` mappings a clear removes.
+///
+/// Mirrors what the rebuild does before its first block; a test that hand-replays has to do it too,
+/// because genesis ratification replaces those mappings wholesale and refuses one that is absent.
+fn initialize_credits_mappings(ledger: &CurrentLedger) {
+    let credits = snarkvm_synthesizer::program::Program::<CurrentNetwork>::credits().unwrap();
+    let store = ledger.vm().finalize_store();
+    let initialized = store.get_mapping_names_confirmed(credits.id()).unwrap().unwrap_or_default();
+    for mapping in credits.mappings().values() {
+        if !initialized.contains(mapping.name()) {
+            store.initialize_mapping(*credits.id(), *mapping.name()).unwrap();
+        }
+    }
+}
+
+/// A rebuild must reproduce the history the chain originally wrote, entry for entry.
+#[test]
+fn test_rebuild_reproduces_history() {
+    let rng = &mut TestRng::default();
+    let (ledger, storage_mode) = sample_ledger(rng);
+
+    let expected = snapshot_history(&ledger);
+
+    ledger.vm().rebuild_finalize_state().unwrap();
+
+    assert_eq!(snapshot_history(&ledger), expected, "the rebuilt history differs from the one the chain wrote");
+    assert_eq!(ledger.vm().block_store().current_block_height(), NUM_BLOCKS, "the rebuild changed the block store");
+
+    // A completed rebuild stamps the schema version and clears the in-progress flag, which is what
+    // lets a node start again.
+    let database = rocksdb::open_for_rebuild(CurrentNetwork::ID, storage_mode).unwrap();
+    assert_eq!(rocksdb::schema_version(&database, CurrentNetwork::ID).unwrap(), rocksdb::STORAGE_VERSION);
+    assert!(!rocksdb::is_rebuilding(&database, CurrentNetwork::ID).unwrap());
+}
+
+/// A rebuild interrupted partway must resume where it stopped, not start over or skip ahead.
+#[test]
+fn test_rebuild_resumes_after_interruption() {
+    let rng = &mut TestRng::default();
+    let (ledger, storage_mode) = sample_ledger(rng);
+
+    let expected = snapshot_history(&ledger);
+
+    // Interrupt a rebuild by hand: discard the state, then replay only part of the chain.
+    let database = rocksdb::open_for_rebuild(CurrentNetwork::ID, storage_mode).unwrap();
+    rocksdb::clear_rebuilt_state(&database, CurrentNetwork::ID).unwrap();
+    initialize_credits_mappings(&ledger);
+
+    let stopped_at = NUM_BLOCKS / 2;
+    for height in 0..=stopped_at {
+        let block = ledger.get_block(height).unwrap();
+        ledger.vm().replay_block(&block).unwrap();
+    }
+    assert_eq!(ledger.vm().finalize_store().committee_store().current_height().unwrap(), stopped_at);
+
+    // Resuming must not re-clear: the committee store is the resume point, and clearing it would
+    // silently throw away the blocks already replayed rather than continuing from them.
+    ledger.vm().rebuild_finalize_state().unwrap();
+
+    assert_eq!(snapshot_history(&ledger), expected, "the resumed rebuild differs from the history the chain wrote");
+    assert_eq!(rocksdb::schema_version(&database, CurrentNetwork::ID).unwrap(), rocksdb::STORAGE_VERSION);
+    assert!(!rocksdb::is_rebuilding(&database, CurrentNetwork::ID).unwrap());
+}
+
+/// A rebuild that has already finished must be a no-op, not a second pass over the chain.
+#[test]
+fn test_rebuild_is_idempotent() {
+    let rng = &mut TestRng::default();
+    let (ledger, _storage_mode) = sample_ledger(rng);
+
+    ledger.vm().rebuild_finalize_state().unwrap();
+    let once = snapshot_history(&ledger);
+
+    ledger.vm().rebuild_finalize_state().unwrap();
+    assert_eq!(snapshot_history(&ledger), once);
+}

--- a/ledger/tests/history_rebuild.rs
+++ b/ledger/tests/history_rebuild.rs
@@ -167,15 +167,19 @@ fn initialize_credits_mappings(ledger: &CurrentLedger) {
     ledger.vm().finalize_store().initialize_credits_mappings(&credits).unwrap();
 }
 
-/// A rebuild must replay a program's own deployment and the mapping updates its execution made.
-///
-/// The beacon-only chains above hold no programs, so they never exercise the process being built as
-/// the replay proceeds -- the whole reason the rebuild constructs its VM without preloaded
-/// deployments. Here the program's stack exists only because its deployment was replayed first.
-#[test]
-fn test_rebuild_replays_a_deployed_program() {
-    let _guard = serial();
-    let rng = &mut TestRng::default();
+/// Builds a chain that deploys a program and executes it twice, and returns what its mapping
+/// history should look like.
+#[allow(clippy::type_complexity)]
+fn sample_program_ledger(
+    rng: &mut TestRng,
+) -> (
+    CurrentLedger,
+    StorageMode,
+    ProgramID<CurrentNetwork>,
+    Identifier<CurrentNetwork>,
+    Plaintext<CurrentNetwork>,
+    Option<Vec<u32>>,
+) {
     let storage_mode = StorageMode::new_test(None);
 
     let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
@@ -233,6 +237,20 @@ finalize bump:
         .map(|heights| heights.into_owned());
     assert!(expected.as_ref().is_some_and(|heights| heights.len() == 2), "the chain should have written two updates");
 
+    (ledger, storage_mode, program_id, mapping_name, key, expected)
+}
+
+/// A rebuild must replay a program's own deployment and the mapping updates its execution made.
+///
+/// The beacon-only chains above hold no programs, so they never exercise the process being built as
+/// the replay proceeds -- the whole reason the rebuild constructs its VM without preloaded
+/// deployments. Here the program's stack exists only because its deployment was replayed first.
+#[test]
+fn test_rebuild_replays_a_deployed_program() {
+    let _guard = serial();
+    let rng = &mut TestRng::default();
+    let (ledger, storage_mode, program_id, mapping_name, key, expected) = sample_program_ledger(rng);
+
     // Release the ledger's VM, which preloaded the program, and rebuild through one that did not --
     // the arrangement the tool uses, and the only one that can replay a deployment correctly.
     drop(ledger);
@@ -244,7 +262,18 @@ finalize bump:
     rocksdb::allow_downlevel_open();
     let store = CurrentConsensusStore::open(storage_mode).unwrap();
     let vm = VM::from_without_deployments(store).unwrap();
+
+    // Without this the comparison below would hold on a rebuild that returned early.
+    let sentinel_program = ProgramID::<CurrentNetwork>::from_str("not_on_chain.aleo").unwrap();
+    let sentinel_mapping = Identifier::<CurrentNetwork>::from_str("sentinel").unwrap();
+    vm.finalize_store().initialize_mapping(sentinel_program, sentinel_mapping).unwrap();
+
     vm.rebuild_finalize_state().unwrap();
+
+    assert!(
+        vm.finalize_store().get_mapping_names_confirmed(&sentinel_program).unwrap().is_none(),
+        "the rebuild did not discard the finalize state"
+    );
 
     let rebuilt = vm
         .finalize_store()
@@ -252,6 +281,52 @@ finalize bump:
         .unwrap()
         .map(|heights| heights.into_owned());
     assert_eq!(rebuilt, expected, "the replayed program's mapping history differs from the chain's");
+}
+
+/// A rebuild interrupted after a program's deployment must still replay that program's executions.
+///
+/// The process is built empty, so a resumed run holds none of the programs deployed below the
+/// resume point. Without loading them it fails on the first execution of one -- and since resuming
+/// skips the clear, such a ledger can neither continue nor start over.
+#[test]
+fn test_rebuild_resumes_over_a_deployed_program() {
+    let _guard = serial();
+    let rng = &mut TestRng::default();
+    let (ledger, storage_mode, program_id, mapping_name, key, expected) = sample_program_ledger(rng);
+    drop(ledger);
+
+    let database = open_db(storage_mode.clone());
+    rocksdb::clear_rebuilt_state(&database, CurrentNetwork::ID).unwrap();
+
+    rocksdb::allow_downlevel_open();
+    let store = CurrentConsensusStore::open(storage_mode.clone()).unwrap();
+    let vm = VM::from_without_deployments(store).unwrap();
+    vm.finalize_store()
+        .initialize_credits_mappings(&snarkvm_synthesizer::program::Program::<CurrentNetwork>::credits().unwrap())
+        .unwrap();
+
+    // Stop after the deployment but before the executions that depend on it.
+    let tip = vm.block_store().current_block_height();
+    let stop_at = tip - 2;
+    for height in 0..=stop_at {
+        let hash = vm.block_store().get_block_hash(height).unwrap().unwrap();
+        let block = vm.block_store().get_block(&hash).unwrap().unwrap();
+        vm.replay_block(block).unwrap();
+    }
+    drop(vm);
+
+    // A fresh VM, as a second invocation of the tool would build: empty process, resuming.
+    rocksdb::allow_downlevel_open();
+    let store = CurrentConsensusStore::open(storage_mode).unwrap();
+    let vm = VM::from_without_deployments(store).unwrap();
+    vm.rebuild_finalize_state().unwrap();
+
+    let rebuilt = vm
+        .finalize_store()
+        .get_mapping_update_heights(program_id, mapping_name, key)
+        .unwrap()
+        .map(|heights| heights.into_owned());
+    assert_eq!(rebuilt, expected, "the resumed rebuild lost the program's mapping history");
 }
 
 /// A rebuild must reproduce the history the chain originally wrote, entry for entry.

--- a/ledger/tests/history_rebuild.rs
+++ b/ledger/tests/history_rebuild.rs
@@ -166,6 +166,10 @@ fn test_rebuild_resumes_after_interruption() {
 }
 
 /// A rebuild that has already finished must be a no-op, not a second pass over the chain.
+///
+/// Comparing the history across the two runs would not show the difference -- a second full pass
+/// reproduces it exactly. So this leaves a mapping behind that only a clear would remove and that
+/// no replay would recreate: if it survives, the second call returned without touching anything.
 #[test]
 fn test_rebuild_is_idempotent() {
     let rng = &mut TestRng::default();
@@ -174,6 +178,16 @@ fn test_rebuild_is_idempotent() {
     ledger.vm().rebuild_finalize_state().unwrap();
     let once = snapshot_history(&ledger);
 
+    let sentinel_program = ProgramID::<CurrentNetwork>::from_str("not_on_chain.aleo").unwrap();
+    let sentinel_mapping = Identifier::<CurrentNetwork>::from_str("sentinel").unwrap();
+    ledger.vm().finalize_store().initialize_mapping(sentinel_program, sentinel_mapping).unwrap();
+
     ledger.vm().rebuild_finalize_state().unwrap();
+
+    let names = ledger.vm().finalize_store().get_mapping_names_confirmed(&sentinel_program).unwrap();
+    assert!(
+        names.is_some_and(|names| names.contains(&sentinel_mapping)),
+        "the second rebuild discarded the finalize state instead of returning early"
+    );
     assert_eq!(snapshot_history(&ledger), once);
 }

--- a/synthesizer/src/vm/helpers/sequential_op.rs
+++ b/synthesizer/src/vm/helpers/sequential_op.rs
@@ -44,6 +44,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                         let ret = vm.atomic_speculate_inner(a, b, c, d, e, f);
                         SequentialOperationResult::AtomicSpeculate(ret)
                     }
+                    SequentialOperation::ReplayBlock(block) => {
+                        let ret = vm.replay_block_inner(block);
+                        SequentialOperationResult::ReplayBlock(ret)
+                    }
                 };
 
                 // Relay the results of the operation to the caller.
@@ -89,6 +93,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 pub enum SequentialOperation<N: Network> {
     AddNextBlock(Block<N>),
     AtomicSpeculate(FinalizeGlobalState, i64, Option<u64>, Vec<Ratify<N>>, Solutions<N>, Vec<Transaction<N>>),
+    ReplayBlock(Block<N>),
 }
 
 impl<N: Network> fmt::Display for SequentialOperation<N> {
@@ -99,6 +104,9 @@ impl<N: Network> fmt::Display for SequentialOperation<N> {
             }
             SequentialOperation::AtomicSpeculate(state, ..) => {
                 write!(f, "atomic speculate (height {}, round {})", state.block_height(), state.block_round())
+            }
+            SequentialOperation::ReplayBlock(block) => {
+                write!(f, "replay block ({})", block.height())
             }
         }
     }
@@ -121,4 +129,5 @@ pub enum SequentialOperationResult<N: Network> {
             Vec<FinalizeOperation<N>>,
         )>,
     ),
+    ReplayBlock(Result<()>),
 }

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -150,14 +150,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     #[inline]
     pub fn from(store: ConsensusStore<N, C>) -> Result<Self> {
         // Initialize the store for 'credits.aleo'.
-        let credits = Program::<N>::credits()?;
-        for mapping in credits.mappings().values() {
-            // Ensure that all mappings are initialized.
-            if !store.finalize_store().contains_mapping_confirmed(credits.id(), mapping.name())? {
-                // Initialize the mappings for 'credits.aleo'.
-                store.finalize_store().initialize_mapping(*credits.id(), *mapping.name())?;
-            }
-        }
+        store.finalize_store().initialize_credits_mappings(&Program::<N>::credits()?)?;
 
         // Retrieve the transaction store.
         let transaction_store = store.transaction_store();
@@ -638,9 +631,30 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // batch still open and the database's atomic depth non-zero. Every later block would then
         // fail to start a batch at all, turning one transient write error into a rebuild that cannot
         // be retried without restarting the process.
-        if let Err(error) = self.finalize(state, block.ratifications(), block.solutions(), block.transactions()) {
+        let ratified_finalize_operations =
+            match self.finalize(state, block.ratifications(), block.solutions(), block.transactions()) {
+                Ok(operations) => operations,
+                Err(error) => {
+                    self.finalize_store().abort_atomic();
+                    return Err(error);
+                }
+            };
+
+        // Check the finalize root, which is what covers the ratification half of the block.
+        //
+        // `atomic_finalize` diffs recomputed operations against recorded ones per confirmed
+        // transaction, but nothing compares the operations that pre- and post-ratify return. On a
+        // live node that coverage comes from `check_next_block`, which a replay does not run -- so
+        // without this every `replace_mapping` of the credits staking mappings, which is the
+        // majority of an archive node's history, would be rebuilt against nothing.
+        let finalize_root = block.transactions().to_finalize_root(ratified_finalize_operations)?;
+        if finalize_root != block.header().finalize_root() {
             self.finalize_store().abort_atomic();
-            return Err(error);
+            bail!(
+                "Replay of block {} produced finalize root {finalize_root}, but the block records {}",
+                block.height(),
+                block.header().finalize_root()
+            );
         }
 
         // If the block advances to `ConsensusVersion::V8`, update the VKs used for the credits program.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -615,24 +615,6 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
 
     /// Re-applies a block's finalize operations, without inserting the block.
     ///
-    /// Used to rebuild the finalize state from blocks already in storage. Inserting them again
-    /// would append to the block Merkle tree a second time, so this deliberately covers only the
-    /// half of `add_next_block` that writes mapping state.
-    ///
-    /// # Panics
-    /// This function panics if called from an async context.
-    #[inline]
-    pub fn replay_block(&self, block: &Block<N>) -> Result<()> {
-        let sequential_op = SequentialOperation::ReplayBlock(block.clone());
-        let Some(SequentialOperationResult::ReplayBlock(ret)) = self.run_sequential_operation(sequential_op) else {
-            bail!("Already shutting down");
-        };
-
-        ret
-    }
-
-    /// Re-applies a block's finalize operations, without inserting the block.
-    ///
     /// # Note
     /// This must only be called from the sequential operation thread.
     ///
@@ -650,7 +632,16 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         //
         // `atomic_finalize` checks every operation it recomputes against the one the block records,
         // so reaching this point means the replay agreed with the chain on every transaction.
-        self.finalize(state, block.ratifications(), block.solutions(), block.transactions())?;
+        //
+        // The explicit abort matters for a failure in `finish_atomic` itself rather than inside the
+        // batch: that walks the maps in sequence, so an error partway leaves the earlier ones with a
+        // batch still open and the database's atomic depth non-zero. Every later block would then
+        // fail to start a batch at all, turning one transient write error into a rebuild that cannot
+        // be retried without restarting the process.
+        if let Err(error) = self.finalize(state, block.ratifications(), block.solutions(), block.transactions()) {
+            self.finalize_store().abort_atomic();
+            return Err(error);
+        }
 
         // If the block advances to `ConsensusVersion::V8`, update the VKs used for the credits program.
         if N::CONSENSUS_HEIGHT(ConsensusVersion::V8).unwrap_or_default() == block.height() {

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -171,15 +171,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Initialize the store for 'credits.aleo'.
         store.finalize_store().initialize_credits_mappings(&Program::<N>::credits()?)?;
 
-        // Retrieve the transaction store.
-        let transaction_store = store.transaction_store();
-        // Retrieve the block store.
-        let block_store = store.block_store();
-
         #[cfg(not(any(test, feature = "test")))]
         let process = {
             // Determine the latest block height.
-            let latest_block_height = block_store.current_block_height();
+            let latest_block_height = store.block_store().current_block_height();
             // Determine the consensus version.
             let consensus_version = N::CONSENSUS_VERSION(latest_block_height)?; // TODO (raychu86): Record Commitment - Select the proper consensus version.
             // Initialize a new process based on the consensus version.
@@ -193,11 +188,50 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Initialize a new process.
         let process = Process::load()?;
 
-        // Retrieve the list of deployment transaction IDs and their associated block heights.
-        let deployment_ids = match preload_deployments {
-            true => transaction_store.deployment_transaction_ids().collect::<Vec<_>>(),
-            false => Vec::new(),
+        // Construct the VM object.
+        let vm = Self {
+            process: Arc::new(process),
+            puzzle: Self::new_puzzle()?,
+            store,
+            partially_verified_transactions: Arc::new(RwLock::new(LruCache::new(
+                NonZeroUsize::new(Transactions::<N>::MAX_TRANSACTIONS).unwrap(),
+            ))),
+            restrictions: Restrictions::load()?,
+            sequential_ops_tx: Default::default(),
+            pending_rejected_reasons: Default::default(),
+            sequential_ops_thread: Default::default(),
         };
+
+        // Load every deployment in storage, unless the caller is replaying and will load them as it
+        // reaches them.
+        if preload_deployments {
+            vm.load_deployments_below(u32::MAX)?;
+        }
+
+        // Spawn a thread for sequential operations.
+        let (sequential_ops_tx, sequential_ops_rx) = mpsc::channel();
+        let sequential_ops_thread = vm.start_sequential_queue(sequential_ops_rx);
+
+        // Populate the fields related to the sequential operations.
+        *vm.sequential_ops_tx.write() = Some(sequential_ops_tx);
+        *vm.sequential_ops_thread.lock() = Some(sequential_ops_thread);
+
+        // Return the new VM.
+        Ok(vm)
+    }
+
+    /// Loads into the process every program deployed below `height`, in deployment order.
+    ///
+    /// A replay must see each program as it stood at the block being replayed, so a resumed run
+    /// loads exactly the deployments that had already happened. Loading all of them, as a node
+    /// does, would hand a replayed deployment its program's latest edition to check against.
+    fn load_deployments_below(&self, height: u32) -> Result<()> {
+        let transaction_store = self.transaction_store();
+        let block_store = self.block_store();
+        let process = &self.process;
+
+        // Retrieve the list of deployment transaction IDs and their associated block heights.
+        let deployment_ids = transaction_store.deployment_transaction_ids().collect::<Vec<_>>();
         let mut deployment_ids = cfg_into_iter!(deployment_ids)
             .map(|transaction_id| {
                 // Retrieve the block hash for the deployment transaction ID.
@@ -219,6 +253,9 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
                 Ok((transaction_id, (height, index)))
             })
             .collect::<Result<Vec<_>>>()?;
+        // Keep only the deployments that had happened by `height`, so the process matches the state
+        // a replay resuming there expects.
+        deployment_ids.retain(|(_, (deployed_at, _))| *deployed_at < height);
         // Sort the deployment transaction IDs by their block heights.
         deployment_ids.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));
 
@@ -246,30 +283,7 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
             deployments.iter().try_for_each(|deployment| process.load_deployment(deployment))?;
         }
 
-        // Construct the VM object.
-        let vm = Self {
-            process: Arc::new(process),
-            puzzle: Self::new_puzzle()?,
-            store,
-            partially_verified_transactions: Arc::new(RwLock::new(LruCache::new(
-                NonZeroUsize::new(Transactions::<N>::MAX_TRANSACTIONS).unwrap(),
-            ))),
-            restrictions: Restrictions::load()?,
-            sequential_ops_tx: Default::default(),
-            pending_rejected_reasons: Default::default(),
-            sequential_ops_thread: Default::default(),
-        };
-
-        // Spawn a thread for sequential operations.
-        let (sequential_ops_tx, sequential_ops_rx) = mpsc::channel();
-        let sequential_ops_thread = vm.start_sequential_queue(sequential_ops_rx);
-
-        // Populate the fields related to the sequential operations.
-        *vm.sequential_ops_tx.write() = Some(sequential_ops_tx);
-        *vm.sequential_ops_thread.lock() = Some(sequential_ops_thread);
-
-        // Return the new VM.
-        Ok(vm)
+        Ok(())
     }
 
     /// Returns `true` if a program with the given program ID exists.
@@ -642,42 +656,38 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         // Construct the finalize state.
         let state = Self::finalize_state(&block)?;
 
-        // Finalize the transactions. A failure aborts the atomic batch, leaving the finalize store
-        // as it stood before this block, which is what a resumed replay expects to find.
-        //
-        // `atomic_finalize` checks every operation it recomputes against the one the block records,
-        // so reaching this point means the replay agreed with the chain on every transaction.
-        //
-        // The explicit abort matters for a failure in `finish_atomic` itself rather than inside the
-        // batch: that walks the maps in sequence, so an error partway leaves the earlier ones with a
-        // batch still open and the database's atomic depth non-zero. Every later block would then
-        // fail to start a batch at all, turning one transient write error into a rebuild that cannot
-        // be retried without restarting the process.
-        let ratified_finalize_operations =
-            match self.finalize(state, block.ratifications(), block.solutions(), block.transactions()) {
-                Ok(operations) => operations,
-                Err(error) => {
-                    self.finalize_store().abort_atomic();
-                    return Err(error);
-                }
-            };
+        // Hold the writes until the finalize root has been checked. Without this the batch commits
+        // inside `finalize`, so a mismatch would be detected only after the block's mapping updates
+        // and its committee row were already durable -- and a resumed run, starting after that
+        // block, would never look at it again.
+        self.block_store().pause_atomic_writes()?;
 
-        // Check the finalize root, which is what covers the ratification half of the block.
-        //
-        // `atomic_finalize` diffs recomputed operations against recorded ones per confirmed
-        // transaction, but nothing compares the operations that pre- and post-ratify return. On a
-        // live node that coverage comes from `check_next_block`, which a replay does not run -- so
-        // without this every `replace_mapping` of the credits staking mappings, which is the
-        // majority of an archive node's history, would be rebuilt against nothing.
-        let finalize_root = block.transactions().to_finalize_root(ratified_finalize_operations)?;
-        if finalize_root != block.header().finalize_root() {
+        let outcome = self.finalize(state, block.ratifications(), block.solutions(), block.transactions()).and_then(
+            |ratified_finalize_operations| {
+                // Check the finalize root, which is what covers the ratification half of the block.
+                // `atomic_finalize` diffs recomputed operations against recorded ones per confirmed
+                // transaction, but nothing compares what pre- and post-ratify return; on a live node
+                // that coverage comes from `check_next_block`, which a replay does not run.
+                let finalize_root = block.transactions().to_finalize_root(ratified_finalize_operations)?;
+                match finalize_root == block.header().finalize_root() {
+                    true => Ok(()),
+                    false => bail!(
+                        "Replay of block {} produced finalize root {finalize_root}, but the block records {}",
+                        block.height(),
+                        block.header().finalize_root()
+                    ),
+                }
+            },
+        );
+
+        if let Err(error) = outcome {
             self.finalize_store().abort_atomic();
-            bail!(
-                "Replay of block {} produced finalize root {finalize_root}, but the block records {}",
-                block.height(),
-                block.header().finalize_root()
-            );
+            self.block_store().abort_atomic();
+            // Discards the queued writes, leaving the store as it stood before this block.
+            self.block_store().unpause_atomic_writes::<true>()?;
+            return Err(error);
         }
+        self.block_store().unpause_atomic_writes::<false>()?;
 
         // If the block advances to `ConsensusVersion::V8`, update the VKs used for the credits program.
         if N::CONSENSUS_HEIGHT(ConsensusVersion::V8).unwrap_or_default() == block.height() {

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -149,6 +149,25 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     /// Initializes the VM from storage.
     #[inline]
     pub fn from(store: ConsensusStore<N, C>) -> Result<Self> {
+        Self::from_inner(store, true)
+    }
+
+    /// Initializes the VM from storage, without loading the deployments already in it.
+    ///
+    /// For replaying a chain from genesis, where the process must hold each program as it stood at
+    /// the block being replayed. Loading them up front instead gives every replayed deployment the
+    /// program's *latest* edition and amendments to check itself against, which fails for any
+    /// program later revised.
+    ///
+    /// The process starts with `credits.aleo` alone and the replay adds the rest as it reaches
+    /// their deployments, which is how a node builds it when syncing.
+    #[inline]
+    pub fn from_without_deployments(store: ConsensusStore<N, C>) -> Result<Self> {
+        Self::from_inner(store, false)
+    }
+
+    #[inline]
+    fn from_inner(store: ConsensusStore<N, C>, preload_deployments: bool) -> Result<Self> {
         // Initialize the store for 'credits.aleo'.
         store.finalize_store().initialize_credits_mappings(&Program::<N>::credits()?)?;
 
@@ -175,7 +194,10 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         let process = Process::load()?;
 
         // Retrieve the list of deployment transaction IDs and their associated block heights.
-        let deployment_ids = transaction_store.deployment_transaction_ids().collect::<Vec<_>>();
+        let deployment_ids = match preload_deployments {
+            true => transaction_store.deployment_transaction_ids().collect::<Vec<_>>(),
+            false => Vec::new(),
+        };
         let mut deployment_ids = cfg_into_iter!(deployment_ids)
             .map(|transaction_id| {
                 // Retrieve the block hash for the deployment transaction ID.

--- a/synthesizer/src/vm/mod.rs
+++ b/synthesizer/src/vm/mod.rs
@@ -20,6 +20,8 @@ mod authorize;
 mod deploy;
 mod execute;
 mod finalize;
+#[cfg(feature = "rocks")]
+mod rebuild;
 mod verify;
 
 #[cfg(test)]
@@ -584,6 +586,80 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
         }
     }
 
+    /// Returns the finalize state a block is finalized under.
+    ///
+    /// Shared by the block-advancing path and the rebuild's replay, which must derive it
+    /// identically: a replay that finalized a block under different state would produce different
+    /// mapping values from the same block.
+    fn finalize_state(block: &Block<N>) -> Result<FinalizeGlobalState> {
+        // Determine if the block timestamp should be included.
+        let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
+            .then_some(block.timestamp());
+        // Determine the block spend and synthesis limits.
+        let (block_spend_limit, block_synthesis_limit) = if let Authority::Quorum(subdag) = block.authority() {
+            (subdag.spend_limit(block.height()), subdag.synthesis_limit(block.height()))
+        } else {
+            (None, None)
+        };
+        FinalizeGlobalState::new::<N>(
+            block.round(),
+            block.height(),
+            block_timestamp,
+            block.cumulative_weight(),
+            block.cumulative_proof_target(),
+            block.previous_hash(),
+            block_spend_limit,
+            block_synthesis_limit,
+        )
+    }
+
+    /// Re-applies a block's finalize operations, without inserting the block.
+    ///
+    /// Used to rebuild the finalize state from blocks already in storage. Inserting them again
+    /// would append to the block Merkle tree a second time, so this deliberately covers only the
+    /// half of `add_next_block` that writes mapping state.
+    ///
+    /// # Panics
+    /// This function panics if called from an async context.
+    #[inline]
+    pub fn replay_block(&self, block: &Block<N>) -> Result<()> {
+        let sequential_op = SequentialOperation::ReplayBlock(block.clone());
+        let Some(SequentialOperationResult::ReplayBlock(ret)) = self.run_sequential_operation(sequential_op) else {
+            bail!("Already shutting down");
+        };
+
+        ret
+    }
+
+    /// Re-applies a block's finalize operations, without inserting the block.
+    ///
+    /// # Note
+    /// This must only be called from the sequential operation thread.
+    ///
+    /// # Panics
+    /// This function panics if not called from the sequential operation thread.
+    #[inline]
+    pub(crate) fn replay_block_inner(&self, block: Block<N>) -> Result<()> {
+        self.ensure_sequential_processing();
+
+        // Construct the finalize state.
+        let state = Self::finalize_state(&block)?;
+
+        // Finalize the transactions. A failure aborts the atomic batch, leaving the finalize store
+        // as it stood before this block, which is what a resumed replay expects to find.
+        //
+        // `atomic_finalize` checks every operation it recomputes against the one the block records,
+        // so reaching this point means the replay agreed with the chain on every transaction.
+        self.finalize(state, block.ratifications(), block.solutions(), block.transactions())?;
+
+        // If the block advances to `ConsensusVersion::V8`, update the VKs used for the credits program.
+        if N::CONSENSUS_HEIGHT(ConsensusVersion::V8).unwrap_or_default() == block.height() {
+            self.process.lock().update_credits_verifying_keys()?;
+        }
+
+        Ok(())
+    }
+
     /// Adds the given block into the VM.
     ///
     /// # Panics
@@ -609,26 +685,8 @@ impl<N: Network, C: ConsensusStorage<N>> VM<N, C> {
     pub(crate) fn add_next_block_inner(&self, block: Block<N>) -> Result<()> {
         self.ensure_sequential_processing();
 
-        // Determine if the block timestamp should be included.
-        let block_timestamp = (block.height() >= N::CONSENSUS_HEIGHT(ConsensusVersion::V12).unwrap_or_default())
-            .then_some(block.timestamp());
-        // Determine the block spend and synthesis limits.
-        let (block_spend_limit, block_synthesis_limit) = if let Authority::Quorum(subdag) = block.authority() {
-            (subdag.spend_limit(block.height()), subdag.synthesis_limit(block.height()))
-        } else {
-            (None, None)
-        };
         // Construct the finalize state.
-        let state = FinalizeGlobalState::new::<N>(
-            block.round(),
-            block.height(),
-            block_timestamp,
-            block.cumulative_weight(),
-            block.cumulative_proof_target(),
-            block.previous_hash(),
-            block_spend_limit,
-            block_synthesis_limit,
-        )?;
+        let state = Self::finalize_state(&block)?;
 
         // Pause the atomic writes, so that both the insertion and finalization belong to a single batch.
         #[cfg(feature = "rocks")]

--- a/synthesizer/src/vm/rebuild.rs
+++ b/synthesizer/src/vm/rebuild.rs
@@ -15,13 +15,8 @@
 
 //! Rebuilds the finalize state by replaying the blocks already in storage.
 //!
-//! Discarding and replaying, rather than repairing the historical mapping entries in place, because
-//! the two height encodings that shipped collide: `LE(256)` and `BE(65_536)` are the same four
-//! bytes, so a key written at both heights kept only the later value. That loss happened on the
-//! running node, and no repair that relocates surviving entries can undo it. Replaying recomputes
-//! the values instead of moving them, so it fills those holes rather than inheriting them.
-//!
-//! See `snarkvm_ledger_store::helpers::rocksdb::internal::history_rebuild` for the storage side.
+//! See `snarkvm_ledger_store::helpers::rocksdb::internal::history_rebuild` for the storage side and
+//! the hazards that shape it.
 
 use super::*;
 
@@ -56,6 +51,8 @@ struct Progress {
     window_started: Instant,
     /// The height the current window started from, one below the first block it covers.
     window_from: u32,
+    /// The smoothed replay rate, in blocks per second.
+    rate: Option<f64>,
 }
 
 impl Progress {
@@ -65,7 +62,7 @@ impl Progress {
         // than before it. Counting from `from` itself loses a block, which on an archive replay
         // slow enough to manage one block per window makes the first estimate -- the one an
         // operator reads while deciding on a maintenance window -- print "unknown".
-        Self { from, to, started: now, window_started: now, window_from: from.saturating_sub(1) }
+        Self { from, to, started: now, window_started: now, window_from: from.saturating_sub(1), rate: None }
     }
 
     /// Reports progress if the interval has elapsed, and opens a new window if it did.
@@ -81,9 +78,20 @@ impl Progress {
         let done = height.saturating_sub(self.from) + 1;
         let total = self.to.saturating_sub(self.from) + 1;
 
+        // Smoothed, not the raw window. A 30-second window holds only tens of blocks at archive
+        // replay speeds, so the raw rate swings by whole multiples between reports and the estimate
+        // with it -- observed ranging from 5h to 48h on consecutive lines of the same run, which is
+        // worse than useless to an operator sizing a maintenance window.
+        const SMOOTHING: f64 = 0.3;
         let window_blocks = f64::from(height.saturating_sub(self.window_from));
-        let rate = window_blocks / self.window_started.elapsed().as_secs_f64();
-        // A window that somehow advanced no blocks would divide by zero on the way to an estimate.
+        let window_rate = window_blocks / self.window_started.elapsed().as_secs_f64();
+        let rate = match self.rate {
+            Some(previous) => previous + SMOOTHING * (window_rate - previous),
+            None => window_rate,
+        };
+        self.rate = Some(rate);
+
+        // A run that has genuinely not advanced would divide by zero on the way to an estimate.
         let remaining = match rate > 0.0 {
             true => human_duration(Duration::from_secs_f64(f64::from(self.to - height) / rate)),
             false => "unknown".to_string(),
@@ -155,9 +163,7 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
 
     /// Discards the finalize state and rebuilds it, or with `check_only` reports and stops.
     ///
-    /// One body rather than two so that a check cannot drift from the thing it claims to predict:
-    /// an operator told a ledger is rebuildable, by code checking something slightly different from
-    /// what the rebuild checks, is worse off than one told nothing.
+    /// The check shares this body so that it cannot drift from what it predicts.
     fn rebuild_finalize_state_inner(&self, check_only: bool) -> Result<()> {
         let network_id = N::ID;
         let storage_mode = self.finalize_store().storage_mode().clone();
@@ -259,8 +265,7 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
         // finalize state discarded and the rebuild flagged in progress -- a ledger that serves
         // nothing, from one that only read history wrongly.
         //
-        // The fix is to build the process as the replay goes rather than preloading it, which is a
-        // change to how a VM is constructed and is deliberately not made here.
+        // Lifting this needs the process built as the replay proceeds rather than preloaded.
         if check_only {
             tracing::info!(
                 "Blocks {} (tip {tip}), history {}, staking rewards {}{}",

--- a/synthesizer/src/vm/rebuild.rs
+++ b/synthesizer/src/vm/rebuild.rs
@@ -120,8 +120,8 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
     /// This function panics if called from an async context.
     #[doc(hidden)]
     #[inline]
-    pub fn replay_block(&self, block: &Block<N>) -> Result<()> {
-        let sequential_op = SequentialOperation::ReplayBlock(block.clone());
+    pub fn replay_block(&self, block: Block<N>) -> Result<()> {
+        let sequential_op = SequentialOperation::ReplayBlock(block);
         let Some(SequentialOperationResult::ReplayBlock(ret)) = self.run_sequential_operation(sequential_op) else {
             bail!("Already shutting down");
         };
@@ -141,6 +141,24 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
     /// The node must not be running: this rewrites the state underneath it, and RocksDB permits a
     /// single writer in any case.
     pub fn rebuild_finalize_state(&self) -> Result<()> {
+        self.rebuild_finalize_state_inner(false)
+    }
+
+    /// Reports whether this ledger can be rebuilt, without changing it.
+    ///
+    /// Runs every pre-flight the rebuild runs and stops before the first write, so an operator can
+    /// find out whether a ledger is a candidate without committing to hours of replay or
+    /// discarding anything.
+    pub fn check_rebuild(&self) -> Result<()> {
+        self.rebuild_finalize_state_inner(true)
+    }
+
+    /// Discards the finalize state and rebuilds it, or with `check_only` reports and stops.
+    ///
+    /// One body rather than two so that a check cannot drift from the thing it claims to predict:
+    /// an operator told a ledger is rebuildable, by code checking something slightly different from
+    /// what the rebuild checks, is worse off than one told nothing.
+    fn rebuild_finalize_state_inner(&self, check_only: bool) -> Result<()> {
         let network_id = N::ID;
         let storage_mode = self.finalize_store().storage_mode().clone();
         let database = rocksdb::open_for_rebuild(network_id, storage_mode)?;
@@ -166,6 +184,12 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
                 rocksdb::STORAGE_VERSION
             );
             return Ok(());
+        }
+
+        // Reported before the pre-flights below, which are about the work rather than the need for
+        // it, so that a check on a ledger needing no rebuild says so plainly.
+        if check_only {
+            tracing::info!("This ledger is at storage schema v0, and needs a rebuild.");
         }
 
         // The blocks are the source this reads from, so the tip is the extent of the work.
@@ -237,21 +261,47 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
         //
         // The fix is to build the process as the replay goes rather than preloading it, which is a
         // change to how a VM is constructed and is deliberately not made here.
-        let upgraded = self
-            .transaction_store()
-            .deployment_store()
-            .program_ids_and_latest_editions()
-            .find(|(_, edition)| **edition > 0)
-            .map(|(program_id, edition)| (program_id.into_owned(), edition.into_owned()));
+        if check_only {
+            tracing::info!(
+                "Blocks {} (tip {tip}), history {}, staking rewards {}{}",
+                tip + 1,
+                if needs_history { "present" } else { "absent" },
+                if needs_rewards { "present" } else { "absent" },
+                if resuming { ", and an unfinished rebuild would be resumed" } else { "" },
+            );
+        }
+
+        //
+        // Amendments are checked alongside editions because a V3 deployment deliberately keeps the
+        // edition it amends, so an amended program reads as edition 0 and would slip past a check
+        // on the edition alone -- into the same stale-process problem, since the amendment count
+        // would be taken from the fully-amended stack.
+        let deployments = self.transaction_store().deployment_store();
+        let mut revised = None;
+        for (program_id, edition) in deployments.program_ids_and_latest_editions() {
+            let (program_id, edition) = (program_id.into_owned(), edition.into_owned());
+            if edition > 0 {
+                revised = Some(format!("{program_id} is at edition {edition}"));
+                break;
+            }
+            if deployments.get_amendment_count(&program_id, edition)?.is_some_and(|count| count > 0) {
+                revised = Some(format!("{program_id} has been amended"));
+                break;
+            }
+        }
         ensure!(
-            upgraded.is_none(),
-            "This ledger carries an upgraded program ({} is at edition {}), which the replay cannot \
-             reproduce: the process is loaded with the latest edition of every program, so \
+            revised.is_none(),
+            "This ledger carries a revised program ({}), which the replay cannot reproduce: the \
+             process is loaded with the latest edition and amendments of every program, so \
              replaying an earlier deployment of one would be checked against the wrong program. \
              Rebuilding such a ledger needs the process to be built as the replay proceeds.",
-            upgraded.as_ref().map(|(id, _)| id.to_string()).unwrap_or_default(),
-            upgraded.as_ref().map(|(_, edition)| *edition).unwrap_or_default()
+            revised.unwrap_or_default()
         );
+
+        if check_only {
+            tracing::info!("Nothing blocks a rebuild of this ledger.");
+            return Ok(());
+        }
 
         // Discard the state, unless a previous run already did and was interrupted before finishing.
         // Re-clearing would be harmless but would throw away every block already replayed.
@@ -263,17 +313,18 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
         // Re-initialize the mappings of 'credits.aleo', which the clear removed. Genesis ratification
         // replaces their contents wholesale and refuses a mapping that does not yet exist, so this
         // has to happen before the first block rather than as part of it.
-        let credits = Program::<N>::credits()?;
-        for mapping in credits.mappings().values() {
-            if !self.finalize_store().contains_mapping_confirmed(credits.id(), mapping.name())? {
-                self.finalize_store().initialize_mapping(*credits.id(), *mapping.name())?;
-            }
-        }
+        self.finalize_store().initialize_credits_mappings(&Program::<N>::credits()?)?;
 
         // Resume after the last height the committee store recorded, or start at genesis.
         let next = match self.finalize_store().committee_store().current_height() {
             Ok(height) => height + 1,
-            Err(..) => 0,
+            // An empty committee store and a failed read are indistinguishable here, and after a
+            // clear the empty case is the expected one. Reported rather than swallowed, so a real
+            // fault does not surface later as a confusing "Next height must be block height 0".
+            Err(error) => {
+                tracing::info!("No committee height recorded ({error}); replaying from genesis");
+                0
+            }
         };
         if next > 0 {
             tracing::info!("Resuming an interrupted rebuild at block {next}");
@@ -290,7 +341,7 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
             let Some(block) = self.block_store().get_block(&hash)? else {
                 bail!("Block {height} ({hash}) is missing from storage; the ledger must be resynced from genesis")
             };
-            self.replay_block(&block)?;
+            self.replay_block(block)?;
             progress.report(height);
         }
 

--- a/synthesizer/src/vm/rebuild.rs
+++ b/synthesizer/src/vm/rebuild.rs
@@ -149,7 +149,16 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
     /// The node must not be running: this rewrites the state underneath it, and RocksDB permits a
     /// single writer in any case.
     pub fn rebuild_finalize_state(&self) -> Result<()> {
-        self.rebuild_finalize_state_inner(false)
+        self.rebuild_finalize_state_inner(false, false)
+    }
+
+    /// Rebuilds the finalize state even if the ledger already records this schema version.
+    ///
+    /// For a ledger whose history is suspect for a reason the schema version cannot express. It
+    /// discards a finalize state that nothing has reported as wrong, so it is deliberately a
+    /// separate entry point rather than a fallback inside the ordinary one.
+    pub fn force_rebuild_finalize_state(&self) -> Result<()> {
+        self.rebuild_finalize_state_inner(false, true)
     }
 
     /// Reports whether this ledger can be rebuilt, without changing it.
@@ -158,13 +167,13 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
     /// find out whether a ledger is a candidate without committing to hours of replay or
     /// discarding anything.
     pub fn check_rebuild(&self) -> Result<()> {
-        self.rebuild_finalize_state_inner(true)
+        self.rebuild_finalize_state_inner(true, false)
     }
 
     /// Discards the finalize state and rebuilds it, or with `check_only` reports and stops.
     ///
     /// The check shares this body so that it cannot drift from what it predicts.
-    fn rebuild_finalize_state_inner(&self, check_only: bool) -> Result<()> {
+    fn rebuild_finalize_state_inner(&self, check_only: bool, force: bool) -> Result<()> {
         let network_id = N::ID;
         let storage_mode = self.finalize_store().storage_mode().clone();
         let database = rocksdb::open_for_rebuild(network_id, storage_mode)?;
@@ -184,7 +193,7 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
         // matters because this is an operator command: running it twice, or wiring it into a
         // startup script, must not take the node offline for a second full pass -- and an
         // interruption during that pass would leave a half-empty store where a complete one stood.
-        if !resuming && rocksdb::schema_version(&database, network_id)? >= rocksdb::STORAGE_VERSION {
+        if !force && !resuming && rocksdb::schema_version(&database, network_id)? >= rocksdb::STORAGE_VERSION {
             tracing::info!(
                 "This ledger is already at storage schema v{}; nothing to rebuild",
                 rocksdb::STORAGE_VERSION
@@ -286,7 +295,7 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
         // ledger, but it cannot here -- the gate returns early while the rebuild's downlevel bypass
         // is set, so the version stays at 0 and this would otherwise discard and replay a ledger
         // whose history was never wrong.
-        if !needs_history && !needs_rewards {
+        if !force && !needs_history && !needs_rewards {
             tracing::info!("This ledger holds no history to rebuild; recording schema v{}", rocksdb::STORAGE_VERSION);
             if !check_only {
                 rocksdb::set_schema_version(&database, network_id, rocksdb::STORAGE_VERSION)?;

--- a/synthesizer/src/vm/rebuild.rs
+++ b/synthesizer/src/vm/rebuild.rs
@@ -54,14 +54,18 @@ struct Progress {
     started: Instant,
     /// The start of the current reporting window.
     window_started: Instant,
-    /// The last height replayed before the current window opened.
+    /// The height the current window started from, one below the first block it covers.
     window_from: u32,
 }
 
 impl Progress {
     fn new(from: u32, to: u32) -> Self {
         let now = Instant::now();
-        Self { from, to, started: now, window_started: now, window_from: from }
+        // One below the first block, since `from` is replayed *within* the opening window rather
+        // than before it. Counting from `from` itself loses a block, which on an archive replay
+        // slow enough to manage one block per window makes the first estimate -- the one an
+        // operator reads while deciding on a maintenance window -- print "unknown".
+        Self { from, to, started: now, window_started: now, window_from: from.saturating_sub(1) }
     }
 
     /// Reports progress if the interval has elapsed, and opens a new window if it did.
@@ -102,6 +106,29 @@ impl Progress {
 /// memory-backed VM those calls would find no such database and open one, then discard the state of
 /// a ledger on disk that this VM was never reading.
 impl<N: Network> VM<N, ConsensusDB<N>> {
+    /// Re-applies a block's finalize operations, without inserting the block.
+    ///
+    /// Part of the rebuild, and dangerous outside it: applied to a block a running node has already
+    /// finalized, it would re-apply that block's mapping updates and append a duplicate historical
+    /// entry. Kept on this backend-bound impl rather than the generic one for that reason -- it is
+    /// not a general VM operation.
+    ///
+    /// Inserting the block again is deliberately not done: the blocks are already in storage, and
+    /// re-inserting would append to the block Merkle tree a second time.
+    ///
+    /// # Panics
+    /// This function panics if called from an async context.
+    #[doc(hidden)]
+    #[inline]
+    pub fn replay_block(&self, block: &Block<N>) -> Result<()> {
+        let sequential_op = SequentialOperation::ReplayBlock(block.clone());
+        let Some(SequentialOperationResult::ReplayBlock(ret)) = self.run_sequential_operation(sequential_op) else {
+            bail!("Already shutting down");
+        };
+
+        ret
+    }
+
     /// Discards the finalize state and rebuilds it by replaying every block in storage.
     ///
     /// Resumable: interrupt it and call it again. The resume point is the committee store's current

--- a/synthesizer/src/vm/rebuild.rs
+++ b/synthesizer/src/vm/rebuild.rs
@@ -27,6 +27,8 @@ use super::*;
 
 use snarkvm_ledger_store::helpers::rocksdb::{self, ConsensusDB};
 
+use snarkvm_utilities::defer;
+
 use std::time::{Duration, Instant};
 
 /// How often to report progress.
@@ -116,6 +118,29 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
         let storage_mode = self.finalize_store().storage_mode().clone();
         let database = rocksdb::open_for_rebuild(network_id, storage_mode)?;
 
+        // Restore the schema gate however this returns. The bypass has to outlast the store's own
+        // open, which happens before this is called, but it must not outlast the rebuild: a run
+        // that fails partway leaves a discarded finalize state behind, and the gate is what stops
+        // anything else in this process from opening it.
+        defer! {
+            rocksdb::disallow_downlevel_open();
+        }
+
+        let resuming = rocksdb::is_rebuilding(&database, network_id)?;
+
+        // A ledger already at this schema version has nothing to rebuild, and rebuilding it anyway
+        // would discard a healthy finalize state and replay the whole chain to reproduce it. That
+        // matters because this is an operator command: running it twice, or wiring it into a
+        // startup script, must not take the node offline for a second full pass -- and an
+        // interruption during that pass would leave a half-empty store where a complete one stood.
+        if !resuming && rocksdb::schema_version(&database, network_id)? >= rocksdb::STORAGE_VERSION {
+            tracing::info!(
+                "This ledger is already at storage schema v{}; nothing to rebuild",
+                rocksdb::STORAGE_VERSION
+            );
+            return Ok(());
+        }
+
         // The blocks are the source this reads from, so the tip is the extent of the work.
         let tip = self.block_store().current_block_height();
 
@@ -152,7 +177,6 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
         // Read from the record once a rebuild is under way, because by then the data it describes
         // is gone and an emptied history map is indistinguishable from one that never existed. A
         // run begun by a `history` build must not be finishable by one without it.
-        let resuming = rocksdb::is_rebuilding(&database, network_id)?;
         let (needs_history, needs_rewards) = match resuming {
             true => rocksdb::required_features(&database, network_id)?,
             false => {
@@ -170,6 +194,36 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
             "This ledger holds staking rewards history, but this build was compiled without the \
              `history-staking-rewards` feature and so would discard it without writing any back. \
              Rebuild it with a build that has the features the node runs with."
+        );
+
+        // Refuse a ledger carrying an upgraded program, before discarding anything.
+        //
+        // `VM::from` preloads the latest edition of every program, so replaying an *earlier*
+        // deployment of an upgraded one hands `Process::finalize_deployment` the wrong stack: for a
+        // non-zero edition it diffs the block's mappings against the latest program's, yielding
+        // fewer `InitializeMapping` operations than the block records, and for a program with a
+        // constructor it runs the upgrade check in reverse. Either way the replay aborts.
+        //
+        // A pre-flight rather than a mid-run failure. Aborting after the clear would leave the
+        // finalize state discarded and the rebuild flagged in progress -- a ledger that serves
+        // nothing, from one that only read history wrongly.
+        //
+        // The fix is to build the process as the replay goes rather than preloading it, which is a
+        // change to how a VM is constructed and is deliberately not made here.
+        let upgraded = self
+            .transaction_store()
+            .deployment_store()
+            .program_ids_and_latest_editions()
+            .find(|(_, edition)| **edition > 0)
+            .map(|(program_id, edition)| (program_id.into_owned(), edition.into_owned()));
+        ensure!(
+            upgraded.is_none(),
+            "This ledger carries an upgraded program ({} is at edition {}), which the replay cannot \
+             reproduce: the process is loaded with the latest edition of every program, so \
+             replaying an earlier deployment of one would be checked against the wrong program. \
+             Rebuilding such a ledger needs the process to be built as the replay proceeds.",
+            upgraded.as_ref().map(|(id, _)| id.to_string()).unwrap_or_default(),
+            upgraded.as_ref().map(|(_, edition)| *edition).unwrap_or_default()
         );
 
         // Discard the state, unless a previous run already did and was interrupted before finishing.

--- a/synthesizer/src/vm/rebuild.rs
+++ b/synthesizer/src/vm/rebuild.rs
@@ -1,0 +1,250 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkVM library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Rebuilds the finalize state by replaying the blocks already in storage.
+//!
+//! Discarding and replaying, rather than repairing the historical mapping entries in place, because
+//! the two height encodings that shipped collide: `LE(256)` and `BE(65_536)` are the same four
+//! bytes, so a key written at both heights kept only the later value. That loss happened on the
+//! running node, and no repair that relocates surviving entries can undo it. Replaying recomputes
+//! the values instead of moving them, so it fills those holes rather than inheriting them.
+//!
+//! See `snarkvm_ledger_store::helpers::rocksdb::internal::history_rebuild` for the storage side.
+
+use super::*;
+
+use snarkvm_ledger_store::helpers::rocksdb::{self, ConsensusDB};
+
+use std::time::{Duration, Instant};
+
+/// How often to report progress.
+const REPORT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Formats a duration as `1h23m`, `23m45s`, or `45s`.
+fn human_duration(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    match (seconds / 3600, (seconds % 3600) / 60, seconds % 60) {
+        (0, 0, s) => format!("{s}s"),
+        (0, m, s) => format!("{m}m{s:02}s"),
+        (h, m, _) => format!("{h}h{m:02}m"),
+    }
+}
+
+/// Progress across a replay, reported on a timer.
+struct Progress {
+    /// The first height this run replays.
+    from: u32,
+    /// The last height this run replays.
+    to: u32,
+    /// When the run began, used for the overall rate.
+    started: Instant,
+    /// The start of the current reporting window.
+    window_started: Instant,
+    /// The last height replayed before the current window opened.
+    window_from: u32,
+}
+
+impl Progress {
+    fn new(from: u32, to: u32) -> Self {
+        let now = Instant::now();
+        Self { from, to, started: now, window_started: now, window_from: from }
+    }
+
+    /// Reports progress if the interval has elapsed, and opens a new window if it did.
+    ///
+    /// The estimate comes from the most recent window rather than the run as a whole. Early blocks
+    /// are near-empty and late ones carry the chain's real transaction load, so an average taken
+    /// from genesis is optimistic for hours -- which is the opposite of what an operator planning a
+    /// maintenance window needs from it.
+    fn report(&mut self, height: u32) {
+        if self.window_started.elapsed() < REPORT_INTERVAL {
+            return;
+        }
+        let done = height.saturating_sub(self.from) + 1;
+        let total = self.to.saturating_sub(self.from) + 1;
+
+        let window_blocks = f64::from(height.saturating_sub(self.window_from));
+        let rate = window_blocks / self.window_started.elapsed().as_secs_f64();
+        // A window that somehow advanced no blocks would divide by zero on the way to an estimate.
+        let remaining = match rate > 0.0 {
+            true => human_duration(Duration::from_secs_f64(f64::from(self.to - height) / rate)),
+            false => "unknown".to_string(),
+        };
+
+        tracing::info!(
+            "Rebuilding: block {height}/{} ({:.1}%), {rate:.0} blocks/s, {remaining} remaining, {} elapsed",
+            self.to,
+            100.0 * f64::from(done) / f64::from(total),
+            human_duration(self.started.elapsed()),
+        );
+
+        self.window_started = Instant::now();
+        self.window_from = height;
+    }
+}
+
+/// Bound to the RocksDB backend rather than to any `ConsensusStorage`, because the rebuild reaches
+/// past the typed store to clear raw key ranges and to record the schema version. On a
+/// memory-backed VM those calls would find no such database and open one, then discard the state of
+/// a ledger on disk that this VM was never reading.
+impl<N: Network> VM<N, ConsensusDB<N>> {
+    /// Discards the finalize state and rebuilds it by replaying every block in storage.
+    ///
+    /// Resumable: interrupt it and call it again. The resume point is the committee store's current
+    /// height, which ratification writes inside the same atomic batch as the block's mapping
+    /// updates. That makes it the state's own account of how far it has got, rather than a cursor
+    /// recorded alongside the data it describes and able to disagree with it. `CommitteeStorage`
+    /// additionally requires each height to follow the last, so a replay resuming in the wrong
+    /// place is refused by the store rather than silently writing over itself.
+    ///
+    /// The node must not be running: this rewrites the state underneath it, and RocksDB permits a
+    /// single writer in any case.
+    pub fn rebuild_finalize_state(&self) -> Result<()> {
+        let network_id = N::ID;
+        let storage_mode = self.finalize_store().storage_mode().clone();
+        let database = rocksdb::open_for_rebuild(network_id, storage_mode)?;
+
+        // The blocks are the source this reads from, so the tip is the extent of the work.
+        let tip = self.block_store().current_block_height();
+
+        // Establish that the source is complete before discarding the state built from it.
+        //
+        // Deliberately a pre-flight rather than left to the replay to discover. A ledger missing a
+        // block cannot be rebuilt at all, and finding that out at height 12,000,000 -- with the
+        // finalize state already gone -- turns a ledger that merely reads history wrongly into one
+        // that cannot serve anything.
+        //
+        // The tip comes from the block Merkle tree's leaf count and this from the height index, so
+        // the two disagreeing is itself the gap. Counted rather than probed height by height: one
+        // pass over the smallest map in the store, against `tip` point lookups across the largest.
+        let (count, highest) = self
+            .block_store()
+            .heights()
+            .fold((0u32, 0u32), |(count, highest), height| (count.saturating_add(1), highest.max(*height)));
+        ensure!(
+            count == tip + 1 && highest == tip,
+            "This ledger is missing blocks: it holds {count} of the {} up to its tip of {tip}, the \
+             highest being {highest}. The finalize state is rebuilt by replaying blocks, so a \
+             ledger with gaps in them must be resynced from genesis instead.",
+            tip + 1
+        );
+
+        // Refuse to discard data this build has no way to write back.
+        //
+        // The clear works on raw prefixes, so it removes history whether or not this build was
+        // compiled to keep any -- but only a `history` build repopulates it. Without this the
+        // failure is silent and total: the history is cleared, the replay writes none, and the
+        // schema version is stamped over the result, so the next history-enabled node finds an
+        // empty map and believes it.
+        //
+        // Read from the record once a rebuild is under way, because by then the data it describes
+        // is gone and an emptied history map is indistinguishable from one that never existed. A
+        // run begun by a `history` build must not be finishable by one without it.
+        let resuming = rocksdb::is_rebuilding(&database, network_id)?;
+        let (needs_history, needs_rewards) = match resuming {
+            true => rocksdb::required_features(&database, network_id)?,
+            false => {
+                (rocksdb::has_history(&database, network_id)?, rocksdb::has_staking_rewards(&database, network_id)?)
+            }
+        };
+        ensure!(
+            cfg!(feature = "history") || !needs_history,
+            "This ledger holds mapping history, but this build was compiled without the `history` \
+             feature and so would discard it without writing any back. Rebuild it with a build that \
+             has the features the node runs with."
+        );
+        ensure!(
+            cfg!(feature = "history-staking-rewards") || !needs_rewards,
+            "This ledger holds staking rewards history, but this build was compiled without the \
+             `history-staking-rewards` feature and so would discard it without writing any back. \
+             Rebuild it with a build that has the features the node runs with."
+        );
+
+        // Discard the state, unless a previous run already did and was interrupted before finishing.
+        // Re-clearing would be harmless but would throw away every block already replayed.
+        if !resuming {
+            tracing::info!("Discarding the finalize state of {} blocks", tip + 1);
+            rocksdb::clear_rebuilt_state(&database, network_id)?;
+        }
+
+        // Re-initialize the mappings of 'credits.aleo', which the clear removed. Genesis ratification
+        // replaces their contents wholesale and refuses a mapping that does not yet exist, so this
+        // has to happen before the first block rather than as part of it.
+        let credits = Program::<N>::credits()?;
+        for mapping in credits.mappings().values() {
+            if !self.finalize_store().contains_mapping_confirmed(credits.id(), mapping.name())? {
+                self.finalize_store().initialize_mapping(*credits.id(), *mapping.name())?;
+            }
+        }
+
+        // Resume after the last height the committee store recorded, or start at genesis.
+        let next = match self.finalize_store().committee_store().current_height() {
+            Ok(height) => height + 1,
+            Err(..) => 0,
+        };
+        if next > 0 {
+            tracing::info!("Resuming an interrupted rebuild at block {next}");
+        }
+
+        let mut progress = Progress::new(next, tip);
+        for height in next..=tip {
+            let Some(hash) = self.block_store().get_block_hash(height)? else {
+                bail!(
+                    "Block {height} is missing from storage, so the state after it cannot be \
+                     reproduced. A ledger with gaps in its blocks must be resynced from genesis."
+                );
+            };
+            let Some(block) = self.block_store().get_block(&hash)? else {
+                bail!("Block {height} ({hash}) is missing from storage; the ledger must be resynced from genesis")
+            };
+            self.replay_block(&block)?;
+            progress.report(height);
+        }
+
+        // The committee store is written by every block's ratification, so its height disagreeing
+        // with the tip means blocks were skipped -- and the rebuild would otherwise go on to stamp
+        // the schema version over an incomplete state.
+        let rebuilt = self.finalize_store().committee_store().current_height()?;
+        ensure!(rebuilt == tip, "Rebuilt the finalize state only to block {rebuilt}, but the ledger's tip is {tip}");
+
+        // Stamped before the flag is cleared. A crash between the two leaves the ledger looking
+        // mid-rebuild, so the next run resumes, finds nothing left to replay, and clears the flag;
+        // the other order would leave a ledger that reports itself unrebuilt and be cleared and
+        // replayed from genesis all over again.
+        rocksdb::set_schema_version(&database, network_id, rocksdb::STORAGE_VERSION)?;
+        rocksdb::set_rebuilding(&database, network_id, false)?;
+
+        tracing::info!(
+            "Rebuilt the finalize state through block {tip} in {}",
+            human_duration(progress.started.elapsed())
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_human_duration() {
+        assert_eq!(human_duration(Duration::from_secs(0)), "0s");
+        assert_eq!(human_duration(Duration::from_secs(45)), "45s");
+        assert_eq!(human_duration(Duration::from_secs(60)), "1m00s");
+        assert_eq!(human_duration(Duration::from_secs(1425)), "23m45s");
+        assert_eq!(human_duration(Duration::from_secs(3600)), "1h00m");
+        assert_eq!(human_duration(Duration::from_secs(5000)), "1h23m");
+    }
+}

--- a/synthesizer/src/vm/rebuild.rs
+++ b/synthesizer/src/vm/rebuild.rs
@@ -195,7 +195,11 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
         // Reported before the pre-flights below, which are about the work rather than the need for
         // it, so that a check on a ledger needing no rebuild says so plainly.
         if check_only {
-            tracing::info!("This ledger is at storage schema v0, and needs a rebuild.");
+            tracing::info!(
+                "This ledger is at storage schema v{}, and needs v{}.",
+                rocksdb::schema_version(&database, network_id)?,
+                rocksdb::STORAGE_VERSION
+            );
         }
 
         // The blocks are the source this reads from, so the tip is the extent of the work.
@@ -278,6 +282,18 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
             );
         }
 
+        // Nothing to rebuild: stamp the version and stop. The startup gate does the same for such a
+        // ledger, but it cannot here -- the gate returns early while the rebuild's downlevel bypass
+        // is set, so the version stays at 0 and this would otherwise discard and replay a ledger
+        // whose history was never wrong.
+        if !needs_history && !needs_rewards {
+            tracing::info!("This ledger holds no history to rebuild; recording schema v{}", rocksdb::STORAGE_VERSION);
+            if !check_only {
+                rocksdb::set_schema_version(&database, network_id, rocksdb::STORAGE_VERSION)?;
+            }
+            return Ok(());
+        }
+
         if check_only {
             tracing::info!("Nothing blocks a rebuild of this ledger.");
             return Ok(());
@@ -308,6 +324,11 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
         };
         if next > 0 {
             tracing::info!("Resuming an interrupted rebuild at block {next}");
+            // The process was built empty, so a resumed run holds none of the programs deployed
+            // below the resume point and would fail on the first execution of one. Load exactly the
+            // deployments that had happened by then, in order, so the process matches the state the
+            // next block is finalized against.
+            self.load_deployments_below(next)?;
         }
 
         let mut progress = Progress::new(next, tip);

--- a/synthesizer/src/vm/rebuild.rs
+++ b/synthesizer/src/vm/rebuild.rs
@@ -253,19 +253,21 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
              Rebuild it with a build that has the features the node runs with."
         );
 
-        // Refuse a ledger carrying an upgraded program, before discarding anything.
+        // Refuse to replay against a preloaded process, before discarding anything.
         //
-        // `VM::from` preloads the latest edition of every program, so replaying an *earlier*
-        // deployment of an upgraded one hands `Process::finalize_deployment` the wrong stack: for a
-        // non-zero edition it diffs the block's mappings against the latest program's, yielding
-        // fewer `InitializeMapping` operations than the block records, and for a program with a
-        // constructor it runs the upgrade check in reverse. Either way the replay aborts.
-        //
-        // A pre-flight rather than a mid-run failure. Aborting after the clear would leave the
-        // finalize state discarded and the rebuild flagged in progress -- a ledger that serves
-        // nothing, from one that only read history wrongly.
-        //
-        // Lifting this needs the process built as the replay proceeds rather than preloaded.
+        // A process holding programs beyond `credits.aleo` was loaded from storage, so it carries
+        // each program's latest edition and amendments. Replaying an earlier deployment of a
+        // revised program would check it against the wrong program and abort -- after the state had
+        // been discarded, leaving a ledger that serves nothing.
+        let credits = ProgramID::<N>::from_str("credits.aleo")?;
+        let preloaded = self.process().program_ids().into_iter().filter(|id| *id != credits).count();
+        ensure!(
+            preloaded == 0,
+            "This VM holds {preloaded} program(s) loaded from storage, so replaying their \
+             deployments would check them against their latest editions rather than the ones the \
+             blocks carry. Build the VM with `from_without_deployments` to rebuild."
+        );
+
         if check_only {
             tracing::info!(
                 "Blocks {} (tip {tip}), history {}, staking rewards {}{}",
@@ -275,33 +277,6 @@ impl<N: Network> VM<N, ConsensusDB<N>> {
                 if resuming { ", and an unfinished rebuild would be resumed" } else { "" },
             );
         }
-
-        //
-        // Amendments are checked alongside editions because a V3 deployment deliberately keeps the
-        // edition it amends, so an amended program reads as edition 0 and would slip past a check
-        // on the edition alone -- into the same stale-process problem, since the amendment count
-        // would be taken from the fully-amended stack.
-        let deployments = self.transaction_store().deployment_store();
-        let mut revised = None;
-        for (program_id, edition) in deployments.program_ids_and_latest_editions() {
-            let (program_id, edition) = (program_id.into_owned(), edition.into_owned());
-            if edition > 0 {
-                revised = Some(format!("{program_id} is at edition {edition}"));
-                break;
-            }
-            if deployments.get_amendment_count(&program_id, edition)?.is_some_and(|count| count > 0) {
-                revised = Some(format!("{program_id} has been amended"));
-                break;
-            }
-        }
-        ensure!(
-            revised.is_none(),
-            "This ledger carries a revised program ({}), which the replay cannot reproduce: the \
-             process is loaded with the latest edition and amendments of every program, so \
-             replaying an earlier deployment of one would be checked against the wrong program. \
-             Rebuilding such a ledger needs the process to be built as the replay proceeds.",
-            revised.unwrap_or_default()
-        );
 
         if check_only {
             tracing::info!("Nothing blocks a rebuild of this ledger.");


### PR DESCRIPTION
Draft, for 4.10.1. **An alternative to #3408, not a successor to it** — same base (`testnet`), same storage-schema-version machinery, but it repairs the history by discarding and replaying it rather than by re-encoding the entries in place. Both branches merge independently; the point is to measure this one on the cluster and pick.

## Why an alternative

#3408 classifies every historical mapping entry as little- or big-endian and byte-reverses the little-endian ones. Reviewing the direction turned up a property of the corruption that no amount of classification can get past:

**The two encodings collide, and the collision already destroyed data on the running node.**

`LE(256)` and `BE(65_536)` are the same four bytes, and `HeightBytes` is the final field of the raw key. A mapping key written at height 256 while the node ran a little-endian build, and again at height 65,536 after it upgraded, produced *one* raw key — the second write overwrote the first, and height 256's value is gone. That happened months ago, on the partner's node, before any repair ran.

So a repair that relocates surviving entries inherits those holes. It cannot be complete, however good its classifier is.

**How many.** The collision needs `byte_reverse(h)` to also be a real height, which for a ~20.8M tip forces the low byte of `h` to be ≤ 1 — roughly 0.6% of the little-endian window. `credits.aleo/{committee, delegated, bonded}` reach that bound exactly, because `replace_mapping` rewrites every key in the mapping on every reward block. On #3408's measured ledger (20.8M tip, five-hour window, ~100 mixed keys) that arithmetic lands at ~2,200 entries, against the 2,887 it reports as "undecidable" — close enough that those are plausibly the same entries, seen from the other side: not "we cannot decide which height this is", but "one of these two heights lost its value".

Filling them requires regenerating the values, and the values are recoverable: the blocks are still on disk.

## What this does

Discards the finalize and committee stores, then replays every block already in local storage. No network, no 7 TB resync.

It is **self-verifying**, which is the main reason to prefer it, and the verification covers both halves of a block:

- Per confirmed transaction, `VM::atomic_finalize` already compares every recomputed finalize operation against the one the block records (`synthesizer/src/vm/finalize.rs:1030`, `:1060`) and aborts the batch on a mismatch.
- Per block, the replay checks its finalize root against the header's. That half was missing at first: the operations returned by pre- and post-ratify were discarded, and on a live node their coverage comes from `check_next_block`, which a replay never runs — so `replace_mapping` of the `credits.aleo` staking mappings, the majority of an archive node's history, was being rebuilt against nothing.

A replay that completes is one that agreed with the chain on every transaction *and* every ratification of every block. There is no classifier to review, no heuristic, no undecidable residue, and no boundary inference.

**The mapping state goes with the history**, necessarily: reproducing the update at height `h` needs the state as it stood at `h - 1`, and the only state on disk is the one at the tip. Blocks, transactions, transitions and deployments are never touched — they are the source.

## Shape

- **A storage schema version**, unchanged in substance from #3408: a metadata map records the version a database was last written under, `RocksDB::open` refuses one from a newer build, and a ledger with no history is stamped in passing so a fresh node never sees a prompt for work that does not exist. An explicit `allow_downlevel_open` is the one bypass, for the rebuild itself.
- **Both legacy paths removed**, as in #3408. The write path is the half that matters: retiring the heights row is what ends the amplification.
- **`VM::replay_block`**, a new `SequentialOperation` variant that finalizes a block without inserting it — re-inserting would append to the block Merkle tree a second time. It shares `finalize_state` with `add_next_block_inner` so the two cannot drift.
- **`VM::rebuild_finalize_state`**, the driver. Bound to `ConsensusDB` rather than any `ConsensusStorage`, so it cannot be called on a memory-backed VM and go wipe a ledger on disk.

## Progress reporting

Requested, and easier to do honestly here than in #3408: the work is a known number of blocks, so percentage and ETA are direct rather than inferred from an entries-per-second constant (#3408 had to correct its estimate downward by 7×). Every 30 seconds:

```
Rebuilding: block 8214000/20847646 (39.4%), 214 blocks/s, 16h24m remaining, 10h39m elapsed
```

The rate comes from the most recent window, not from genesis. Early blocks are near-empty and late ones carry the chain's real load, so a running average is optimistic for hours — the opposite of what an operator planning a maintenance window needs.

## Safety properties

- **Block completeness is checked before anything is discarded.** A ledger missing a block cannot be rebuilt, and discovering that at height 12,000,000 with the finalize state already gone would turn a ledger that merely reads history wrongly into one that serves nothing.
- **The feature set is checked before anything is discarded.** The clear works on raw prefixes, so it removes history whether or not the build was compiled to write any. Without the guard the failure is silent and total: history cleared, replay writes none, schema version stamped over the result. A build without `history` (or `history-staking-rewards`) refuses a ledger that holds it — and because an emptied history map is indistinguishable from one that never existed, the clear *records* which optional maps it discarded, so a run begun by a `history` build cannot be finished by one without it.
- **Resume needs no cursor.** The resume point is the committee store's current height, which ratification writes inside the same atomic batch as the block's mapping updates — the state's own account of where it got to, rather than a record kept alongside the data it describes and able to disagree with it. `CommitteeStorage::insert` additionally requires each height to follow the last, so a replay resuming in the wrong place is refused by the store. Every substantive defect found in #3408's lineage was in the interruption path; this removes the mechanism those defects lived in.
- **A half-finished rebuild refuses to serve.** An in-progress flag is set before the clear and cleared after the version is stamped, because an empty finalize store cannot distinguish itself from a fresh ledger and only one of the two must refuse reads.

## Operator impact

Same as #3408 in shape: a node will not start on an unrebuilt ledger, it reports what to run, and the gate is on the data rather than on the build's features. The command is intended to be `snarkos developer rebuild-history <ledger-dir>` in a companion snarkOS PR; the driver stays here, where the finalize semantics and the test infrastructure are.

For testing before that lands, this carries a small binary: `cargo build --release --bin rebuild_db --features rebuild,history`. Deliberately a binary and not an example — an example is built with the crate's dev-dependencies unified into the graph, which would hand an operator a tool compiled with `snarkvm-synthesizer/test`: the wrong `Process` for the tip height, and confirmed transactions capped at eight. The `rebuild` feature turns on the synthesizer's rocks support from a real dependency, and pulls in `tracing-subscriber` optionally for the progress log. It drops out once snarkOS has the command.

## One thing that deliberately did not change

`snarkvm-ledger`'s `rocks` feature still does not enable `snarkvm-synthesizer/rocks`. Adding it there would flip `add_next_block_inner` onto its atomic-batch path for anyone building that crate on its own, which is unrelated to this work. The new opt-in `rebuild` feature pairs them instead. Real consumers are unaffected either way: the umbrella `snarkvm` crate's `rocks` already pairs the two.

## What a reviewer should attack

**The process is now built during the replay** (`VM::from_without_deployments`), and this commit is the one most in need of review — it landed after the review pass.

`VM::from` preloads every deployment at its latest edition and amendment count, so replaying an earlier deployment of a revised program checked it against the wrong program. The cluster confirmed this is not hypothetical: a real 20.8M-block mainnet archive carries `xqc_ccc.aleo` at edition 1, and the tool refused it. The process now starts with `credits.aleo` alone and the replay adds each program as it reaches that program's deployment, which is how a node builds it while syncing. After the change the same ledger reports `Nothing blocks a rebuild of this ledger`.

The guard changed shape with it. It no longer refuses any ledger holding a revised program — a blanket ban that would have excluded most of mainnet's future — but refuses a VM that holds programs loaded from storage, naming the constructor to use. Covered by `test_rebuild_replays_a_deployed_program`, which deploys a program, executes it twice and rebuilds through a non-preloading VM; the program's stack exists during that replay only because its own deployment was replayed first.

**Pre-V8 credits verifying keys.** `VM::from` selects `Process::load_v0()` or `load()` from the *tip* height, so replaying pre-V8 blocks runs with post-V8 keys. Finalize verifies no proofs, so this should not matter — but "should not" is why it is listed.

**Runtime.** Unmeasured; that is what the cluster test is for. The replay is inherently sequential — block `h` consumes the state left by `h - 1`, `atomic_finalize` is pinned to the sequential-ops thread, and `CommitteeStorage::insert` enforces `next_height == current_height + 1`. Block *loading* can be parallelised with a prefetch window, which is the obvious next step if I/O turns out to dominate; it is deliberately not in this PR, because correctness comes first and the measurement should tell us whether it is worth it.

**No `--check` mode yet.** The pre-flight completeness check covers the part that matters before anything is destroyed, but there is no read-only report.

## Verification

`cargo test -p snarkvm-ledger --features rocks,history,test --test history-rebuild` — 3 passed.

Each test winds the recorded schema version back to 0 first. Without that they are vacuous: a ledger built in a test is stamped at the current version as it is created, since it has no history and the startup gate records the version in passing, so the rebuild would take its "nothing to do" path and every assertion would hold over a chain nothing had touched. Each test also plants a mapping that no replay would recreate, so a rebuild that silently does not run fails the test instead of passing it.

- `test_rebuild_reproduces_history` — the rebuilt history matches the one the chain wrote, key for key and height for height, read back through the public path a node would serve from.
- `test_rebuild_resumes_after_interruption` — a rebuild stopped halfway resumes where it stopped rather than restarting or skipping.
- `test_rebuild_is_idempotent` — a finished rebuild is a no-op, not a second pass.

### Review round

A review pass found two defects worth naming here, both fixed:

- **The clear discarded rejection reasons and could never write them back.** They are keyed by transaction id rather than height, so the encoding fault never touched them, and `atomic_finalize` only writes one for a transaction id held in `pending_rejected_reasons` — which speculation populates and a replay never runs. They should not have been in the clear list at all.
- **The clear wiped the committee maps last, and the committee height is the resume point.** An interruption during the mapping-update clear — the longest phase, and the one followed by a synchronous compaction — left the mapping state gone while the committee still read as the tip. The next run resumed at `tip + 1`, replayed nothing, satisfied its own completeness check vacuously, and stamped the schema version over a destroyed ledger while reporting success. The committee maps now clear first, so any interruption resumes from genesis.

Also fixed: a second run on an already-rebuilt ledger discarded a healthy finalize state and replayed the whole chain; an upgraded program is now refused before anything is discarded rather than aborting the replay midway; the replay aborts the finalize batch when `finish_atomic` itself fails; and the schema-gate bypass no longer outlives the rebuild that needed it.

### On real ledgers

Run against the fixtures built for #3408, on the same m7i.4xlarge.

**The defect reproduces, and the rebuild repairs it.** On the genesis-synced three-format ledger (tip 77,672, complete from genesis), stock `snarkos-be` 4.9.1 reads `credits.aleo/bonded` for `aleo1vfukg8ky…` as frozen at 12,180,637,827 across heights 33,000–53,000. The same binary reads both sides of the experiment, since after a rebuild no heights rows remain and it takes the big-endian path.

After replaying all 77,672 blocks:

| height | before | after |
|---:|---|---|
| 30,000 | 11,959,892,352 | 11,959,892,352 |
| 40,000 | **12,180,637,827** | 15,260,647,937 |
| 50,000 | **12,180,637,827** | 18,573,197,004 |
| 55,000 | **12,180,637,827** | 20,238,778,565 |
| 60,000 | **12,180,637,827** | 21,892,412,609 |
| 70,000 | **12,180,637,827** | 25,199,566,409 |
| 77,000 | **12,180,637,827** | 27,520,361,383 |

The rebuilt series is monotone and lands against the live tip value of 27,732,555,245. The run took **2h17m for 77,672 blocks (9.45 blocks/s) at 875 MB peak RSS**, with no finalize-operation mismatch on any block.

(Raising `--rest-rps` matters when sampling many heights: the node's default of 10 requests per second otherwise throttles a tight query loop, and the rejections are indistinguishable from missing history in the v1 REST error format.)

**`--check` on the 20.8M-block archive**: `Blocks 20847647 (tip 20847646), history present, staking rewards absent` → `Nothing blocks a rebuild of this ledger`. It is complete from genesis, so it can be replayed.

**Opening a 1.7 TB ledger** costs 117 s and **10.3 GB peak RSS** before any work begins, against #3408's tool peaking at 1.12 GB for its entire migration. That tool worked on raw RocksDB with `max_open_files` bounded; this one goes through the typed store and block tree, and does not bound open files. Worth fixing before this is put in front of an operator.

**Throughput**: uncontended, the replay holds ~11 blocks/s on early-chain blocks, which would put 20.85M blocks near 24 days against the ~57-day genesis resync measured on the same hardware. That figure is a **ceiling, not a forecast** — early blocks are nearly empty and replay cost scales with transactions finalized. `perf` shows it hash-bound inside finalize (`keccakf` ~13%, `Fp256::mul_assign` ~11%), which is the same work a node does, so there is no pathology to remove and block prefetching would not help. A run at realistic load is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5mtJ1Qr73t8KRHZP8RBkA
