### PR TITLE
Pin the Varuna query point count and stop truncating batch sizes

### DIFF
--- a/algorithms/src/snark/varuna/ahp/verifier/messages.rs
+++ b/algorithms/src/snark/varuna/ahp/verifier/messages.rs
@@ -193,3 +193,65 @@ pub fn select_third_round_challenges<F: PrimeField>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        fft::EvaluationDomain,
+        snark::varuna::{
+            VarunaHidingMode,
+            ahp::verifier::{CircuitSpecificState, State},
+        },
+    };
+    use snarkvm_curves::bls12_377::Fr;
+
+    use core::marker::PhantomData;
+    use std::collections::BTreeSet;
+
+    /// Builds a verifier state holding a single circuit, with arbitrary field
+    /// values.
+    ///
+    /// `QuerySet::new` reads only `alpha`, `beta`, `gamma` and the circuit ids,
+    /// and the query point names it assigns depend on none of them, so
+    /// nothing here has to come from a real proof.
+    fn dummy_state() -> State<Fr, VarunaHidingMode> {
+        // Any domain will do; `QuerySet::new` never looks at them.
+        let domain = EvaluationDomain::new(4).unwrap();
+        let circuit_specific_state = CircuitSpecificState {
+            input_domain: domain,
+            variable_domain: domain,
+            constraint_domain: domain,
+            non_zero_a_domain: domain,
+            non_zero_b_domain: domain,
+            non_zero_c_domain: domain,
+            batch_size: 1,
+        };
+        State {
+            circuit_specific_states: BTreeMap::from([(CircuitId([0u8; 32]), circuit_specific_state)]),
+            max_constraint_domain: domain,
+            max_variable_domain: domain,
+            max_non_zero_domain: domain,
+            first_round_message: None,
+            second_round_message: Some(SecondMessage { alpha: Fr::from(1u64), eta_b: None, eta_c: None }),
+            prepare_third_round_message: None,
+            third_round_message: Some(ThirdMessage { beta: Fr::from(2u64) }),
+            fourth_round_message: None,
+            gamma: Some(Fr::from(3u64)),
+            mode: PhantomData,
+        }
+    }
+
+    #[test]
+    fn test_verifier_queries_at_three_points() {
+        // `SonicKZG10::batch_open` groups the query set by query point name and emits
+        // one evaluation proof per group, and `batch_check` requires the
+        // `BatchProof` it is given to hold exactly that many. `proof_size`
+        // relies on the count being three to compute a proof's size without the
+        // proof. Adding a query under a new name, or renaming one of the existing
+        // queries, changes both and must be reflected in `proof_size`.
+        let query_set = QuerySet::new(&dummy_state());
+        let names: BTreeSet<String> = query_set.to_set().into_iter().map(|(_label, (name, _point))| name).collect();
+        assert_eq!(names.len(), 3, "the verifier queries at {names:?}, which `proof_size` does not account for");
+    }
+}

