### PR TITLE
fix(program): bound the preallocation taken from a wire-declared count

### DIFF
--- a/synthesizer/program/src/closure/bytes.rs
+++ b/synthesizer/program/src/closure/bytes.rs
@@ -43,7 +43,9 @@ impl<N: Network> FromBytes for ClosureCore<N> {
         if num_instructions > u32::try_from(N::MAX_INSTRUCTIONS).map_err(error)? {
             return Err(error(format!("Failed to deserialize a closure: too many instructions ({num_instructions})")));
         }
-        let mut instructions = Vec::with_capacity(num_instructions as usize);
+        // Cap the reservation: the count is attacker-supplied, and the elements behind
+        // it may not exist.
+        let mut instructions = Vec::with_capacity((num_instructions as usize).min(1024));
         for _ in 0..num_instructions {
             instructions.push(Instruction::read_le(&mut reader)?);
         }

--- a/synthesizer/program/src/constructor/bytes.rs
+++ b/synthesizer/program/src/constructor/bytes.rs
@@ -27,7 +27,9 @@ impl<N: Network> FromBytes for ConstructorCore<N> {
         if num_commands > u16::try_from(N::MAX_COMMANDS).map_err(error)? {
             return Err(error(format!("Failed to deserialize constructor: too many commands ({num_commands})")));
         }
-        let mut commands = Vec::with_capacity(num_commands as usize);
+        // Cap the reservation: the count is attacker-supplied, and the elements behind
+        // it may not exist.
+        let mut commands = Vec::with_capacity((num_commands as usize).min(1024));
         for _ in 0..num_commands {
             commands.push(Command::read_le(&mut reader)?);
         }

--- a/synthesizer/program/src/finalize/bytes.rs
+++ b/synthesizer/program/src/finalize/bytes.rs
@@ -40,7 +40,9 @@ impl<N: Network> FromBytes for FinalizeCore<N> {
         if num_commands > u16::try_from(N::MAX_COMMANDS).map_err(error)? {
             return Err(error(format!("Failed to deserialize finalize: too many commands ({num_commands})")));
         }
-        let mut commands = Vec::with_capacity(num_commands as usize);
+        // Cap the reservation: the count is attacker-supplied, and the elements behind
+        // it may not exist.
+        let mut commands = Vec::with_capacity((num_commands as usize).min(1024));
         for _ in 0..num_commands {
             commands.push(Command::read_le(&mut reader)?);
         }

--- a/synthesizer/program/src/function/bytes.rs
+++ b/synthesizer/program/src/function/bytes.rs
@@ -37,7 +37,9 @@ impl<N: Network> FromBytes for FunctionCore<N> {
         if num_instructions > u32::try_from(N::MAX_INSTRUCTIONS).map_err(error)? {
             return Err(error(format!("Failed to deserialize a function: too many instructions ({num_instructions})")));
         }
-        let mut instructions = Vec::with_capacity(num_instructions as usize);
+        // Cap the reservation: the count is attacker-supplied, and the elements behind
+        // it may not exist.
+        let mut instructions = Vec::with_capacity((num_instructions as usize).min(1024));
         for _ in 0..num_instructions {
             instructions.push(Instruction::read_le(&mut reader)?);
         }
@@ -162,5 +164,32 @@ function main:
         assert_eq!(expected.to_string(), candidate.to_string());
         assert_eq!(expected_bytes, candidate.to_bytes_le()?);
         Ok(())
+    }
+
+    /// A function declaring the maximum instruction count, with none of them
+    /// present, must be rejected rather than reserved for.
+    ///
+    /// This is the shape a fuzzer found: eight bytes naming a function, no
+    /// inputs, and a declared instruction count of `u16::MAX`. The count is
+    /// within bounds, so the reader accepts it and then runs out of input on the
+    /// first instruction -- which is exactly why the reservation cannot be taken
+    /// on the count alone.
+    #[test]
+    fn test_declared_instruction_count_without_the_instructions_is_rejected() {
+        let mut bytes = Vec::new();
+        // The function name, as an identifier: one length byte, then the bytes.
+        1u8.write_le(&mut bytes).unwrap();
+        b'f'.write_le(&mut bytes).unwrap();
+        // No inputs.
+        0u16.write_le(&mut bytes).unwrap();
+        // The largest instruction count the reader will accept, and nothing after it.
+        u32::try_from(CurrentNetwork::MAX_INSTRUCTIONS).unwrap().write_le(&mut bytes).unwrap();
+
+        assert_eq!(bytes.len(), 8, "the whole input is eight bytes");
+        assert!(
+            Function::<CurrentNetwork>::read_le(&bytes[..]).is_err(),
+            "a function declaring {} instructions and carrying none must be rejected",
+            CurrentNetwork::MAX_INSTRUCTIONS
+        );
     }
 }

--- a/synthesizer/program/src/view/bytes.rs
+++ b/synthesizer/program/src/view/bytes.rs
@@ -37,7 +37,9 @@ impl<N: Network> FromBytes for ViewCore<N> {
         if num_commands > u16::try_from(N::MAX_COMMANDS).map_err(error)? {
             return Err(error(format!("Failed to deserialize view: too many commands ({num_commands})")));
         }
-        let mut commands = Vec::with_capacity(num_commands as usize);
+        // Cap the reservation: the count is attacker-supplied, and the elements behind
+        // it may not exist.
+        let mut commands = Vec::with_capacity((num_commands as usize).min(1024));
         for _ in 0..num_commands {
             commands.push(Command::read_le(&mut reader)?);
         }


### PR DESCRIPTION
# Bound the preallocation taken from a wire-declared count

Five readers in the program parser reserve space for a count read from the wire
before reading any of the elements it describes:

```rust
let num_instructions = u32::read_le(&mut reader)?;
if num_instructions > u32::try_from(N::MAX_INSTRUCTIONS)? { return Err(..); }
let mut instructions = Vec::with_capacity(num_instructions as usize);
for _ in 0..num_instructions {
    instructions.push(Instruction::read_le(&mut reader)?);   // fails here
}
```

The bound check does its job for valid input. What it does not do is relate the
reservation to the bytes actually available, and the loop that discovers the
shortfall runs after the memory is committed.

`MAX_INSTRUCTIONS` and `MAX_COMMANDS` are both `u16::MAX`, and an `Instruction`
is ~144 bytes. So **103 bytes of input reserved 9.4 MB and then failed to
parse** — the cost landing on input that was never going to be accepted.

## The change

Each site now reserves `(count).min(1024)`. The loop pushes the same number of
elements either way and `Vec` growth is amortised, so a real program pays a
handful of reallocations against a parse already reading thousands of
instructions.

```rust
// Cap the reservation: the count is attacker-supplied, and the elements behind
// it may not exist.
let mut commands = Vec::with_capacity((num_commands as usize).min(1024));
```

Applied to the five readers whose count is bounded by `u16::MAX`:

| file | field |
|---|---|
| `function/bytes.rs` | instructions |
| `closure/bytes.rs` | instructions |
| `view/bytes.rs` | commands |
| `constructor/bytes.rs` | commands |
| `finalize/bytes.rs` | commands |

**The inputs, outputs and operand vectors are deliberately left alone.**
`MAX_INPUTS`, `MAX_OUTPUTS` and `MAX_OPERANDS` are all 16, so those reservations
were never worth taking from an attacker, and changing them would be churn.

## Measured

The twelve inputs that prompted this, before and after:

| input | before | after |
|---|---|---|
| 103 B | 9,425,888 (91,513x) | 362,240 (3,517x) |
| 526 B | 22,310,334 (42,415x) | 902,574 (1,716x) |
| 1,002 B | 22,891,082 (22,845x) | 362,730 (362x) |

**The residue is structural rather than declared.** `MAX_FUNCTIONS` is 31, so a
program can still repeat a capped reservation, and 1024 is a balance rather than
a floor — a tighter cap trades reallocations for a smaller bound. Worth a
reviewer's opinion; I had no basis for preferring one number over another beyond
"large enough that real programs never notice".

## Test plan

`test_declared_instruction_count_without_the_instructions_is_rejected` — the
eight-byte shape the fuzzer found: a function name, no inputs, a declared count of
`u16::MAX`, and nothing after it.

Being straight about what that does and does not cover: it pins the input, but it
passes before this change too, because the parse always failed — what changed is
what it costs on the way. The reservation itself is not observable from a unit
test without an allocator hook, and instrumenting the test binary for one figure
seemed worse than measuring it directly. The evidence for the bound is the
before/after table above, taken with a counting allocator over the twelve stored
artifacts.

`snarkvm-synthesizer-program`: 646 passed, 0 failed. Full pre-commit hook green.

## How this was found

A byte-identity fuzz target on deployments. The allocation oracle fired rather
than the re-encode one, twelve artifacts holding 3–22.9 MB from 103–1,640 byte
inputs, flat across `alloc-probe` iterations so a property of the parse rather
than one-time initialisation.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qb8dzi6WAXBSCeyEkpBvrc
