### PR TITLE
Convert Varuna batch sizes instead of truncating them

### DIFF
--- a/algorithms/src/snark/varuna/data_structures/proof.rs
+++ b/algorithms/src/snark/varuna/data_structures/proof.rs
@@ -348,7 +348,15 @@ impl<E: PairingEngine> CanonicalDeserialize for Proof<E> {
         validate: Validate,
     ) -> Result<Self, SerializationError> {
         let batch_sizes: Vec<u64> = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
-        let batch_sizes: Vec<usize> = batch_sizes.into_iter().map(|x| x as usize).collect();
+        // On a target whose `usize` is narrower than 64 bits, `as` would truncate a
+        // batch size into a smaller one that the rest of the proof can satisfy,
+        // so convert rather than cast. This mirrors the `usize` codec in
+        // `snarkvm-utilities`, and the `u64::try_from` that
+        // `serialize_with_mode` already applies to these same values.
+        let batch_sizes: Vec<usize> = batch_sizes
+            .into_iter()
+            .map(|x| usize::try_from(x).map_err(|_| SerializationError::IncompatibleTarget))
+            .collect::<Result<_, _>>()?;
         let commitments = Commitments::deserialize_with_mode(&batch_sizes, &mut reader, compress, validate)?;
         let evaluations = Evaluations::deserialize_with_mode(&batch_sizes, &mut reader, compress, validate)?;
         let third_msg_sums = batch_sizes


### PR DESCRIPTION
## Motivation

`Proof::deserialize_with_mode` reads `batch_sizes` as a `Vec<u64>` off the wire and converts it with `as usize`:

```rust
let batch_sizes: Vec<u64> = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
let batch_sizes: Vec<usize> = batch_sizes.into_iter().map(|x| x as usize).collect();
```

Where `usize` is narrower than 64 bits, `as` silently discards the high bits.

That matters here because it does not turn a readable proof into an unreadable one — it does the opposite. A batch size the rest of the proof could never satisfy becomes one it can. `0x1_0000_0001` truncates to `1`; a proof carrying a single instance then passes `check_batch_sizes`, since the truncated value is what both the loop counts and the comparison use, and goes on to verify as an ordinary one-instance proof.

So on such a target two distinct byte strings deserialize to the same `Proof`, and only one of them is what `serialize_with_mode` writes back for it. Decoding stops being injective, and the round trip stops being a round trip.

**This is reachable, not hypothetical.** `snarkvm-wasm` depends on `snarkvm-synthesizer` and so on `snarkvm-algorithms`, and CI builds and tests it on wasm32 (`cd wasm && wasm-pack test --node`, `.circleci/config.yml:1127`), where `usize` is 32 bits.

Reported by @ljedrz in review on #3393. That PR would have made the cast unreachable as a side effect of bounding the batch shapes; this is the same defect fixed on its own terms, independent of whether any of that lands.

## The fix

Convert rather than cast, with `SerializationError::IncompatibleTarget`.

This is not a new convention. It is the one `snarkvm-utilities` already uses for precisely this situation — the `usize` codec (`utilities/src/serialize/impls.rs:150,183`) checks in both directions and reports `IncompatibleTarget`:

```rust
let u64_value = u64::try_from(*self).map_err(|_| SerializationError::IncompatibleTarget)?;
...
usize::try_from(u64_value).map_err(|_| SerializationError::IncompatibleTarget)
```

It also removes an asymmetry inside this same `impl`: `Proof::serialize_with_mode` already applies `u64::try_from` to these values on the way out (`proof.rs:307`). Only the read was unchecked.

## Test Plan

- `cargo test -p snarkvm-algorithms --lib` — 101/101, including every `prove_and_verify_*` test and the hiding variants, so real proofs still round-trip.
- `cargo check -p snarkvm-wasm --target wasm32-unknown-unknown` — clean. This is the target the change actually affects, so it is checked directly rather than by inference.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo +nightly-2026-04-02 fmt --all -- --check` — clean.

**No new test.** I could not write one that would actually run: on the 64-bit targets CI tests, `usize::try_from(u64)` is infallible, so a test of the rejection path cannot fail before this change. A `#[cfg(target_pointer_width = "32")]` test would not run either — the wasm CI job runs the `wasm` crate's own tests via `wasm-pack`, not `snarkvm-algorithms` unit tests. Rather than add a test that never executes, I am flagging the gap. If we want this class covered properly, the thing worth building is running some part of the `snarkvm-algorithms` serialization suite under wasm32, which would cover every other `as usize` on a decode path too, not just this one. Happy to open an issue for that.

## Documentation

N/A

## Backwards compatibility

No consensus version guard needed. The wire format is unchanged.

On every 64-bit target — which is every target a validator runs on — `usize::try_from(u64)` is infallible and compiles to the same code as `as`. No byte string that was accepted before is rejected now, and no proof serializes differently.

On wasm32 the change is deliberate and confined to inputs that were already malformed: a `batch_size` above `u32::MAX` is now rejected with `IncompatibleTarget` instead of being silently reinterpreted as a smaller one. No honest prover produces such a value, and no proof that verified before stops verifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpdsLM4zLaSU5DACsUuy4u