--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -348,7 +348,10 @@ impl<E: PairingEngine> CanonicalDeserialize for Proof<E> {
         validate: Validate,
     ) -> Result<Self, SerializationError> {
         let batch_sizes: Vec<u64> = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
-        let batch_sizes: Vec<usize> = batch_sizes.into_iter().map(|x| x as usize).collect();
+        // These counts come off the wire, so convert rather than truncate: on a target
+        // where `usize` is narrower than `u64`, `as` would silently turn an
+        // unreadable batch size into a readable one.
+        let batch_sizes: Vec<usize> = batch_sizes.into_iter().map(usize::try_from).collect::<Result<_, _>>()?;
         let commitments = Commitments::deserialize_with_mode(&batch_sizes, &mut reader, compress, validate)?;
         let evaluations = Evaluations::deserialize_with_mode(&batch_sizes, &mut reader, compress, validate)?;
         let third_msg_sums = batch_sizes


### PR DESCRIPTION
Draft. This is a **reduced alternative to #3393**, opened so the two can be compared side by side. If we take this one, #3393 gets closed; if not, this gets closed.

## Motivation

#3393 hardened `varuna::Proof` and `sonic_pc::BatchProof` by bounding their length-prefixed reads. Two review cycles kept circling the same question from both @ljedrz and @Antonio95: where do the numbers come from? There is no satisfying answer, and I think that is the signal rather than the obstacle.

The bounds have no natural home in `snarkvm-algorithms`:

- **`MAX_BATCH_PROOF_LEN = 3`** is a property of the caller's query set, not of the polynomial commitment scheme. Nothing about a Sonic PCS proof says three.
- **`MAX_CIRCUITS_PER_BATCH_PROOF` / `MAX_INSTANCES_PER_BATCH_PROOF`** are consensus limits, but `snarkvm-algorithms` cannot depend on `snarkvm-console-network`, so #3393 hand-copies them and pins them with a `const _: () = { ... }` block reaching downward from console into algorithms.

The consensus one is worse than awkward: `MAX_BATCH_PROOF_INSTANCES` only binds from `ConsensusVersion::V14`, and `FromBytes` has no consensus version. So any constant living in the deserializer has to be the loose union of all eras — which is exactly why `1024` looks arbitrary sitting next to `128`, and always will. That answers @Antonio95's question, but the answer is that the deserializer is the wrong place for a consensus limit.

And the bounds turn out to duplicate checks that already exist and are *exact* rather than approximate:

- `SonicKZG10::batch_check` (`sonic_pc/mod.rs:503`) — `ensure!(query_to_labels_map.len() == proof.0.len())`. Exact equality against the verifier's own query set, not a bound.
- `Proof::check_batch_sizes` (`proof.rs:268`) — ties `sum(batch_sizes)` to `witness_commitments.len()` and each `batch_sizes[i]` to `third_msg.sums[i].len()`.
- `Varuna::verify_batch` (`varuna.rs:747-766`) — requires `batch_sizes.len() == keys_to_inputs.len()` and `batch_sizes[i] == public_inputs_i.len()`, against values derived from the transitions rather than from the proof. Empty batch and zero-size batch both bail here.
- `verify_execution` (`verify_execution/mod.rs:321-331`) — enforces `MAX_BATCH_PROOF_INSTANCES` from V14, where the consensus version is in scope.

The allocation concern is covered generically by #3391 (merged): `Vec<T>::deserialize_with_mode` caps `try_reserve` at `len.min(1024)`, and `deserialize_vec_without_len` collects into `Result<Vec<_>>`, whose `size_hint` lower bound is 0 and so reserves nothing. Peak allocation is already proportional to bytes actually supplied, everywhere, with no per-type constants.

There is also a smaller design cost. To keep the round trip total, #3393 makes `BatchProof::serialize_with_mode` fallible — the type can hold four proofs but refuses to write them. A value that is constructible but unserializable is the thing @Antonio95's `BatchProof<const N: usize>` suggestion would have fixed properly, and it disappears entirely if the bound goes away.

So this PR keeps the two pieces of #3393 that are not already covered, and drops the rest.

### 1. Pin the query point count

`proof_size` (`proof.rs:455`) computes a proof's serialized size *without the proof*, and hardcodes `3 * (size_commitment + 1)` for the `pc_proof` — the existing comment says "which is always 3". It is public and re-exported through `snarkvm-synthesizer-snark`. Nothing checked that three against the verifier's actual query set, so adding a query under a new name, or renaming one so an existing group splits, would have made `proof_size` silently wrong.

This is the drift test @ljedrz asked for, anchored to a real consumer of the number rather than to a constant introduced alongside it.

### 2. Convert the batch sizes instead of truncating them

`Proof::deserialize_with_mode` used `map(|x| x as usize)` on values read straight from the wire. @ljedrz flagged this on #3393. On a target where `usize` is narrower than `u64`, `as` truncates — turning a batch size no reader could satisfy into one it can. `usize::try_from` errors instead, and `SerializationError::IntError` already carries `TryFromIntError`, so `?` just works.

## Test Plan

- New `test_verifier_queries_at_three_points` in `algorithms/src/snark/varuna/ahp/verifier/messages.rs`. Confirmed the assertion actually fires, not merely compiles: changing the expected count to 4 fails the test.
- `cargo test -p snarkvm-algorithms --lib` — 102/102, including all eight `prove_and_verify_*` tests and the hiding variants, so real proofs still round-trip.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo +nightly-2026-04-02 fmt --all -- --check` — clean.

The `try_from` change is not directly testable on a 64-bit host, where the conversion is infallible.

## Documentation

N/A

## Backwards compatibility

No consensus version guard needed. The wire format is unchanged.

The test changes no behavior. The `try_from` is a no-op on every 64-bit target, which is every target a node runs on; on a narrower target it converts a silent truncation into a rejection, and the truncated value would have failed `check_batch_sizes` downstream regardless. No byte string that was accepted before is rejected now on any platform the network runs on.

Unlike #3393, this PR does not narrow the accepted set at all, so there is no historical-block question to answer.

## Open question

If we want the allocation property to rest on something better than #3391's `min(1024)` heuristic, the constant-free version is to bound each length by the input rather than by semantics: every element has a known nonzero minimum serialized size, so `len * T::MIN_SERIALIZED_SIZE > reader.remaining()` can be rejected before the loop. One rule in the generic length-prefixed read, covering every collection in the tree, no consensus constants, encoders stay total. It needs a `remaining()` notion that `io::Read` lacks — a small trait over `&[u8]` and `io::Take`, falling back to today's cap when unknown. That is a new abstraction and a separate PR; flagging it here rather than doing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpdsLM4zLaSU5DACsUuy4u
