### PR TITLE
build: remove lld config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,3 @@
 # Note: override by setting RUSTFLAGS
 [target.'cfg(not(target_arch = "wasm32"))']
 rustflags = ["-C", "target-cpu=native"]
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = [
-    # LLD is generally faster and might be the default for Rust in the future.
-    # See here: https://github.com/rust-lang/rust/issues/71515
-    "-C", "link-arg=-fuse-ld=lld"
-]


### PR DESCRIPTION
Removes the lld linker configuration from the cargo build settings. No longer necessary since lld became the default in Rust 1.90.0.

https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/#lld-is-now-the-default-linker-on-x86-64-unknown-linux-gnu

Follow-up to: https://github.com/ProvableHQ/snarkOS/pull/4441