### PR TITLE
hardening(curve): reject the non-canonical sign flag on Short Weierstrass y = 0

### DIFF
--- a/curves/src/templates/macros.rs
+++ b/curves/src/templates/macros.rs
@@ -133,8 +133,19 @@ macro_rules! impl_sw_curve_serializer {
                         }
                         Self::zero()
                     } else {
-                        Affine::<P>::from_x_coordinate(x, flags.is_positive().unwrap())
-                            .ok_or(snarkvm_utilities::serialize::SerializationError::InvalidData)?
+                        // The infinity flag is clear in this branch, so the sign
+                        // is present and this cannot panic.
+                        let is_positive = flags.is_positive().unwrap();
+                        let point = Affine::<P>::from_x_coordinate(x, is_positive)
+                            .ok_or(snarkvm_utilities::serialize::SerializationError::InvalidData)?;
+                        // y = 0 is its own negation, so both sign flags select it
+                        // and from_x_coordinate cannot tell them apart. The
+                        // serializer writes the negative-y flag for such a point,
+                        // so the positive-y spelling is a second encoding of it.
+                        if point.y.is_zero() && is_positive {
+                            return Err(snarkvm_utilities::serialize::SerializationError::InvalidData);
+                        }
+                        point
                     }
                 } else {
                     let x = P::BaseField::deserialize_uncompressed(&mut reader)?;

--- a/curves/src/templates/short_weierstrass_jacobian/tests.rs
+++ b/curves/src/templates/short_weierstrass_jacobian/tests.rs
@@ -33,6 +33,76 @@ pub fn sw_tests<P: ShortWeierstrassParameters>(rng: &mut TestRng) {
     sw_from_random_bytes::<P>(rng);
     sw_from_x_coordinate::<P>(rng);
     sw_non_canonical_infinity_is_rejected::<P>();
+    sw_non_canonical_zero_y_is_rejected::<P>();
+}
+
+/// Searches for a point with `y = 0`, returning `None` if this curve has none
+/// within the range tried.
+///
+/// Such a point exists only where `x^3 + ax + b` has a root, which is curve
+/// dependent: BLS12-377 G1 has `(-1, 0)`, because `y^2 = x^3 + 1`. There is no
+/// general constructor to lean on here, since `from_y_coordinate` is
+/// `unimplemented!()` for Short Weierstrass.
+fn find_zero_y_point<P: ShortWeierstrassParameters>() -> Option<Affine<P>> {
+    let mut magnitude = P::BaseField::zero();
+    for _ in 0..1024 {
+        for x in [magnitude, -magnitude] {
+            match Affine::<P>::from_x_coordinate(x, false) {
+                Some(point) if point.y.is_zero() => return Some(point),
+                _ => {}
+            }
+        }
+        magnitude += P::BaseField::one();
+    }
+    None
+}
+
+/// A point with `y = 0` must have exactly one compressed encoding.
+///
+/// `y` is its own negation there, so both sign flags select it and
+/// `from_x_coordinate` cannot tell them apart:
+/// `if (y < negy) ^ greatest { y } else { negy }` returns zero either way. The
+/// serializer writes the negative-y flag for such a point, so the positive-y
+/// spelling is a second encoding of one value.
+///
+/// A point with `y = 0` has order two and so sits outside the prime-order
+/// subgroup, which is why `Validate::Yes` rejects both spellings on its own.
+/// This is about `Validate::No`, where the subgroup check is not doing the work.
+pub fn sw_non_canonical_zero_y_is_rejected<P: ShortWeierstrassParameters>() {
+    let Some(point) = find_zero_y_point::<P>() else {
+        return;
+    };
+    assert!(point.is_on_curve(), "the search must return a point on the curve");
+    assert!(!point.is_in_correct_subgroup_assuming_on_curve(), "a point of order two is outside the subgroup");
+
+    // The canonical encoding is whatever the serializer emits.
+    let mut canonical = Vec::new();
+    point.serialize_with_mode(&mut canonical, Compress::Yes).unwrap();
+
+    // It must keep working, or the rejection below would refuse our own output.
+    let recovered =
+        Affine::<P>::deserialize_with_mode(Cursor::new(&canonical[..]), Compress::Yes, Validate::No).unwrap();
+    assert_eq!(recovered, point, "the canonical y = 0 encoding must still deserialize");
+
+    // The same x with the opposite sign flag. The flag is the high bit of the
+    // last byte, and it names the same point.
+    let mut non_canonical = canonical.clone();
+    let last = non_canonical.len() - 1;
+    non_canonical[last] ^= 1 << 7;
+    assert_ne!(non_canonical, canonical);
+
+    for (validate, mode) in [(Validate::Yes, "Validate::Yes"), (Validate::No, "Validate::No")] {
+        if let Ok(other) = Affine::<P>::deserialize_with_mode(Cursor::new(&non_canonical[..]), Compress::Yes, validate)
+        {
+            assert_ne!(
+                other, point,
+                "a non-canonical y = 0 encoding was accepted ({mode}).\n\
+                 The encodings differ only in the flag byte, {:#04x} against the canonical {:#04x},\n\
+                 so those are two ways to write one value.",
+                non_canonical[last], canonical[last],
+            );
+        }
+    }
 }
 
 /// The point at infinity must have exactly one compressed encoding.


### PR DESCRIPTION
Split out of #3407, which bundled both halves and is now closed in favour of this pair. **This is the consensus-reachable half**; the twisted Edwards half is #3425.

## The bug

`from_x_coordinate` picks y with `if (y < negy) ^ greatest { y } else { negy }`, which returns zero for either value of `greatest` when y is zero. Both sign flags therefore name the same point. The serializer emits the negative-y flag there — `from_y_sign(y > -y)` is false when y is zero — so the positive-y spelling is a second encoding of one value.

BLS12-377 G1 has such a point at `(-1, 0)`, since `y^2 = x^3 + 1`. G2 has none, and the test skips it.

## Reachability and severity

**Reachable.** The G1 and G2 elements of `Proof<E>` go through this macro (`Proof::write_le` → `serialize_compressed`), and a `Proof` is part of every submitted transaction.

**But low severity.** A `y = 0` point has order two, so it is outside the prime-order subgroup and `Validate::Yes` rejects both spellings on the subgroup check alone. Only `Validate::No` ever accepted them. That is the inverse of #3397, where the identity *is* in the subgroup and the encoding was the only thing that could have caught it.

## Backwards compatibility

Two claims: one settled, one needing data.

**Settled — the encoding has never changed.** `git log --oneline -S 'mask |= 1 << 6' -- utilities/src/serialize/flags.rs` returns only `2e1312c12`, the initial commit. The one commit that ever changed decoder behaviour is `e8ef1d2db` (May 2022), which narrowed `SWFlags::from_u8` from `(_, true) => Infinity` to `(true, true) => None`, commented *"we only want **one** way to serialize the point at infinity"*. Decoder narrowed, encoder untouched — the same move as this PR.

**Needs data — whether any historical block contains such an encoding.** Nothing on the wire is parsed with `Validate::No`: `Proof::read_le` is `deserialize_compressed`; a `Vec<Affine>` reads elements unchecked and then runs `batch_check`, which is `is_on_curve() & is_in_correct_subgroup_assuming_on_curve()`; and the `unchecked_deserialize` path is gated to the RocksDB layer reading back what the node already validated. So such an encoding should never have reached a block.

That is the reasoning being tested, though, so it cannot also be the evidence. **Backtest done — clean.** 210,001 historical blocks (the last 100k, plus eleven 10k slices from genesis to 19M), 226,182 objects, 3,110,652 compressed Short Weierstrass points, **zero** with `y = 0` and zero parse failures. Full numbers, method, and an honest statement of what the scan can and cannot establish are in the comment below.

(@vicsn's approval on #3397 was conditional on the same regression sync, which did not run before that merge. This covers both.)

## Tests

`sw_non_canonical_zero_y_is_rejected`, in the generic `sw_tests<P>` harness so it covers every Short Weierstrass curve. It searches for a `y = 0` point and no-ops on curves without one, so it exercises G1 and skips G2. Written first; fails on an unfixed tree.

`cargo test -p snarkvm-curves`: 65 passed, 0 failed.

