### PR TITLE
build: improve dev compile times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid",
  "pem-rfc7468",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -673,7 +673,7 @@ incremental = false
 debug-assertions = false
 
 [profile.dev]
-opt-level = 3
+debug = "line-tables-only"
 lto = "off"
 incremental = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -660,26 +660,10 @@ workspace = true
 version = "2"
 
 [profile.release]
-opt-level = 3
 lto = "thin"
-incremental = false
-
-[profile.bench]
-opt-level = 3
-debug = false
-rpath = false
-lto = "thin"
-incremental = false
-debug-assertions = false
 
 [profile.dev]
 debug = "line-tables-only"
-lto = "off"
-incremental = true
 
 [profile.test]
 opt-level = 2
-lto = "off"
-incremental = true
-debug = true
-debug-assertions = true


### PR DESCRIPTION
## Summary

Changes the dev profile configuration to improve compile times. Also removes profile configuration that is redundant.

Follow-up to https://github.com/ProvableHQ/snarkOS/pull/4445.

## Changes

- Changed the dev profile optimization level to 0 and the debug info to line tables only. Improved compile time for full builds by 39% (from 32.2s to 19.8s).
- Removed all configuration that was equal to the default profile values already. https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles