### PR TITLE
[Feat] Increase maximum program mappings

### DIFF
--- a/console/network/src/consensus_heights.rs
+++ b/console/network/src/consensus_heights.rs
@@ -76,7 +76,7 @@ pub enum ConsensusVersion {
     /// V20: Adds more accurate type checking for the root call, bounds the size of every
     /// `PlaintextType` declared in a deployed program, and updates the number of validators.
     V20 = 20,
-    /// V21: TBD
+    /// V21: Increases the maximum number of mappings in a program to 128.
     V21 = 21,
 }
 
@@ -398,6 +398,11 @@ mod tests {
             assert!(*version > previous_version);
             previous_version = *version;
         }
+        let mut previous_version = N::MAX_MAPPINGS.first().unwrap().0;
+        for (version, _) in N::MAX_MAPPINGS.iter().skip(1) {
+            assert!(*version > previous_version);
+            previous_version = *version;
+        }
         let mut previous_version = N::MAX_PROGRAM_SIZE.first().unwrap().0;
         for (version, _) in N::MAX_PROGRAM_SIZE.iter().skip(1) {
             assert!(*version > previous_version);
@@ -459,6 +464,12 @@ mod tests {
             // Double-check that consensus_config_value returns the correct value.
             assert_eq!(consensus_config_value!(N, MAX_ARRAY_ELEMENTS, height).unwrap(), *value);
         }
+        for (version, value) in N::MAX_MAPPINGS.iter() {
+            // Ensure that the height at which an update occurs are present in CONSENSUS_VERSION_HEIGHTS.
+            let height = N::CONSENSUS_VERSION_HEIGHTS().iter().find(|(c_version, _)| *c_version == *version).unwrap().1;
+            // Double-check that consensus_config_value returns the correct value.
+            assert_eq!(consensus_config_value!(N, MAX_MAPPINGS, height).unwrap(), *value);
+        }
         for (version, value) in N::MAX_PROGRAM_SIZE.iter() {
             // Ensure that the height at which an update occurs are present in CONSENSUS_VERSION_HEIGHTS.
             let height = N::CONSENSUS_VERSION_HEIGHTS().iter().find(|(c_version, _)| *c_version == *version).unwrap().1;
@@ -490,6 +501,7 @@ mod tests {
             assert!(consensus_config_value!(N, TRANSACTION_SPEND_LIMIT, *height).is_some());
             assert!(consensus_config_value!(N, CREDITS_PER_SECOND_OF_RUNTIME, *height).is_some());
             assert!(consensus_config_value!(N, MAX_ARRAY_ELEMENTS, *height).is_some());
+            assert!(consensus_config_value!(N, MAX_MAPPINGS, *height).is_some());
             assert!(consensus_config_value!(N, MAX_PROGRAM_SIZE, *height).is_some());
             assert!(consensus_config_value!(N, MAX_TRANSACTION_SIZE, *height).is_some());
             assert!(consensus_config_value!(N, MAX_WRITES, *height).is_some());
@@ -515,6 +527,15 @@ mod tests {
     fn max_array_elements_increasing<N: Network>() {
         let mut previous_value = N::MAX_ARRAY_ELEMENTS.first().unwrap().1;
         for (_, value) in N::MAX_ARRAY_ELEMENTS.iter().skip(1) {
+            assert!(*value >= previous_value);
+            previous_value = *value;
+        }
+    }
+
+    /// Ensure that `MAX_MAPPINGS` increases and is correctly defined.
+    fn max_mappings_increasing<N: Network>() {
+        let mut previous_value = N::MAX_MAPPINGS.first().unwrap().1;
+        for (_, value) in N::MAX_MAPPINGS.iter().skip(1) {
             assert!(*value >= previous_value);
             previous_value = *value;
         }
@@ -579,6 +600,7 @@ mod tests {
         let _ =
             [N1::CREDITS_PER_SECOND_OF_RUNTIME, N2::CREDITS_PER_SECOND_OF_RUNTIME, N3::CREDITS_PER_SECOND_OF_RUNTIME];
         let _ = [N1::MAX_ARRAY_ELEMENTS, N2::MAX_ARRAY_ELEMENTS, N3::MAX_ARRAY_ELEMENTS];
+        let _ = [N1::MAX_MAPPINGS, N2::MAX_MAPPINGS, N3::MAX_MAPPINGS];
         let _ = [N1::MAX_PROGRAM_SIZE, N2::MAX_PROGRAM_SIZE, N3::MAX_PROGRAM_SIZE];
         let _ = [N1::MAX_TRANSACTION_SIZE, N2::MAX_TRANSACTION_SIZE, N3::MAX_TRANSACTION_SIZE];
         let _ = [N1::MAX_WRITES, N2::MAX_WRITES, N3::MAX_WRITES];
@@ -590,6 +612,8 @@ mod tests {
     fn latest_max_functions_are_safe<N: Network>() {
         // Verify LATEST_MAX_CERTIFICATES returns a positive value.
         assert!(N::LATEST_MAX_CERTIFICATES() > 0, "LATEST_MAX_CERTIFICATES must be positive");
+        // Verify LATEST_MAX_MAPPINGS returns a positive value.
+        assert!(N::LATEST_MAX_MAPPINGS() > 0, "LATEST_MAX_MAPPINGS must be positive");
         // Verify LATEST_MAX_PROGRAM_SIZE returns a positive value.
         assert!(N::LATEST_MAX_PROGRAM_SIZE() > 0, "LATEST_MAX_PROGRAM_SIZE must be positive");
         // Verify LATEST_MAX_TRANSACTION_SIZE returns a positive value.
@@ -629,6 +653,10 @@ mod tests {
         max_array_elements_increasing::<MainnetV0>();
         max_array_elements_increasing::<TestnetV0>();
         max_array_elements_increasing::<CanaryV0>();
+
+        max_mappings_increasing::<MainnetV0>();
+        max_mappings_increasing::<TestnetV0>();
+        max_mappings_increasing::<CanaryV0>();
 
         transaction_size_exceeds_program_size::<MainnetV0>();
         transaction_size_exceeds_program_size::<TestnetV0>();

--- a/console/network/src/lib.rs
+++ b/console/network/src/lib.rs
@@ -245,8 +245,8 @@ pub trait Network:
         (ConsensusVersion::V14, 512_000),   // 512 kB
         (ConsensusVersion::V16, 2_048_000), // 2048 kB
     ];
-    /// The maximum number of mappings in a program.
-    const MAX_MAPPINGS: usize = 31;
+    /// A list of consensus versions and their corresponding maximum number of mappings in a program.
+    const MAX_MAPPINGS: [(ConsensusVersion, usize); 2] = [(ConsensusVersion::V1, 31), (ConsensusVersion::V21, 128)];
     /// The maximum number of functions in a program.
     const MAX_FUNCTIONS: usize = 31;
     /// The maximum number of structs in a program.
@@ -379,6 +379,12 @@ pub trait Network:
     #[allow(non_snake_case)]
     fn LATEST_MAX_CERTIFICATES() -> u16 {
         Self::MAX_CERTIFICATES.last().expect("MAX_CERTIFICATES must have at least one entry").1
+    }
+
+    /// Returns the last `MAX_MAPPINGS` value.
+    #[allow(non_snake_case)]
+    fn LATEST_MAX_MAPPINGS() -> usize {
+        Self::MAX_MAPPINGS.last().expect("MAX_MAPPINGS must have at least one entry").1
     }
 
     /// Returns the last `MAX_PROGRAM_SIZE` value.

--- a/synthesizer/process/src/verify_deployment.rs
+++ b/synthesizer/process/src/verify_deployment.rs
@@ -28,6 +28,14 @@ impl<N: Network> Process<N> {
 
         // Retrieve the program ID.
         let program_id = deployment.program().id();
+        // Retrieve the maximum number of mappings for the consensus version.
+        let max_mappings = consensus_config_value_by_version!(N, MAX_MAPPINGS, consensus_version)
+            .ok_or_else(|| anyhow!("Missing consensus config value: MAX_MAPPINGS"))?;
+        // Ensure the program does not exceed the maximum number of mappings.
+        ensure!(
+            deployment.program().mappings().len() <= max_mappings,
+            "Program '{program_id}' exceeds the maximum number of mappings ({max_mappings}) for {consensus_version}"
+        );
         // Check if this deployment is an amendment.
         let version = deployment.version()?;
         let is_amendment = matches!(version, DeploymentVersion::V3);
@@ -136,6 +144,44 @@ mod tests {
             deployment.program_owner(),
         )
         .unwrap()
+    }
+
+    fn program_with_mappings(num_mappings: usize) -> Result<Program<CurrentNetwork>> {
+        let mut program = String::new();
+        program.push_str("program mappings.aleo;\n\n");
+        for i in 0..num_mappings {
+            program
+                .push_str(&format!("mapping mapping_{i}:\n    key as field.public;\n    value as field.public;\n\n"));
+        }
+        program.push_str("function foo:\n    add 0u8 1u8 into r0;\n");
+        Program::from_str(&program)
+    }
+
+    #[test]
+    fn test_mapping_limits_by_consensus_version() -> Result<()> {
+        let rng = &mut TestRng::default();
+        let process = Process::load()?;
+
+        let program_with_31_mappings = program_with_mappings(31)?;
+        let deployment_with_31_mappings = process.deploy::<CurrentAleo, _>(&program_with_31_mappings, rng)?;
+        process.verify_deployment::<CurrentAleo, _>(ConsensusVersion::V20, &deployment_with_31_mappings, rng)?;
+
+        let program_with_32_mappings = program_with_mappings(32)?;
+        let deployment_with_32_mappings = process.deploy::<CurrentAleo, _>(&program_with_32_mappings, rng)?;
+        assert!(
+            process
+                .verify_deployment::<CurrentAleo, _>(ConsensusVersion::V20, &deployment_with_32_mappings, rng)
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds the maximum number of mappings (31) for V20")
+        );
+        process.verify_deployment::<CurrentAleo, _>(ConsensusVersion::V21, &deployment_with_32_mappings, rng)?;
+
+        let program_with_128_mappings = program_with_mappings(128)?;
+        let deployment_with_128_mappings = process.deploy::<CurrentAleo, _>(&program_with_128_mappings, rng)?;
+        process.verify_deployment::<CurrentAleo, _>(ConsensusVersion::V21, &deployment_with_128_mappings, rng)?;
+
+        Ok(())
     }
 
     /// Per-transaction variable and constraint limits are enforced before V18 and from V19,

--- a/synthesizer/program/src/lib.rs
+++ b/synthesizer/program/src/lib.rs
@@ -562,7 +562,7 @@ impl<N: Network> ProgramCore<N> {
         let mapping_name = *mapping.name();
 
         // Ensure the program has not exceeded the maximum number of mappings.
-        ensure!(self.mappings.len() < N::MAX_MAPPINGS, "Program exceeds the maximum number of mappings");
+        ensure!(self.mappings.len() < N::LATEST_MAX_MAPPINGS(), "Program exceeds the maximum number of mappings");
 
         // Ensure the mapping name is new.
         ensure!(self.is_unique_name(&mapping_name), "'{mapping_name}' is already in use.");

--- a/synthesizer/program/src/parse.rs
+++ b/synthesizer/program/src/parse.rs
@@ -526,9 +526,9 @@ function compute:
         // A program with more than MAX_RECORDS should fail.
         test_parse("", &gen_record_string(CurrentNetwork::MAX_RECORDS + 1), false);
         // A program with MAX_MAPPINGS should succeed.
-        test_parse("", &gen_mapping_string(CurrentNetwork::MAX_MAPPINGS), true);
+        test_parse("", &gen_mapping_string(CurrentNetwork::LATEST_MAX_MAPPINGS()), true);
         // A program with more than MAX_MAPPINGS should fail.
-        test_parse("", &gen_mapping_string(CurrentNetwork::MAX_MAPPINGS + 1), false);
+        test_parse("", &gen_mapping_string(CurrentNetwork::LATEST_MAX_MAPPINGS() + 1), false);
         // A program with MAX_CLOSURES should succeed.
         test_parse("", &gen_closure_string(CurrentNetwork::MAX_CLOSURES), true);
         // A program with more than MAX_CLOSURES should fail.
@@ -543,7 +543,7 @@ function compute:
             "{} {} {} {} {}",
             gen_struct_string(CurrentNetwork::MAX_STRUCTS),
             gen_record_string(CurrentNetwork::MAX_RECORDS),
-            gen_mapping_string(CurrentNetwork::MAX_MAPPINGS),
+            gen_mapping_string(CurrentNetwork::LATEST_MAX_MAPPINGS()),
             gen_closure_string(CurrentNetwork::MAX_CLOSURES),
             gen_function_string(CurrentNetwork::MAX_FUNCTIONS)
         );


### PR DESCRIPTION
## Motivation

This PR increases the maximum number of mappings a program can have.

- Convert Network::MAX_MAPPINGS into a versioned consensus configuration.
- Preserve maximum of 31 mappings through V20.
- Increase maximum to 128 mappings beginning with V21.
- Add LATEST_MAX_MAPPINGS() for parsing and program construction.
- Enforce active consensus limit during deployment verification.
- Extend consensus configuration and boundary test coverage.

## Test Plan

Tests have been added to enforce that the new maximum mappings value is properly enforced before and after V21.

## Backwards compatibility

New value will be enabled after `ConsensusVersion::V21`